### PR TITLE
SCP-3165 optimize development workflow with webpack

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,6 +48,22 @@
         "type": "github"
       }
     },
+    "easy-purescript-nix-source": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631961521,
+        "narHash": "sha256-1yPjUdOYzw1+UGFzBXbyZqEbsM6XZu/6+v8W35qFdLo=",
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "rev": "d9a37c75ed361372e1545f6efbc08d819b3c28c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1620759905,
@@ -60,6 +76,56 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1634151530,
+        "narHash": "sha256-l1wnu/jSxhj6+MGurKupKkWZh3Om/6FuYc/FdSlkyRI=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "9e80c4d83026fa6548bc53b1a6fab8549a6991f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -144,6 +210,26 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1629707199,
+        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "df71f5e4babda41cd919a8684b72218e2e809fa9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "flake": false,
       "locked": {
@@ -159,6 +245,20 @@
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1634301554,
+        "narHash": "sha256-yx2NECo6Jrx8mpvEyeeUb98jxlKXeADdqbWkD05LikE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7ee297f96d0a1c5008e00015d4f28280545c04eb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "npmlock2nix": {
@@ -209,6 +309,27 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1634595438,
+        "narHash": "sha256-hV9D41fqTateTligwNd9dmJKQ0R0w6RpCN92xR3LhHk=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "06fa80325b6fe3b28d136071dd0ce55d4817e9fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks-nix": {
       "flake": false,
       "locked": {
@@ -222,6 +343,28 @@
       "original": {
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "rnix-lsp": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1634449716,
+        "narHash": "sha256-JuRCU4KCIA3/pp8BjHqqF9dj1d2xtpkxKKAtSuOzTIY=",
+        "owner": "nix-community",
+        "repo": "rnix-lsp",
+        "rev": "a2d06d2d2910cbe35b4f323a54ef484f51d71e20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "rnix-lsp",
         "type": "github"
       }
     },
@@ -278,14 +421,36 @@
         "type": "github"
       }
     },
-    "web-common": {
-      "flake": false,
+    "utils": {
       "locked": {
-        "lastModified": 1635526611,
-        "narHash": "sha256-qLUmwG7hKGbc3pFWkKSKFFE0uWxgPSrIUZspUwwEFCo=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "web-common": {
+      "inputs": {
+        "easy-purescript-nix-source": "easy-purescript-nix-source",
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2",
+        "pre-commit-hooks": "pre-commit-hooks",
+        "rnix-lsp": "rnix-lsp"
+      },
+      "locked": {
+        "lastModified": 1639586076,
+        "narHash": "sha256-HL3Ikg/pvdLbWBy3QciKXfLXqY0QZ9v+ualqYicfXMo=",
         "owner": "input-output-hk",
         "repo": "purescript-web-common",
-        "rev": "f1241ea27fc6acc78d093574e3707165b4ef9b3e",
+        "rev": "71be4b2b2788aecdcb568a957339de4e16d260d4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,7 @@
     };
     web-common = {
       url = "github:input-output-hk/purescript-web-common";
-      flake = false;
+      flake = true;
     };
   };
 

--- a/marlowe-dashboard-client/default.nix
+++ b/marlowe-dashboard-client/default.nix
@@ -54,7 +54,7 @@ let
       spagoPackages = pkgs.callPackage ./spago-packages.nix { };
     })
     (_: {
-      WEB_COMMON_SRC = webCommon;
+      WEB_COMMON_SRC = webCommon.cleanSrc;
     });
 in
 {

--- a/marlowe-playground-client/README.md
+++ b/marlowe-playground-client/README.md
@@ -18,6 +18,8 @@ $(nix-build ../default.nix -A marlowe-playground.generate-purescript)/bin/marlow
 npm install
 # Install purescript depdendencies
 npm run build:spago
+# Precompile js dependencies bundle
+npm run build:webpack:dev:vendor
 ```
 
 Then run `npm run build:webpack:dev` for an auto-reloading dev build on https://localhost:8009

--- a/marlowe-playground-client/README.md
+++ b/marlowe-playground-client/README.md
@@ -27,7 +27,7 @@ Then run `npm run build:webpack:dev` for an auto-reloading dev build on https://
 ## Adding dependencies
 
 * Javascript dependencies are managed with npm, so add them to [package.json](./package.json)
-* purescript uses package sets managed by spago so if the package set doesn't contain a dependency you can add it to [packages.dhall](./packages.dhall)
+* purescript uses package sets managed by spago so if the package set doesn't contain a dependency you can add it to [../packages.dhall](../packages.dhall)
 
 Whenever you change `packages.dhall` you need to make sure that all dependencies can still properly be resolved and built.
 You can do so using the `update-client-deps` script:

--- a/marlowe-playground-client/default.nix
+++ b/marlowe-playground-client/default.nix
@@ -59,7 +59,7 @@ let
       spagoPackages = pkgs.callPackage ./spago-packages.nix { };
     })
     (_: {
-      WEB_COMMON_SRC = webCommon;
+      WEB_COMMON_SRC = webCommon.cleanSrc;
       WEB_COMMON_PLAYGROUND_SRC = webCommonPlayground;
     });
 in

--- a/marlowe-playground-client/entry.js
+++ b/marlowe-playground-client/entry.js
@@ -22,4 +22,4 @@ global.monacoExtraTypeScriptLibs = [
 
 import { BigNumber } from 'bignumber';
 
-require('./src/Main.purs').main();
+require('./output/Main/index.js').main();

--- a/marlowe-playground-client/package-lock.json
+++ b/marlowe-playground-client/package-lock.json
@@ -4764,6 +4764,11 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build:webpack": "webpack --progress --bail --mode=development --node-env=production",
     "build:webpack:dev": "webpack-cli serve --progress --inline --hot --mode=development --node-env=development",
+    "build:webpack:dev:vendor": "webpack --mode production --config webpack.vendor.config.js",
     "build:webpack:prod": "webpack --progress --bail --mode=production --node-env=production",
     "build:spago": "spago build --purs-args \"--strict --censor-lib --stash --is-lib=generated --is-lib=.spago\"",
     "build:spago:watch": "spago build --purs-args \"--strict --censor-lib --stash --is-lib=generated --is-lib=.spago\" --watch --clear-screen",
@@ -27,6 +28,7 @@
     "monaco-vim": "^0.1.7",
     "moo": "^0.5.1",
     "nearley": "^2.19.1",
+    "popper.js": "^1.16.1",
     "safe-eval": "^0.4.1",
     "xhr2": "^0.1.4"
   },

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -11,7 +11,7 @@
     "install:spago": "spago install",
     "docs": "spago docs",
     "repl": "spago repl",
-    "start": "marlowe-playground-generate-purs && npm install && npm run install:spago && npm run build:webpack:vendor:dev && npm run build:webpack:dev",
+    "start": "marlowe-playground-generate-purs && npm install && npm run install:spago && npm run build:webpack:dev:vendor && npm run build:webpack:dev",
     "test": "NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --config webpack.test.config.js --mode=development && node --max-old-space-size=8192 dist/test.js"
   },
   "dependencies": {

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -11,7 +11,7 @@
     "install:spago": "spago install",
     "docs": "spago docs",
     "repl": "spago repl",
-    "start": "marlowe-playground-generate-purs && npm install && npm run install:spago && npm run build:webpack:dev",
+    "start": "marlowe-playground-generate-purs && npm install && npm run install:spago && npm run build:webpack:vendor:dev && npm run build:webpack:dev",
     "test": "NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --config webpack.test.config.js --mode=development && node --max-old-space-size=8192 dist/test.js"
   },
   "dependencies": {

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -11,7 +11,7 @@
     "install:spago": "spago install",
     "docs": "spago docs",
     "repl": "spago repl",
-    "start": "marlowe-playground-generate-purs && npm install && npm run install:spago && npm run build:webpack:dev:vendor && npm run build:webpack:dev",
+    "start": "marlowe-playground-generate-purs && npm install && npm run install:spago && npm run build:spago && npm run build:webpack:dev:vendor && npm run build:webpack:dev",
     "test": "NODE_OPTIONS=\"--max-old-space-size=8192\" webpack --config webpack.test.config.js --mode=development && node --max-old-space-size=8192 dist/test.js"
   },
   "dependencies": {

--- a/marlowe-playground-client/spago-packages.nix
+++ b/marlowe-playground-client/spago-packages.nix
@@ -1229,18 +1229,6 @@ let
         installPhase = "ln -s $src $out";
       };
 
-    "string-parsers" = pkgs.stdenv.mkDerivation {
-        name = "string-parsers";
-        version = "v6.0.1";
-        src = pkgs.fetchgit {
-          url = "https://github.com/purescript-contrib/purescript-string-parsers.git";
-          rev = "7c3cad8ce7cd4d1036eeafa09af323dc7b8d367c";
-          sha256 = "143a2s56kbx3i0xi5wfqp28znr0hdydy902jla236i7kal5y098m";
-        };
-        phases = "installPhase";
-        installPhase = "ln -s $src $out";
-      };
-
     "strings" = pkgs.stdenv.mkDerivation {
         name = "strings";
         version = "v5.0.0";
@@ -1435,11 +1423,11 @@ let
 
     "web-common" = pkgs.stdenv.mkDerivation {
         name = "web-common";
-        version = "v1.1.3";
+        version = "v1.2.0";
         src = pkgs.fetchgit {
           url = "https://github.com/input-output-hk/purescript-web-common";
-          rev = "f6ba33c8543e5c830592f86e94b3e89ca117e602";
-          sha256 = "10hsvndlvag0c89gwn6hmiiar45cifl1416b0psbvqjdjqbmhvv0";
+          rev = "9d79acdadefec29225d81cd2f546f24c69169390";
+          sha256 = "1jjw3wkn4sm9p7zdnrqhinlxgwjxib443dqwb3dx5gg91y9cig8w";
         };
         phases = "installPhase";
         installPhase = "ln -s $src $out";

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -4,6 +4,7 @@ const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
+const webpack = require("webpack");
 
 const isDevelopment = process.env.NODE_ENV === "development";
 
@@ -16,7 +17,12 @@ class ErrorReportingPlugin {
     }
 }
 
-const plugins = isDevelopment ? [] : [new ErrorReportingPlugin()];
+const plugins = (function() {
+  if(isDevelopment)
+    return [ new webpack.DllReferencePlugin({ manifest: path.resolve(__dirname, "dist/vendor-dll-manifest.json") })]
+  else
+    return [ new ErrorReportingPlugin() ] ;
+})();
 
 // source map adds 20Mb to the output!
 const devtool = isDevelopment ? "eval-source-map" : false;
@@ -40,21 +46,9 @@ module.exports = {
     entry: "./entry.js",
     output: {
         path: path.join(__dirname, "dist"),
-        filename: "[name].[hash].js",
+        filename: "[name].[fullhash].js",
         pathinfo: true,
         clean: true,
-    },
-    optimization: {
-        runtimeChunk: "single",
-        splitChunks: {
-            cacheGroups: {
-                vendor: {
-                    test: /[\\/]node_modules[\\/]/,
-                    name: "vendors",
-                    chunks: "all",
-                },
-            },
-        },
     },
     module: {
         rules: [
@@ -73,36 +67,6 @@ module.exports = {
                 options: {
                     baseDir: "."
                 }
-            },
-            {
-                test: /\.purs$/,
-                use: [
-                    {
-                        loader: 'purs-loader',
-                        options: {
-                            bundle: !isDevelopment,
-                            psc: "psa",
-                            pscArgs: {
-                                strict: true,
-                                censorLib: true,
-                                stash: isDevelopment,
-                                isLib: ["generated", ".spago"],
-                            },
-                            spago: isDevelopment,
-                            watch: isDevelopment,
-                            src: isDevelopment
-                                ? []
-                                : [
-                                    '.spago/*/*/src/**/*.purs',
-                                    'src/**/*.purs',
-                                    'test/**/*.purs',
-                                    'generated/**/*.purs',
-                                    "web-common-marlowe/src/**/*.purs",
-                                    `${process.env.WEB_COMMON_PLAYGROUND_SRC}/src/**/*.purs`,
-                                ],
-                        }
-                    }
-                ]
             },
             {
                 test: /\.tsx?$/,
@@ -151,8 +115,9 @@ module.exports = {
             favicon: "static/favicon.ico",
             title: "Marlowe Playground",
             productName: "marlowe-playground",
-            googleAnalyticsId: isDevelopment ? "UA-XXXXXXXXX-X" : "G-G06CGG33D4",
-            segmentAnalyticsId: isDevelopment ? "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" : "RMh20hw83CbQY1CXanru5hnwkFWZOzL0",
+            googleAnalyticsId: isDevelopment ? null : "G-G06CGG33D4",
+            segmentAnalyticsId: isDevelopment ? null : "RMh20hw83CbQY1CXanru5hnwkFWZOzL0",
+            vendorDll: isDevelopment ? "vendor.bundle.js" : null,
         }),
         new MonacoWebpackPlugin({
             // note that you have to include typescript if you want javascript to work!
@@ -161,6 +126,5 @@ module.exports = {
         new MiniCssExtractPlugin({
             filename: "[name].[contenthash].css",
         }),
-
     ].concat(plugins)
 };

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -50,6 +50,18 @@ module.exports = {
         pathinfo: true,
         clean: true,
     },
+    optimization: isDevelopment? undefined : {
+        runtimeChunk: "single",
+        splitChunks: {
+            cacheGroups: {
+                vendor: {
+                    test: /[\\/]node_modules[\\/]/,
+                    name: "vendors",
+                    chunks: "all",
+                },
+            },
+        },
+    },
     module: {
         rules: [
             {

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -69,6 +69,36 @@ module.exports = {
                 }
             },
             {
+                test: /\.purs$/,
+                use: isDevelopment? [] : [
+                    {
+                        loader: 'purs-loader',
+                        options: {
+                            bundle: !isDevelopment,
+                            psc: "psa",
+                            pscArgs: {
+                                strict: true,
+                                censorLib: true,
+                                stash: isDevelopment,
+                                isLib: ["generated", ".spago"],
+                            },
+                            spago: isDevelopment,
+                            watch: isDevelopment,
+                            src: isDevelopment
+                                ? []
+                                : [
+                                    '.spago/*/*/src/**/*.purs',
+                                    'src/**/*.purs',
+                                    'test/**/*.purs',
+                                    'generated/**/*.purs',
+                                    "web-common-marlowe/src/**/*.purs",
+                                    `${process.env.WEB_COMMON_PLAYGROUND_SRC}/src/**/*.purs`,
+                                ],
+                        }
+                    }
+                ]
+            },
+            {
                 test: /\.tsx?$/,
                 loader: "ts-loader"
             },

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -140,7 +140,7 @@ module.exports = {
             static: path.resolve(__dirname, "./static"),
             src: path.resolve(__dirname, "./src")
         },
-        extensions: [".purs", ".js", ".ts", ".tsx"],
+        extensions: [".js", ".ts", ".tsx"].concat(isDevelopment? []: [".purs"]),
         fallback: {
             vm: require.resolve("vm-browserify"),
         },

--- a/marlowe-playground-client/webpack.vendor.config.js
+++ b/marlowe-playground-client/webpack.vendor.config.js
@@ -9,6 +9,23 @@ module.exports = {
       "big-integer", "bignumber", "blockly", "bootstrap",
       "decimal.js", "json-bigint", "monaco-editor", "monaco-emacs",
       "monaco-vim", "moo", "nearley", "safe-eval",
+      // Most heavy libs: `du -hs output/* | sort -h`
+      // check `dist/vendor-dll-manifest.json`
+      // to get info about cached libs.
+      "./output/Affjax/index.js",
+      "./output/Data.Array/index.js",
+      "./output/Data.Array.NonEmpty/index.js",
+      "./output/Data.CodePoint.Unicode.Internal/index.js",
+      "./output/Data.Either.Nested/index.js",
+      "./output/Data.Functor.Product.Nested/index.js",
+      "./output/Data.Functor.Variant/index.js",
+      "./output/Data.Lens/index.js",
+      "./output/Data.CodePoint.Unicode.Internal.Casing",
+      "./output/Data.Tuple.Nested/index.js",
+      "./output/Halogen/index.js",
+      "./output/Halogen.HTML.Elements.Keyed/index.js",
+      "./output/Halogen.Hooks/index.js",
+      "./output/Prologue/index.js",
   ],
   externals: {
     "jquery": "jQuery"

--- a/marlowe-playground-client/webpack.vendor.config.js
+++ b/marlowe-playground-client/webpack.vendor.config.js
@@ -1,0 +1,65 @@
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
+const path = require("path");
+const webpack = require("webpack");
+
+module.exports = {
+  context: __dirname,
+  entry: [
+      "big-integer", "bignumber", "blockly", "bootstrap",
+      "decimal.js", "json-bigint", "monaco-editor", "monaco-emacs",
+      "monaco-vim", "moo", "nearley", "safe-eval",
+  ],
+  externals: {
+    "jquery": "jQuery"
+  },
+  module: {
+    rules: [{
+      test: /\.css$/,
+      use: [ MiniCssExtractPlugin.loader, "css-loader", "postcss-loader" ]
+    },
+    {
+        test: /\.ne$/,
+        loader: "nearley-webpack-loader",
+        options: {
+            baseDir: "."
+        }
+    },
+    { test: /\.tsx?$/,
+      loader: "ts-loader"
+    },
+    {
+        test: /\.ttf$/,
+        use: ["file-loader"],
+    }
+    ]
+  },
+  output: {
+    filename: "vendor.bundle.js",
+    path: path.resolve(__dirname, "dist"),
+    library: "vendor[fullhash]"
+  },
+  plugins: [
+    new MonacoWebpackPlugin({
+        // note that you have to include typescript if you want javascript to work!
+        languages: ["javascript", "typescript"],
+    }),
+    new MiniCssExtractPlugin({
+      filename: "[name].[contenthash].css",
+    }),
+    new webpack.DllPlugin({
+      // We use dll plugin only during the development workflow currently
+      // so we don't have to care about DCE.
+      entryOnly: false,
+      format: true,
+      name: "vendor[fullhash]",
+      path: path.resolve(__dirname, "dist/vendor-dll-manifest.json")
+    }),
+  ],
+  resolve: {
+      extensions: [".css", ".js", ".ts", ".tsx"],
+      fallback: {
+          vm: require.resolve("vm-browserify"),
+      },
+  },
+};

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/input-output-hk/purescript-web-common/releases/download/v1.1.5/packages.dhall sha256:ddf79f54f80dbdaec6c7bce0bae4e583b3b035c9c9bfc7affdb10cc81c96b0f9
+      https://github.com/input-output-hk/purescript-web-common/releases/download/v1.2.0/packages.dhall sha256:2fd872f5d3fbd13ffc3859dafa2bbd34df9d86874d1368207b5490db5532eff6
 
 let overrides = {=}
 

--- a/shell.nix
+++ b/shell.nix
@@ -120,7 +120,7 @@ haskell.project.shellFor {
   # Point to some source dependencies
   + ''
     export ACTUS_TEST_DATA_DIR=${packages.actus-tests}/tests/
-    export WEB_COMMON_SRC="${webCommon}"
+    export WEB_COMMON_SRC="${webCommon.cleanSrc}"
     export WEB_COMMON_PLAYGROUND_SRC="${webCommonPlayground}"
   '';
 }


### PR DESCRIPTION
It seems that it should not affect production builds in any way but please read it through with me.

For testing it is required to use a branch of [`web-common`](https://github.com/paluh/purescript-web-common/tree/optimize-webpack-rebuilds) and point to it in the build terminal (before running `npm`) by (please use absolute path!):

`export WEB_COMMON_SRC=/home/paluh/programming/purescript/projects/web-common`


Commit message:

* Drop `purs-loader`. We just assume here that the compilation itself is done
by programmer "ide" (possibly editor + `purescript-lts` / `purs ide server` or `pscid`).

* Add "dll" prebundling step by introducing `DllPlugin` into the dev
build. I've decided to use separate `webpack.vendor.config.js` for
additional prebundling step.

* Drop `CommonChunksPlugin` (`optimization` section) as we don't
have multiple entry points so we don't want to share any prebuild
bundles between them. A really nice `DllPlugin` vs `CommonChunksPlugin` comparison
can be found here: https://stackoverflow.com/a/43876021

* Skip any loading of analytics scripts on devel
