### PR TITLE
SCP-643 - Implement merkleization in Plutus semantics

### DIFF
--- a/marlowe-actus/test/Spec/Marlowe/ACTUS/Examples.hs
+++ b/marlowe-actus/test/Spec/Marlowe/ACTUS/Examples.hs
@@ -57,9 +57,9 @@ ex_pam1 =
       ( \ct -> case genFsContract defaultRiskFactors (toMarlowe ct) of
           Failure _ -> assertFailure "Terms validation should not fail"
           Success contract ->
-            let principal = IDeposit (Role "counterparty") "counterparty" ada 10000
-                ip = IDeposit (Role "party") "party" ada 200
-                redemption = IDeposit (Role "party") "party" ada 10000
+            let principal = NormalInput $ IDeposit (Role "counterparty") "counterparty" ada 10000
+                ip = NormalInput $ IDeposit (Role "party") "party" ada 200
+                redemption = NormalInput $ IDeposit (Role "party") "party" ada 10000
 
                 out =
                   computeTransaction
@@ -118,9 +118,9 @@ ex_lam1 =
       ( \ct -> case genFsContract defaultRiskFactors (toMarlowe ct) of
           Failure _ -> assertFailure "Terms validation should not fail"
           Success contract ->
-            let principal = IDeposit (Role "counterparty") "counterparty" ada 10000
-                pr i = IDeposit (Role "party") "party" ada i
-                ip i = IDeposit (Role "party") "party" ada i
+            let principal = NormalInput $ IDeposit (Role "counterparty") "counterparty" ada 10000
+                pr i = NormalInput $ IDeposit (Role "party") "party" ada i
+                ip i = NormalInput $ IDeposit (Role "party") "party" ada i
                 out =
                   computeTransaction
                     ( TransactionInput
@@ -179,9 +179,9 @@ ex_nam1 =
       ( \ct -> case genFsContract defaultRiskFactors (toMarlowe ct) of
         Failure _ -> assertFailure "Terms validation should not fail"
         Success contract ->
-          let principal = IDeposit (Role "counterparty") "counterparty" ada 10000
-              pr i = IDeposit (Role "party") "party" ada i
-              ip i = IDeposit (Role "party") "party" ada i
+          let principal = NormalInput $ IDeposit (Role "counterparty") "counterparty" ada 10000
+              pr i = NormalInput $ IDeposit (Role "party") "party" ada i
+              ip i = NormalInput $ IDeposit (Role "party") "party" ada i
               out =
                 computeTransaction
                   ( TransactionInput
@@ -240,9 +240,9 @@ ex_ann1 =
       ( \ct -> case genFsContract defaultRiskFactors (toMarlowe ct) of
         Failure _ -> assertFailure "Terms validation should not fail"
         Success contract ->
-          let principal = IDeposit (Role "counterparty") "counterparty" ada 10000
-              pr i = IDeposit (Role "party") "party" ada i
-              ip i = IDeposit (Role "party") "party" ada i
+          let principal = NormalInput $ IDeposit (Role "counterparty") "counterparty" ada 10000
+              pr i = NormalInput $ IDeposit (Role "party") "party" ada i
+              ip i = NormalInput $ IDeposit (Role "party") "party" ada i
               out =
                 computeTransaction
                   ( TransactionInput
@@ -284,8 +284,8 @@ ex_optns1 =
     run ct = case genStaticContract rf ct of
       Failure _ -> assertFailure "Terms validation should not fail"
       Success contract ->
-          let principal = IDeposit (Role "counterparty") "counterparty" ada
-              ex = IDeposit (Role "party") "party" ada
+          let principal = NormalInput . IDeposit (Role "counterparty") "counterparty" ada
+              ex = NormalInput . IDeposit (Role "party") "party" ada
               out =
                 computeTransaction
                   ( TransactionInput

--- a/marlowe/cli/Main.hs
+++ b/marlowe/cli/Main.hs
@@ -26,8 +26,8 @@ import           Language.Marlowe.CLI            (mainCLI)
 import           Language.Marlowe.CLI.Export     (printMarlowe)
 import           Language.Marlowe.CLI.Types      (CliError (..), liftCli)
 import           Language.Marlowe.Client         (defaultMarloweParams)
-import           Language.Marlowe.SemanticsTypes (Action (..), Case (..), Contract (..), Input (..), Party (..),
-                                                  State (..), Token (..), Value (..))
+import           Language.Marlowe.SemanticsTypes (Action (..), Case (..), Contract (..), Input (..), InputContent (..),
+                                                  Party (..), State (..), Token (..), Value (..))
 import           Language.Marlowe.Util           (ada)
 import           Ledger.Ada                      (adaSymbol, adaToken)
 import           Paths_marlowe                   (version)
@@ -92,7 +92,7 @@ example =
         , minSlot     = 42293000
         }
       contract2 = When [Case (Deposit party party ada (Constant 12000000)) Close] 42294000 Close
-      inputs2 = [IDeposit party party adatoken 12000000]
+      inputs2 = [NormalInput $ IDeposit party party adatoken 12000000]
     printMarlowe
       defaultMarloweParams costModelParams
       testnet NoStakeAddress

--- a/marlowe/src/Language/Marlowe.hs
+++ b/marlowe/src/Language/Marlowe.hs
@@ -14,7 +14,7 @@ where
 import           Language.Marlowe.Client
 import           Language.Marlowe.Pretty
 import           Language.Marlowe.Semantics
-import           Language.Marlowe.SemanticsTypes
+import           Language.Marlowe.SemanticsTypes hiding (getAction)
 import           Language.Marlowe.Util
 import           Ledger                          (Slot (..))
 import           Ledger.Ada                      (adaSymbol, adaToken)

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -41,7 +41,7 @@ import           GHC.Generics                    (Generic)
 import           Language.Marlowe.Scripts
 import           Language.Marlowe.Semantics
 import qualified Language.Marlowe.Semantics      as Marlowe
-import           Language.Marlowe.SemanticsTypes hiding (Contract)
+import           Language.Marlowe.SemanticsTypes hiding (Contract, getAction)
 import qualified Language.Marlowe.SemanticsTypes as Marlowe
 import           Language.Marlowe.Util           (extractContractRoles)
 import           Ledger                          (CurrencySymbol, Datum (..), PubKeyHash, Slot (..), TokenName,
@@ -339,7 +339,7 @@ marlowePlutusContract = selectList [create, apply, auto, redeem, close]
             PayDeposit acc p token amount -> do
                 logInfo @String $ "PayDeposit " <> show amount <> " at within slots " <> show slotRange
                 let payDeposit = do
-                        marloweData <- SM.runStep theClient (slotRange, [IDeposit acc p token amount])
+                        marloweData <- SM.runStep theClient (slotRange, [NormalInput $ IDeposit acc p token amount])
                         case marloweData of
                             SM.TransitionFailure e -> throwing _TransitionError e
                             SM.TransitionSuccess d -> continueWith d

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -43,7 +43,7 @@ import           Language.Marlowe.Semantics
 import qualified Language.Marlowe.Semantics      as Marlowe
 import           Language.Marlowe.SemanticsTypes hiding (Contract, getAction)
 import qualified Language.Marlowe.SemanticsTypes as Marlowe
-import           Language.Marlowe.Util           (extractContractRoles)
+import           Language.Marlowe.Util           (extractNonMerkleizedContractRoles)
 import           Ledger                          (CurrencySymbol, Datum (..), PubKeyHash, Slot (..), TokenName,
                                                   TxOut (..), inScripts, txOutValue)
 import qualified Ledger
@@ -390,7 +390,7 @@ setupMarloweParams
         (MarloweParams, TxConstraints i o, ScriptLookups (SM.StateMachine MarloweData MarloweInput))
 setupMarloweParams owners contract = mapError (review _MarloweError) $ do
     ownAddress <- pubKeyHashAddress <$> Contract.ownPubKeyHash
-    let roles = extractContractRoles contract
+    let roles = extractNonMerkleizedContractRoles contract
     if Set.null roles
     then do
         let params = MarloweParams

--- a/marlowe/src/Language/Marlowe/Deserialisation.hs
+++ b/marlowe/src/Language/Marlowe/Deserialisation.hs
@@ -1,7 +1,8 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 module Language.Marlowe.Deserialisation (byteStringToPositiveInt, getByteString, byteStringToInt, byteStringToList) where
 
-import           PlutusTx.Builtins (BuiltinByteString, divideInteger, indexByteString, lengthOfByteString,
-                                    sliceByteString)
+import           PlutusTx.Builtins (divideInteger)
+import           PlutusTx.Prelude
 
 {-# INLINABLE unconsByte #-}
 -- | @unconsByte bs@ returns a tuple where the first element is the first byte

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -428,7 +428,7 @@ data ApplyAction = AppliedAction ApplyWarning State
                  | NotAppliedAction
   deriving stock (Haskell.Show)
 
--- | Try to apply a single input contentent to a single action
+-- | Try to apply a single input content to a single action
 applyAction :: Environment -> State -> InputContent -> Action -> ApplyAction
 applyAction env state (IDeposit accId1 party1 tok1 amount) (Deposit accId2 party2 tok2 val) =
     if accId1 == accId2 && party1 == party2 && tok1 == tok2 && amount == evalValue env state val

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -412,8 +412,9 @@ reduceContractUntilQuiescent env state contract = let
     reductionLoop reduced env state contract warnings payments =
         case reduceContractStep env state contract of
             Reduced warning effect newState cont -> let
-                newWarnings = if warning == ReduceNoWarning then warnings
-                              else warning : warnings
+                newWarnings = case warning of
+                                ReduceNoWarning -> warnings
+                                _               -> warning : warnings
                 newPayments  = case effect of
                     ReduceWithPayment payment -> payment : payments
                     ReduceNoPayment           -> payments

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DefaultSignatures          #-}
 {-# LANGUAGE DeriveAnyClass             #-}
@@ -21,6 +22,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans       #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+
 
 {-| = Marlowe: financial contracts domain specific language for blockchain
 
@@ -51,7 +53,9 @@ import           Data.Text                               (pack)
 import           Deriving.Aeson
 import           Language.Marlowe.ParserUtil             (getInteger, withInteger)
 import           Language.Marlowe.Pretty                 (Pretty (..))
+#ifndef DisableMerkleization
 import           Language.Marlowe.SemanticsSerialisation (contractToByteString)
+#endif
 import           Language.Marlowe.SemanticsTypes         (AccountId, Accounts, Action (..), Case (..), Contract (..),
                                                           Environment (..), Input (..), InputContent (..),
                                                           IntervalError (..), IntervalResult (..), Money,
@@ -451,10 +455,12 @@ applyAction _ _ _ _ = NotAppliedAction
 -- | Try to get a continuation from a pair of Input and Case
 getContinuation :: Input -> Case Contract -> Maybe Contract
 getContinuation (NormalInput _) (Case _ continuation) = Just continuation
+#ifndef DisableMerkleization
 getContinuation (MerkleizedInput _ continuation) (MerkleizedCase _ continuationHash) =
     if Builtins.sha2_256 (contractToByteString continuation) == continuationHash
     then Just continuation
     else Nothing
+#endif
 getContinuation _ _ = Nothing
 
 applyCases :: Environment -> State -> Input -> [Case Contract] -> ApplyResult

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -42,33 +42,33 @@ and actions (i.e. /Choices/) are passed as
 
 module Language.Marlowe.Semantics where
 
-import           Control.Applicative                       ((<*>), (<|>))
-import qualified Data.Aeson                                as JSON
-import           Data.Aeson.Types                          hiding (Error, Value)
-import qualified Data.Foldable                             as F
-import           Data.Scientific                           (Scientific)
-import           Data.Text                                 (pack)
+import           Control.Applicative                     ((<*>), (<|>))
+import qualified Data.Aeson                              as JSON
+import           Data.Aeson.Types                        hiding (Error, Value)
+import qualified Data.Foldable                           as F
+import           Data.Scientific                         (Scientific)
+import           Data.Text                               (pack)
 import           Deriving.Aeson
-import           Language.Marlowe.ParserUtil               (getInteger, withInteger)
-import           Language.Marlowe.Pretty                   (Pretty (..))
-import           Language.Marlowe.SemanticsDeserialisation (byteStringToContract)
-import           Language.Marlowe.SemanticsTypes           (AccountId, Accounts, Action (..), Case (..), Contract (..),
-                                                            Environment (..), Input (..), InputContent (..),
-                                                            IntervalError (..), IntervalResult (..), Money,
-                                                            Observation (..), Party, Payee (..), SlotInterval,
-                                                            State (..), Token (..), Value (..), ValueId, getAction,
-                                                            getInputContent, inBounds)
-import           Ledger                                    (Slot (..), ValidatorHash)
-import           Ledger.Value                              (CurrencySymbol (..))
-import qualified Ledger.Value                              as Val
-import           PlutusTx                                  (makeIsDataIndexed)
-import qualified PlutusTx.AssocMap                         as Map
-import qualified PlutusTx.Builtins                         as Builtins
-import           PlutusTx.Lift                             (makeLift)
-import           PlutusTx.Prelude                          hiding (encodeUtf8, mapM, (<$>), (<*>), (<>))
-import           Prelude                                   (mapM, (<$>))
-import qualified Prelude                                   as Haskell
-import           Text.PrettyPrint.Leijen                   (comma, hang, lbrace, line, rbrace, space, text, (<>))
+import           Language.Marlowe.ParserUtil             (getInteger, withInteger)
+import           Language.Marlowe.Pretty                 (Pretty (..))
+import           Language.Marlowe.SemanticsSerialisation (contractToByteString)
+import           Language.Marlowe.SemanticsTypes         (AccountId, Accounts, Action (..), Case (..), Contract (..),
+                                                          Environment (..), Input (..), InputContent (..),
+                                                          IntervalError (..), IntervalResult (..), Money,
+                                                          Observation (..), Party, Payee (..), SlotInterval, State (..),
+                                                          Token (..), Value (..), ValueId, getAction, getInputContent,
+                                                          inBounds)
+import           Ledger                                  (Slot (..), ValidatorHash)
+import           Ledger.Value                            (CurrencySymbol (..))
+import qualified Ledger.Value                            as Val
+import           PlutusTx                                (makeIsDataIndexed)
+import qualified PlutusTx.AssocMap                       as Map
+import qualified PlutusTx.Builtins                       as Builtins
+import           PlutusTx.Lift                           (makeLift)
+import           PlutusTx.Prelude                        hiding (encodeUtf8, mapM, (<$>), (<*>), (<>))
+import           Prelude                                 (mapM, (<$>))
+import qualified Prelude                                 as Haskell
+import           Text.PrettyPrint.Leijen                 (comma, hang, lbrace, line, rbrace, space, text, (<>))
 
 {- HLINT ignore "Avoid restricted function" -}
 
@@ -451,9 +451,9 @@ applyAction _ _ _ _ = NotAppliedAction
 -- | Try to get a continuation from a pair of Input and Case
 getContinuation :: Input -> Case Contract -> Maybe Contract
 getContinuation (NormalInput _) (Case _ continuation) = Just continuation
-getContinuation (MerkleizedInput _ serialisedContinuation) (MerkleizedCase _ continuationHash) =
-    if Builtins.sha2_256 serialisedContinuation == continuationHash
-    then fst <$> byteStringToContract serialisedContinuation
+getContinuation (MerkleizedInput _ continuation) (MerkleizedCase _ continuationHash) =
+    if Builtins.sha2_256 (contractToByteString continuation) == continuationHash
+    then Just continuation
     else Nothing
 getContinuation _ _ = Nothing
 

--- a/marlowe/src/Language/Marlowe/SemanticsSerialisation.hs
+++ b/marlowe/src/Language/Marlowe/SemanticsSerialisation.hs
@@ -64,7 +64,7 @@ actionToByteString (Notify obs) = positiveIntToByteString 2 `appendByteString` o
 
 caseToByteString :: Case Contract -> BuiltinByteString
 caseToByteString (Case action cont) = positiveIntToByteString 0 `appendByteString` actionToByteString action `appendByteString` contractToByteString cont
---caseToByteString (MerkleizedCase action bs) = positiveIntToByteString 1 `appendByteString` actionToByteString action `appendByteString` packByteString bs
+caseToByteString (MerkleizedCase action bs) = positiveIntToByteString 1 `appendByteString` actionToByteString action `appendByteString` packByteString bs
 
 contractToByteString :: Contract -> BuiltinByteString
 contractToByteString Close = positiveIntToByteString 0

--- a/marlowe/src/Language/Marlowe/SemanticsSerialisation.hs
+++ b/marlowe/src/Language/Marlowe/SemanticsSerialisation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 module Language.Marlowe.SemanticsSerialisation (contractToByteString) where
 
 import           Language.Marlowe.SemanticsTypes (Action (..), Bound (..), Case (..), ChoiceId (..), Contract (..),
@@ -7,7 +8,19 @@ import           Language.Marlowe.Serialisation  (intToByteString, listToByteStr
                                                   positiveIntToByteString)
 import           Ledger                          (PubKeyHash (..), Slot (..))
 import           Ledger.Value                    (CurrencySymbol (..), TokenName (..))
-import           PlutusTx.Builtins               (BuiltinByteString, appendByteString)
+import           PlutusTx.Prelude
+
+{-# INLINABLE partyToByteString #-}
+{-# INLINABLE choiceIdToByteString #-}
+{-# INLINABLE valueIdToByteString #-}
+{-# INLINABLE tokenToByteString #-}
+{-# INLINABLE observationToByteString #-}
+{-# INLINABLE valueToByteString #-}
+{-# INLINABLE payeeToByteString #-}
+{-# INLINABLE boundToByteString #-}
+{-# INLINABLE actionToByteString #-}
+{-# INLINABLE caseToByteString #-}
+{-# INLINABLE contractToByteString #-}
 
 partyToByteString :: Party -> BuiltinByteString
 partyToByteString (PK (PubKeyHash x))  = positiveIntToByteString 0 `appendByteString` packByteString x

--- a/marlowe/src/Language/Marlowe/SemanticsTypes.hs
+++ b/marlowe/src/Language/Marlowe/SemanticsTypes.hs
@@ -708,7 +708,7 @@ instance Eq Contract where
     When cases1 timeout1 cont1 == When cases2 timeout2 cont2 =
         timeout1 == timeout2 && cont1 == cont2
         && length cases1 == length cases2
-        && all id (zipWith (==) cases1 cases2)
+        && and (zipWith (==) cases1 cases2)
     Let valId1 val1 cont1 == Let valId2 val2 cont2 =
         valId1 == valId2 && val1 == val2 && cont1 == cont2
     Assert obs1 cont1 == Assert obs2 cont2 = obs1 == obs2 && cont1 == cont2

--- a/marlowe/src/Language/Marlowe/Serialisation.hs
+++ b/marlowe/src/Language/Marlowe/Serialisation.hs
@@ -9,11 +9,11 @@
 -- be used in on-chain code.
 --
 -----------------------------------------------------------------------------
-
+{-# LANGUAGE NoImplicitPrelude #-}
 module Language.Marlowe.Serialisation(positiveIntToByteString, packByteString, intToByteString, listToByteString) where
 
-import           PlutusTx.Builtins (BuiltinByteString, appendByteString, consByteString, divideInteger, emptyByteString,
-                                    lengthOfByteString, modInteger)
+import           PlutusTx.Builtins (divideInteger, modInteger)
+import           PlutusTx.Prelude
 
 {-# INLINABLE singletonByteString #-}
 -- | @singletonByteString n@ returns a single-byte 'BuiltinByteString' with the byte represented by
@@ -42,12 +42,18 @@ intToByteString x =
    then positiveIntToByteString (x * 2)
    else positiveIntToByteString (0 - (x * 2 + 1))
 
+{-# INLINABLE genericLength #-}
+genericLength :: [a] -> Integer
+genericLength []    = 0
+genericLength (_:t) = 1 + genericLength t
+
 {-# INLINABLE listToByteString #-}
 -- | @listToByteString f l@ Serialises the list of elements @l@ such that each of
 -- the elements of @l@ can be serialised using the function @f@.
 listToByteString :: (a -> BuiltinByteString) -> [a] -> BuiltinByteString
 listToByteString f l =
-  positiveIntToByteString (fromIntegral $ length l) `appendByteString` listToByteStringAux f l
+  positiveIntToByteString (genericLength l) `appendByteString` listToByteStringAux f l
   where listToByteStringAux :: (a -> BuiltinByteString) -> [a] -> BuiltinByteString
-        listToByteStringAux f' = foldr (appendByteString . f') mempty
+        listToByteStringAux _ []     = mempty
+        listToByteStringAux f' (h:t) = appendByteString (f' h) (listToByteStringAux f' t)
 

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -45,7 +45,7 @@ getAccountsDiff :: [Payment] -> [Input] -> AccountsDiff
 getAccountsDiff payments inputs =
     foldl' (\acc (p, m) -> addAccountsDiff p m acc) emptyAccountsDiff (incomes ++ outcomes)
   where
-    incomes  = [ (p, Val.singleton cur tok m) | IDeposit _ p (Token cur tok) m <- inputs ]
+    incomes  = [ (p, Val.singleton cur tok m) | IDeposit _ p (Token cur tok) m <- map getInputContent inputs ]
     outcomes = [ (p, P.negate m) | Payment _ (Party p) m  <- payments ]
 
 
@@ -65,7 +65,9 @@ foldMapContract fcont fcase fobs fvalue contract =
         Assert obs cont      -> fobs' obs <> go cont
   where
     go = foldMapContract fcont fcase fobs fvalue
-    fcase' cs@(Case _ cont) = fcase cs <> go cont
+    fcase' cs = fcase cs <> case cs of
+        Case _ cont        -> go cont
+        MerkleizedCase _ _ -> mempty
     fobs' obs = fobs obs <> case obs of
         AndObs a b  -> fobs' a <> fobs' b
         OrObs  a b  -> fobs' a <> fobs' b

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -50,12 +50,13 @@ getAccountsDiff payments inputs =
 
 
 foldMapContract :: Monoid m
-    => (Contract -> m)
+    => (P.BuiltinByteString -> Maybe Contract)
+    -> (Contract -> m)
     -> (Case Contract -> m)
     -> (Observation -> m)
     -> (Value Observation -> m)
     -> Contract -> m
-foldMapContract fcont fcase fobs fvalue contract =
+foldMapContract funmerk fcont fcase fobs fvalue contract =
     fcont contract <> case contract of
         Close                -> mempty
         Pay _ _ _ value cont -> fvalue' value <> go cont
@@ -64,10 +65,10 @@ foldMapContract fcont fcase fobs fvalue contract =
         Let _ value cont     -> fvalue value <> go cont
         Assert obs cont      -> fobs' obs <> go cont
   where
-    go = foldMapContract fcont fcase fobs fvalue
+    go = foldMapContract funmerk fcont fcase fobs fvalue
     fcase' cs = fcase cs <> case cs of
-        Case _ cont        -> go cont
-        MerkleizedCase _ _ -> mempty
+        Case _ cont            -> go cont
+        MerkleizedCase _ chash -> maybe mempty go (funmerk chash)
     fobs' obs = fobs obs <> case obs of
         AndObs a b  -> fobs' a <> fobs' b
         OrObs  a b  -> fobs' a <> fobs' b
@@ -88,12 +89,17 @@ foldMapContract fcont fcase fobs fvalue contract =
         _            -> mempty
 
 
-foldMapContractValue :: Monoid m => (Value Observation -> m) -> Contract -> m
-foldMapContractValue = foldMapContract (const mempty) (const mempty) (const mempty)
+foldMapNonMerkleizedContract :: Monoid m
+    => (Contract -> m)
+    -> (Case Contract -> m)
+    -> (Observation -> m)
+    -> (Value Observation -> m)
+    -> Contract -> m
+foldMapNonMerkleizedContract = foldMapContract (const Nothing)
 
 
-extractContractRoles :: Contract -> Set Val.TokenName
-extractContractRoles = foldMapContract extract extractCase (const mempty) (const mempty)
+extractNonMerkleizedContractRoles :: Contract -> Set Val.TokenName
+extractNonMerkleizedContractRoles = foldMapNonMerkleizedContract extract extractCase (const mempty) (const mempty)
   where
     extract (Pay from payee _ _ _) = fromParty from <> fromPayee payee
     extract _                      = mempty

--- a/marlowe/test/Spec/Marlowe/Common.hs
+++ b/marlowe/test/Spec/Marlowe/Common.hs
@@ -266,6 +266,7 @@ caseRelGenSized s bn = Case <$> actionGenSized s <*> contractRelGenSized s bn
 shrinkCase :: Case Contract -> [Case Contract]
 shrinkCase (Case act cont) = [Case act x | x <- shrinkContract cont]
                               ++ [Case y cont | y <- shrinkAction act]
+shrinkCase (MerkleizedCase act bs) = [MerkleizedCase y bs | y <- shrinkAction act]
 
 
 contractRelGenSized :: Int -> Integer -> Gen Contract

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -151,10 +151,10 @@ zeroCouponBondTest = checkPredicateOptions defaultCheckOptions "Zero Coupon Bond
     Trace.callEndpoint @"create" aliceHdl (reqId, AssocMap.empty, zeroCouponBond)
     Trace.waitNSlots 2
 
-    Trace.callEndpoint @"apply-inputs" aliceHdl (reqId, params, Nothing, [IDeposit alicePk alicePk ada 850])
+    Trace.callEndpoint @"apply-inputs" aliceHdl (reqId, params, Nothing, [NormalInput $ IDeposit alicePk alicePk ada 850])
     Trace.waitNSlots 2
 
-    Trace.callEndpoint @"apply-inputs" bobHdl (reqId, params, Nothing, [IDeposit alicePk bobPk ada 1000])
+    Trace.callEndpoint @"apply-inputs" bobHdl (reqId, params, Nothing, [NormalInput $ IDeposit alicePk bobPk ada 1000])
     void $ Trace.waitNSlots 2
 
     Trace.callEndpoint @"close" aliceHdl reqId
@@ -188,7 +188,7 @@ errorHandlingTest = checkPredicateOptions defaultCheckOptions "Error handling"
     Trace.callEndpoint @"create" aliceHdl (reqId, AssocMap.empty, zeroCouponBond)
     Trace.waitNSlots 2
 
-    Trace.callEndpoint @"apply-inputs" aliceHdl (reqId, params, Nothing, [IDeposit alicePk alicePk ada 1000])
+    Trace.callEndpoint @"apply-inputs" aliceHdl (reqId, params, Nothing, [NormalInput $ IDeposit alicePk alicePk ada 1000])
     Trace.waitNSlots 2
     pure ()
 
@@ -231,8 +231,8 @@ trustFundTest = checkPredicateOptions defaultCheckOptions "Trust Fund Contract"
         (pms, _) : _ -> do
 
             Trace.callEndpoint @"apply-inputs" aliceHdl (reqId, pms, Nothing,
-                [ IChoice chId 256
-                , IDeposit "alice" "alice" ada 256
+                [ NormalInput $ IChoice chId 256
+                , NormalInput $ IDeposit "alice" "alice" ada 256
                 ])
             Trace.waitNSlots 17
 
@@ -240,7 +240,7 @@ trustFundTest = checkPredicateOptions defaultCheckOptions "Trust Fund Contract"
             Trace.callEndpoint @"follow" bobFollowHdl pms
             Trace.waitNSlots 2
 
-            Trace.callEndpoint @"apply-inputs" bobHdl (reqId, pms, Nothing, [INotify])
+            Trace.callEndpoint @"apply-inputs" bobHdl (reqId, pms, Nothing, [NormalInput INotify])
 
             Trace.waitNSlots 2
             Trace.callEndpoint @"redeem" bobHdl (reqId, pms, "bob", bobPkh)

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -354,14 +354,14 @@ untypedValidatorSize = do
 
 extractContractRolesTest :: IO ()
 extractContractRolesTest = do
-    extractContractRoles Close @=? mempty
-    extractContractRoles
+    extractNonMerkleizedContractRoles Close @=? mempty
+    extractNonMerkleizedContractRoles
         (Pay (Role "Alice") (Party (Role "Bob")) ada (Constant 1) Close)
             @=? Set.fromList ["Alice", "Bob"]
-    extractContractRoles
+    extractNonMerkleizedContractRoles
         (When [Case (Deposit (Role "Bob") (Role "Alice") ada (Constant 10)) Close] 10 Close)
             @=? Set.fromList ["Alice", "Bob"]
-    extractContractRoles
+    extractNonMerkleizedContractRoles
         (When [Case (Choice (ChoiceId "test" (Role "Alice")) [Bound 0 1]) Close] 10 Close)
             @=? Set.fromList ["Alice"]
 

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -85,7 +85,11 @@ tests = testGroup "Marlowe"
     , testCase "Token Show instance respects HEX and Unicode" tokenShowTest
     , testCase "Pangram Contract serializes into valid JSON" pangramContractSerialization
     , testCase "State serializes into valid JSON" stateSerialization
-    , testCase "Validator size is reasonable" validatorSize
+    , testGroup "Validator size is reasonable"
+        [ testCase "StateMachine validator size" stateMachineValidatorSize
+        , testCase "Typed validator size" typedValidatorSize
+        , testCase "Untyped validator size" untypedValidatorSize
+        ]
     , testCase "Mul analysis" mulAnalysisTest
     , testCase "Div analysis" divAnalysisTest
     , testCase "Div tests" divTest
@@ -285,19 +289,23 @@ uniqueContractHash = do
     assertBool "Hashes must be different" (hash1 /= hash2)
     assertBool "Hashes must be same" (hash2 == hash3)
 
-
-validatorSize :: IO ()
-validatorSize = do
+stateMachineValidatorSize :: IO ()
+stateMachineValidatorSize = do
     let validator = Scripts.validatorScript $ typedValidator defaultMarloweParams
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    let validator1 = Scripts.validatorScript $ smallTypedValidator defaultMarloweParams
-    let vsize1 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator1
-    let validator2 = smallUntypedValidator defaultMarloweParams
-    let vsize2 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator2
     assertBool ("StateMachine Validator is too large " <> show vsize) (vsize < 18000)
-    assertBool ("smallTypedValidator is too large " <> show vsize1) (vsize1 < 15000)
-    assertBool ("smallUntypedValidator is too large " <> show vsize2) (vsize2 < 14000)
 
+typedValidatorSize :: IO ()
+typedValidatorSize = do
+    let validator = Scripts.validatorScript $ smallTypedValidator defaultMarloweParams
+    let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
+    assertBool ("smallTypedValidator is too large " <> show vsize) (vsize < 15000)
+
+untypedValidatorSize :: IO ()
+untypedValidatorSize = do
+    let validator = smallUntypedValidator defaultMarloweParams
+    let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
+    assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 14000)
 
 extractContractRolesTest :: IO ()
 extractContractRolesTest = do

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -180,13 +180,13 @@ merkleizedZeroCouponBondTest = checkPredicateOptions defaultCheckOptions "Merkle
     let params = defaultMarloweParams
 
     let zeroCouponBondStage1 = When [ MerkleizedCase (Deposit alicePk alicePk ada (Constant 850))
-                                                     (sha2_256 zeroCouponBondStage2)
+                                                     (sha2_256 (contractToByteString zeroCouponBondStage2))
                                     ] (Slot 100) Close
-        zeroCouponBondStage2 = contractToByteString $ Pay alicePk (Party bobPk) ada (Constant 850)
-                                                         (When [ MerkleizedCase (Deposit alicePk bobPk ada (Constant 1000))
-                                                                                (sha2_256 zeroCouponBondStage3)
-                                                               ] (Slot 200) Close)
-        zeroCouponBondStage3 = contractToByteString Close
+        zeroCouponBondStage2 = Pay alicePk (Party bobPk) ada (Constant 850)
+                                  (When [ MerkleizedCase (Deposit alicePk bobPk ada (Constant 1000))
+                                                         (sha2_256 (contractToByteString zeroCouponBondStage3))
+                                        ] (Slot 200) Close)
+        zeroCouponBondStage3 = Close
 
     bobHdl <- Trace.activateContractWallet bob marlowePlutusContract
     aliceHdl <- Trace.activateContractWallet alice marlowePlutusContract
@@ -338,19 +338,19 @@ stateMachineValidatorSize :: IO ()
 stateMachineValidatorSize = do
     let validator = Scripts.validatorScript $ typedValidator defaultMarloweParams
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    assertBool ("StateMachine Validator is too large " <> show vsize) (vsize < 18000)
+    assertBool ("StateMachine Validator is too large " <> show vsize) (vsize < 18500)
 
 typedValidatorSize :: IO ()
 typedValidatorSize = do
     let validator = Scripts.validatorScript $ smallTypedValidator defaultMarloweParams
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    assertBool ("smallTypedValidator is too large " <> show vsize) (vsize < 15000)
+    assertBool ("smallTypedValidator is too large " <> show vsize) (vsize < 15500)
 
 untypedValidatorSize :: IO ()
 untypedValidatorSize = do
     let validator = smallUntypedValidator defaultMarloweParams
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 14000)
+    assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 14500)
 
 extractContractRolesTest :: IO ()
 extractContractRolesTest = do

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
@@ -108,7 +109,9 @@ tests = testGroup "Marlowe"
         , testProperty "Contract (de)serialisation roundtrip" contractBSRoundtripTest
         ]
     , zeroCouponBondTest
+#ifndef DisableMerkleization
     , merkleizedZeroCouponBondTest
+#endif
     , errorHandlingTest
     , trustFundTest
     ]


### PR DESCRIPTION
This PR adds merkleization to the Plutus semantics and updates:
 - JSON serialisation and deserialisation (in a way that is backwards compatible)
 - Haskell code that depends on the format of inputs

And also:
 - Adds a test for merkleized excution
- Augment QuickCheck generator to include MerkleizedCase

I had to revert the deserialisation implementation to the tree version because Plutus doesn't implement matching on integers.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
