### PR TITLE
SCP-3089 - Marlowe Run Frontend - Re implement welcome page with wallet restore

### DIFF
--- a/marlowe-dashboard-client/README.md
+++ b/marlowe-dashboard-client/README.md
@@ -13,8 +13,8 @@ The [marlowe-pab](https://github.com/input-output-hk/marlowe-cardano/tree/master
 Marlowe Run requires a running instance of the Marlowe PAB to work:
 
 ```bash
-$ plutus-pab-migrate
-$ marlowe-pab-server
+[nix-shell] $ plutus-pab-migrate
+[nix-shell] $ marlowe-pab-server
 ```
 
 The first command (`plutus-pab-migrate`) initialises the database needed to run the Marlowe PAB. You should only need to do this once, but you might need to do it again if the PAB code changes in ways that require modifications to the database schema.

--- a/marlowe-dashboard-client/default.nix
+++ b/marlowe-dashboard-client/default.nix
@@ -25,10 +25,9 @@ let
   start-backend = pkgs.writeShellScriptBin "marlowe-pab-server" ''
     echo "marlowe-pab-server: for development use only"
     (trap 'kill 0' SIGINT;
-      $(nix-build ../default.nix --quiet --no-build-output -A marlowe-dashboard.marlowe-invoker)/bin/marlowe-pab --config plutus-pab.yaml all-servers &
+      $(nix-build ../default.nix --quiet --no-build-output -A marlowe-dashboard.marlowe-invoker)/bin/marlowe-pab --config plutus-pab.yaml webserver &
       $(nix-build ../default.nix -A marlowe-dashboard.marlowe-run-backend-invoker)/bin/marlowe-dashboard-server webserver -c ./config.json
     )
-
   '';
 
   cleanSrc = gitignore-nix.gitignoreSource ./.;

--- a/marlowe-dashboard-client/default.nix
+++ b/marlowe-dashboard-client/default.nix
@@ -24,7 +24,11 @@ let
 
   start-backend = pkgs.writeShellScriptBin "marlowe-pab-server" ''
     echo "marlowe-pab-server: for development use only"
-    $(nix-build ../default.nix --quiet --no-build-output -A marlowe-dashboard.marlowe-invoker)/bin/marlowe-pab --config plutus-pab.yaml all-servers
+    (trap 'kill 0' SIGINT;
+      $(nix-build ../default.nix --quiet --no-build-output -A marlowe-dashboard.marlowe-invoker)/bin/marlowe-pab --config plutus-pab.yaml all-servers &
+      $(nix-build ../default.nix -A marlowe-dashboard.marlowe-run-backend-invoker)/bin/marlowe-dashboard-server webserver -c ./config.json
+    )
+
   '';
 
   cleanSrc = gitignore-nix.gitignoreSource ./.;

--- a/marlowe-dashboard-client/docs/use-cases/Readme.md
+++ b/marlowe-dashboard-client/docs/use-cases/Readme.md
@@ -1,0 +1,10 @@
+# Marlowe Run Use Cases
+
+> Nomenclature `UC-{module name}-{optional modifier}-{use case number}`
+
+You can search in the code for `[UC-MODULE-MOD-0]` to see important places where the use case is implemented.
+
+## Wallet
+
+* [UC-WALLET-TESTNET-1](./wallet.md#UC-WALLET-TESTNET-1): Create a new testnet wallet
+* [UC-WALLET-TESTNET-2](./wallet.md#UC-WALLET-TESTNET-2): Restore a testnet wallet

--- a/marlowe-dashboard-client/docs/use-cases/wallet.md
+++ b/marlowe-dashboard-client/docs/use-cases/wallet.md
@@ -1,0 +1,12 @@
+## Create a new testnet wallet
+**NOT IMPLEMENTED YET**
+#### UC-WALLET-TESTNET-1
+
+Allow a user to create a new wallet in a centralized server connected to the testnet. This helps users to try marlowe contracts in Marlowe Run without having to install a wallet.
+
+## Restore a testnet wallet
+#### UC-WALLET-TESTNET-2
+
+With the use of a mnemonic phrase the user can retrieve the wallet created in `UC-WALLET-TESTNET-1` in the centralized server.
+
+**IMPORTANT!!!: ** The user should never use a mnemonic phrase from a real mainnet wallet.

--- a/marlowe-dashboard-client/entry.js
+++ b/marlowe-dashboard-client/entry.js
@@ -1,4 +1,9 @@
 /*eslint-env node*/
 import './static/css/main.css';
+// We need to patch the JSON.stringify in order for BigInt serialization to work.
+var JSONbig = require("json-bigint");
+
+JSON.stringify = JSONbig.stringify;
+JSON.parse = JSONbig.parse;
 
 require('./src/Main.purs').main();

--- a/marlowe-dashboard-client/spago-packages.nix
+++ b/marlowe-dashboard-client/spago-packages.nix
@@ -1255,11 +1255,11 @@ let
 
     "web-common" = pkgs.stdenv.mkDerivation {
         name = "web-common";
-        version = "v1.1.3";
+        version = "v1.1.5";
         src = pkgs.fetchgit {
           url = "https://github.com/input-output-hk/purescript-web-common";
-          rev = "f6ba33c8543e5c830592f86e94b3e89ca117e602";
-          sha256 = "10hsvndlvag0c89gwn6hmiiar45cifl1416b0psbvqjdjqbmhvv0";
+          rev = "337be975d1ba4780aad55a7c765938b4244b8c74";
+          sha256 = "1gq3w2kyr4yz55r4hl0z0gx5ymcz4ik0w2c4fa5y09zy4lrqbj14";
         };
         phases = "installPhase";
         installPhase = "ln -s $src $out";

--- a/marlowe-dashboard-client/src/API/Marlowe/Run/TestnetWallet.purs
+++ b/marlowe-dashboard-client/src/API/Marlowe/Run/TestnetWallet.purs
@@ -1,7 +1,7 @@
 module API.Marlowe.Run.TestnetWallet
   ( restoreWallet
   , RestoreWalletOptions
-  , RestoreError
+  , RestoreError(..)
   ) where
 
 import Prologue

--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -20,8 +20,7 @@ module Capability.Marlowe
 
 import Prologue
 import API.Lenses (_cicContract, _cicCurrentState, _cicDefinition, _cicWallet, _observableState)
-import API.Marlowe.Run.TestnetWallet (RestoreError(..))
-import API.Marlowe.Run.TestnetWallet (RestoreWalletOptions)
+import API.Marlowe.Run.TestnetWallet (RestoreError(..), RestoreWalletOptions)
 import AppM (AppM)
 import Bridge (toBack, toFront)
 import Capability.Contract (activateContract, getContractInstanceClientState, getContractInstanceObservableState, getWalletContractInstances, invokeEndpoint) as Contract
@@ -31,10 +30,10 @@ import Capability.PlutusApps.MarloweApp as MarloweApp
 import Capability.Wallet (class ManageWallet)
 import Capability.Wallet as Wallet
 import Component.Contacts.Lenses (_companionAppId, _marloweAppId, _pubKeyHash, _walletId, _walletInfo)
-import Component.Contacts.Types (WalletDetails, WalletId(..), WalletInfo)
+import Component.Contacts.Types (WalletDetails, WalletId, WalletInfo)
 import Control.Monad.Except (ExceptT(..), except, lift, runExceptT, withExceptT)
 import Control.Monad.Reader (asks)
-import Data.Argonaut.Decode (JsonDecodeError, (.!=))
+import Data.Argonaut.Decode (JsonDecodeError)
 import Data.Argonaut.Extra (parseDecodeJson)
 import Data.Array (filter) as Array
 import Data.Array (find)
@@ -42,7 +41,7 @@ import Data.Bifunctor (lmap)
 import Data.Lens (view)
 import Data.Map (Map, fromFoldable)
 import Data.Newtype (unwrap, un)
-import Data.Traversable (for, traverse)
+import Data.Traversable (traverse)
 import Data.Tuple.Nested ((/\))
 import Halogen (HalogenM, liftAff)
 import Marlowe.Client (ContractHistory)

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp/Types.purs
@@ -16,8 +16,8 @@ import Data.Argonaut.Decode (class DecodeJson)
 import Data.Argonaut.Decode.Aeson ((</$\>), (</*\>))
 import Data.Argonaut.Decode.Aeson as D
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
-import Data.Argonaut.Encode.Aeson as E
 import Data.Argonaut.Encode.Aeson ((>/\<))
+import Data.Argonaut.Encode.Aeson as E
 import Data.Generic.Rep (class Generic)
 import Data.Map as Map
 import Data.Tuple (uncurry)
@@ -56,7 +56,7 @@ instance decodeJsonLastResult :: DecodeJson LastResult where
       $ Map.fromFoldable
           [ "OK" /\ D.content (uncurry OK <$> D.value)
           , "SomeError" /\ D.content (D.tuple $ SomeError </$\> D.value </*\> D.value </*\> D.value)
-          , "Unknown" /\ D.content (Unknown <$ D.null)
+          , "Unknown" /\ pure Unknown
           ]
 
 data MarloweError

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -5,7 +5,6 @@ module Main
 import Prologue
 import AppM (runAppM)
 import Capability.PlutusApps.MarloweApp as MarloweApp
-import Data.BigInt.Argonaut as BigInt
 import Effect (Effect)
 import Effect.AVar as AVar
 import Effect.Aff (forkAff, launchAff_)
@@ -33,20 +32,19 @@ mkEnvironment wsManager = do
 main :: Effect Unit
 main = do
   runHalogenAff do
-    BigInt.withJsonPatch do
-      wsManager <- WS.mkWebSocketManager
-      environment <- liftEffect $ mkEnvironment wsManager
-      body <- awaitBody
-      driver <- runUI (hoist (runAppM environment) mkMainFrame) Init body
-      void
-        $ forkAff
-        $ WS.runWebSocketManager
-            (WS.URI "/pab/ws")
-            (\msg -> void $ forkAff $ driver.query $ ReceiveWebSocketMessage msg unit)
-            wsManager
-      -- This handler allows us to call an action in the MainFrame from a child component
-      -- (more info in the MainFrameLoop capability)
-      void
-        $ liftEffect
-        $ HS.subscribe driver.messages
-        $ \(MainFrameActionMsg action) -> launchAff_ $ void $ driver.query $ MainFrameActionQuery action unit
+    wsManager <- WS.mkWebSocketManager
+    environment <- liftEffect $ mkEnvironment wsManager
+    body <- awaitBody
+    driver <- runUI (hoist (runAppM environment) mkMainFrame) Init body
+    void
+      $ forkAff
+      $ WS.runWebSocketManager
+          (WS.URI "/pab/ws")
+          (\msg -> void $ forkAff $ driver.query $ ReceiveWebSocketMessage msg unit)
+          wsManager
+    -- This handler allows us to call an action in the MainFrame from a child component
+    -- (more info in the MainFrameLoop capability)
+    void
+      $ liftEffect
+      $ HS.subscribe driver.messages
+      $ \(MainFrameActionMsg action) -> launchAff_ $ void $ driver.query $ MainFrameActionQuery action unit

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -19,7 +19,6 @@ import Data.Newtype (unwrap)
 import Data.Set (toUnfoldable) as Set
 import Data.Time.Duration (Minutes(..))
 import Data.Traversable (for)
-import Debug (traceM)
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (Component, HalogenM, liftEffect, mkComponent, mkEval, modify_)
@@ -163,9 +162,6 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
                 Right companionAppState -> do
                   -- this check shouldn't be necessary, but at the moment we are getting too many update notifications
                   -- through the PAB - so until that bug is fixed, this will have to mask it
-                  traceM "companionAppState"
-                  when (view (_walletDetails <<< _previousCompanionAppState) dashboardState == Just companionAppState)
-                    $ traceM "Companion state is the same"
                   when (view (_walletDetails <<< _previousCompanionAppState) dashboardState /= Just companionAppState) do
                     assign (_dashboardState <<< _walletDetails <<< _previousCompanionAppState) (Just companionAppState)
                     {- [Workflow 2][5] Connect a wallet -}
@@ -180,11 +176,8 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
               else do
                 -- if this is the wallet's MarloweApp...
                 if (plutusAppId == marloweAppId) then case parseDecodeJson $ unwrap rawJson of
-                  Left decodingError -> do
-                    traceM { msg: "failed to decode marlowe controller", rawJson, decodingError }
-                    addToast $ decodingErrorToast "Failed to parse an update from the marlowe controller." decodingError
+                  Left decodingError -> addToast $ decodingErrorToast "Failed to parse an update from the marlowe controller." decodingError
                   Right lastResult -> do
-                    traceM { msg: "Last result!!!!", lastResult }
                     -- The MarloweApp capability keeps track of the requests it makes to see if this
                     -- new observable state is a WS response for an action that we made. If we refresh
                     -- we get the last observable state, and if we have two tabs open we can get

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -159,7 +159,7 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
             in
               -- if this is the wallet's WalletCompanion app...
               if (plutusAppId == walletCompanionAppId) then case parseDecodeJson $ unwrap rawJson of
-                Left decodingError -> addToast $ decodingErrorToast "Failed to parse contract update." decodingError
+                Left decodingError -> addToast $ decodingErrorToast "Failed to parse an update from the wallet companion." decodingError
                 Right companionAppState -> do
                   -- this check shouldn't be necessary, but at the moment we are getting too many update notifications
                   -- through the PAB - so until that bug is fixed, this will have to mask it
@@ -180,8 +180,11 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
               else do
                 -- if this is the wallet's MarloweApp...
                 if (plutusAppId == marloweAppId) then case parseDecodeJson $ unwrap rawJson of
-                  Left decodingError -> addToast $ decodingErrorToast "Failed to parse contract update." decodingError
+                  Left decodingError -> do
+                    traceM { msg: "failed to decode marlowe controller", rawJson, decodingError }
+                    addToast $ decodingErrorToast "Failed to parse an update from the marlowe controller." decodingError
                   Right lastResult -> do
+                    traceM { msg: "Last result!!!!", lastResult }
                     -- The MarloweApp capability keeps track of the requests it makes to see if this
                     -- new observable state is a WS response for an action that we made. If we refresh
                     -- we get the last observable state, and if we have two tabs open we can get
@@ -198,7 +201,7 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
                       _ -> pure unit
                 -- otherwise this should be one of the wallet's `MarloweFollower` apps
                 else case parseDecodeJson $ unwrap rawJson of
-                  Left decodingError -> addToast $ decodingErrorToast "Failed to parse contract update." decodingError
+                  Left decodingError -> addToast $ decodingErrorToast "Failed to parse an update from a contract." decodingError
                   Right contractHistory -> do
                     {- [Workflow 2][7] Connect a wallet -}
                     {- [Workflow 4][3] Start a contract -}

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -19,6 +19,7 @@ import Data.Newtype (unwrap)
 import Data.Set (toUnfoldable) as Set
 import Data.Time.Duration (Minutes(..))
 import Data.Traversable (for)
+import Debug (traceM)
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (Component, HalogenM, liftEffect, mkComponent, mkEval, modify_)
@@ -162,6 +163,9 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
                 Right companionAppState -> do
                   -- this check shouldn't be necessary, but at the moment we are getting too many update notifications
                   -- through the PAB - so until that bug is fixed, this will have to mask it
+                  traceM "companionAppState"
+                  when (view (_walletDetails <<< _previousCompanionAppState) dashboardState == Just companionAppState)
+                    $ traceM "Companion state is the same"
                   when (view (_walletDetails <<< _previousCompanionAppState) dashboardState /= Just companionAppState) do
                     assign (_dashboardState <<< _walletDetails <<< _previousCompanionAppState) (Just companionAppState)
                     {- [Workflow 2][5] Connect a wallet -}

--- a/marlowe-dashboard-client/src/Page/Welcome/Lenses.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/Lenses.purs
@@ -6,7 +6,7 @@ import Component.InputField.Types (State) as InputField
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
 import Marlowe.PAB (PlutusAppId)
-import Page.Welcome.Types (Card, State, WalletMnemonicError, WalletNicknameOrIdError)
+import Page.Welcome.Types (Card, State, WalletMnemonicError)
 import Type.Proxy (Proxy(..))
 import Types (NotFoundWebData)
 
@@ -18,10 +18,6 @@ _cardOpen = prop (Proxy :: _ "cardOpen")
 
 _walletLibrary :: Lens' State WalletLibrary
 _walletLibrary = prop (Proxy :: _ "walletLibrary")
-
--- FIXME: Remove
-_walletNicknameOrIdInput :: Lens' State (InputField.State WalletNicknameOrIdError)
-_walletNicknameOrIdInput = prop (Proxy :: _ "walletNicknameOrIdInput")
 
 _walletNicknameInput :: Lens' State (InputField.State WalletNicknameError)
 _walletNicknameInput = prop (Proxy :: _ "walletNicknameInput")

--- a/marlowe-dashboard-client/src/Page/Welcome/Lenses.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/Lenses.purs
@@ -1,22 +1,13 @@
-module Page.Welcome.Lenses
-  ( _card
-  , _cardOpen
-  , _walletLibrary
-  , _walletNicknameOrIdInput
-  , _walletNicknameInput
-  , _walletId
-  , _remoteWalletDetails
-  , _enteringDashboardState
-  ) where
+module Page.Welcome.Lenses where
 
 import Prologue
 import Component.Contacts.Types (WalletDetails, WalletLibrary, WalletNicknameError)
 import Component.InputField.Types (State) as InputField
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
-import Type.Proxy (Proxy(..))
 import Marlowe.PAB (PlutusAppId)
-import Page.Welcome.Types (Card, State, WalletNicknameOrIdError)
+import Page.Welcome.Types (Card, State, WalletMnemonicError, WalletNicknameOrIdError)
+import Type.Proxy (Proxy(..))
 import Types (NotFoundWebData)
 
 _card :: Lens' State (Maybe Card)
@@ -28,11 +19,15 @@ _cardOpen = prop (Proxy :: _ "cardOpen")
 _walletLibrary :: Lens' State WalletLibrary
 _walletLibrary = prop (Proxy :: _ "walletLibrary")
 
+-- FIXME: Remove
 _walletNicknameOrIdInput :: Lens' State (InputField.State WalletNicknameOrIdError)
 _walletNicknameOrIdInput = prop (Proxy :: _ "walletNicknameOrIdInput")
 
 _walletNicknameInput :: Lens' State (InputField.State WalletNicknameError)
 _walletNicknameInput = prop (Proxy :: _ "walletNicknameInput")
+
+_walletMnemonicInput :: Lens' State (InputField.State WalletMnemonicError)
+_walletMnemonicInput = prop (Proxy :: _ "walletMnemonicInput")
 
 _walletId :: Lens' State PlutusAppId
 _walletId = prop (Proxy :: _ "walletId")

--- a/marlowe-dashboard-client/src/Page/Welcome/State.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/State.purs
@@ -26,7 +26,6 @@ import Data.Map (insert)
 import Data.Map as Map
 import Data.String (Pattern(..), split)
 import Data.UUID.Argonaut (emptyUUID) as UUID
-import Debug (traceM)
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (HalogenM, liftEffect, modify_, tell)
@@ -85,7 +84,8 @@ handleAction ::
   MonadClipboard m =>
   Action -> HalogenM State Action ChildSlots Msg m Unit
 handleAction (OpenCard card) = do
-  -- TODO: make cards real halogen components to encapsulate initialization logic
+  -- TODO: Refactor cards into real halogen components to encapsulate initialization logic. There are multiple
+  -- Reset calls spread over this file.
   case card of
     RestoreTestnetWalletCard -> do
       walletLibrary <- use _walletLibrary
@@ -117,7 +117,7 @@ that wallet: a `WalletCompanion` and a `MarloweApp`.
 - The `MarloweApp` is a control app, used to create Marlowe contracts, apply inputs, and redeem
   payments to this wallet.
 -}
--- TODO: Button disable, re-enable it as part of SCP-3170.
+-- TODO: This functionality is disabled, I'll re-enable it as part of SCP-3170.
 handleAction GenerateWallet = pure unit
 
 -- walletLibrary <- use _walletLibrary
@@ -148,11 +148,12 @@ handleAction RestoreTestnetWallet = do
       handleAction $ CloseCard
     Right walletDetails -> do
       tell _submitButtonSlot "restore-wallet" $ SubmitResult (Milliseconds 1200.0) (Right "Wallet restored")
-      traceM { msg: "oh yeas2", walletDetails }
       assign _remoteWalletDetails $ pure walletDetails
       -- TODO: SCP-3132 Fire logic to sync total funds
       handleAction $ ConnectWallet walletName
 
+-- TODO: We'll most likely won't need the [Workflow 2][X] connect wallet features, but I'll remove them
+--       once the new flow is fully functional.
 {- [Workflow 2][1] Connect a wallet
 If we are connecting a wallet that was selected by the user inputting a wallet nickname, then we
 will have a cache of it's `WalletDetails` in LocalStorage. But those details may well be out of
@@ -180,7 +181,6 @@ This action is triggered by clicking the confirmation button on the UseWalletCar
 UseNewWalletCard. It saves the wallet nickname to LocalStorage, and then calls the
 `MainFrame.EnterDashboardState` action.
 -}
--- FIXME: Probably remove
 handleAction (ConnectWallet walletNickname) = do
   assign _enteringDashboardState true
   remoteWalletDetails <- use _remoteWalletDetails

--- a/marlowe-dashboard-client/src/Page/Welcome/State.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/State.purs
@@ -123,7 +123,7 @@ that wallet: a `WalletCompanion` and a `MarloweApp`.
 - The `MarloweApp` is a control app, used to create Marlowe contracts, apply inputs, and redeem
   payments to this wallet.
 -}
--- FIXME: CHANGE LOGIC
+-- TODO: Button disable, re-enable it as part of SCP-3170.
 handleAction GenerateWallet = pure unit
 
 -- walletLibrary <- use _walletLibrary

--- a/marlowe-dashboard-client/src/Page/Welcome/Types.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/Types.purs
@@ -2,7 +2,6 @@ module Page.Welcome.Types
   ( Action(..)
   , Card(..)
   , State
-  , WalletNicknameOrIdError(..)
   , WalletMnemonicError(..)
   ) where
 
@@ -29,24 +28,12 @@ type State
     -- from the right) - and that's much easier to do with media queries.
     , cardOpen :: Boolean
     , walletLibrary :: WalletLibrary
-    , walletNicknameOrIdInput :: InputField.State WalletNicknameOrIdError
     , walletNicknameInput :: InputField.State WalletNicknameError
     , walletMnemonicInput :: InputField.State WalletMnemonicError
     , walletId :: PlutusAppId
     , remoteWalletDetails :: NotFoundWebData WalletDetails
     , enteringDashboardState :: Boolean
     }
-
--- FIXME: Delete
-data WalletNicknameOrIdError
-  = UnconfirmedWalletNicknameOrId
-  | NonexistentWalletNicknameOrId
-
-derive instance eqWalletNicknameOrIdError :: Eq WalletNicknameOrIdError
-
-instance inputFieldErrorWalletNicknameOrIdError :: InputFieldError WalletNicknameOrIdError where
-  inputErrorToString UnconfirmedWalletNicknameOrId = "Looking up wallet..."
-  inputErrorToString NonexistentWalletNicknameOrId = "Wallet not found"
 
 data WalletMnemonicError
   = MnemonicAmountOfWords
@@ -78,8 +65,6 @@ data Action
   | GenerateWallet
   | RestoreTestnetWallet
   | WalletMnemonicInputAction (InputField.Action WalletMnemonicError)
-  -- FIXME: remove. Choose wallet or paste key
-  | WalletNicknameOrIdInputAction (InputField.Action WalletNicknameOrIdError)
   | OpenUseWalletCardWithDetails WalletDetails
   | WalletNicknameInputAction (InputField.Action WalletNicknameError)
   | ConnectWallet WalletNickname
@@ -93,7 +78,6 @@ instance actionIsEvent :: IsEvent Action where
   toEvent GenerateWallet = Just $ defaultEvent "GenerateWallet"
   toEvent RestoreTestnetWallet = Just $ defaultEvent "RestoreTestnetWallet"
   toEvent (WalletMnemonicInputAction inputFieldAction) = toEvent inputFieldAction
-  toEvent (WalletNicknameOrIdInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (OpenUseWalletCardWithDetails _) = Nothing
   toEvent (WalletNicknameInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (ConnectWallet _) = Just $ defaultEvent "ConnectWallet"

--- a/marlowe-dashboard-client/src/Page/Welcome/Types.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/Types.purs
@@ -50,9 +50,7 @@ instance inputFieldErrorWalletMnemonicError :: InputFieldError WalletMnemonicErr
 data Card
   = GetStartedHelpCard
   | GenerateWalletHelpCard
-  -- FIXME: Remove or change
   | UseNewWalletCard
-  -- FIXME: Remove or change
   | UseWalletCard
   | RestoreTestnetWalletCard
   | LocalWalletMissingCard

--- a/marlowe-dashboard-client/src/Page/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/View.purs
@@ -180,8 +180,7 @@ generateWalletHelpCard =
           [ classNames [ "font-semibold" ] ]
           [ text "Why generate a demo wallet?" ]
       , p_
-          -- FIXME: Change text to reflect new changes
-          [ text "Demo wallets are used so you can play around with the app and all its incredible features without using your own tokens from your real wallet." ]
+          [ text "We use a centralized server connected to a Testnet so you can play around with the app and all its incredible features without using your own tokens from your real wallet. Do not restore a wallet using a mnemonic phrase from a real wallet." ]
       , div
           [ classNames [ "flex" ] ]
           [ button
@@ -249,7 +248,7 @@ restoreTestnetWalletCard state =
         ]
     ]
 
--- FIXME: Remove or change
+-- TODO: Most likely remove or adapt all [Workflow 2][X] functionality
 useNewWalletCard :: forall p. State -> Array (HTML p Action)
 useNewWalletCard state =
   let
@@ -302,7 +301,7 @@ renderWalletId walletId =
       , walletIdTip
       ]
 
--- FIXME: Remove or change
+-- TODO: Most likely remove or adapt all [Workflow 2][X] functionality
 useWalletCard :: forall p. State -> Array (HTML p Action)
 useWalletCard state =
   let

--- a/marlowe-dashboard-client/src/Page/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/View.purs
@@ -34,7 +34,7 @@ import Page.Welcome.Lenses (_card, _cardOpen, _enteringDashboardState, _remoteWa
 import Page.Welcome.Types (Action(..), Card(..), State)
 
 welcomeScreen :: forall p. State -> HTML p Action
-welcomeScreen state =
+welcomeScreen _ =
   main
     [ classNames
         [ "h-full"
@@ -50,7 +50,7 @@ welcomeScreen state =
         , "p-4"
         ]
     ]
-    [ useWalletBox state
+    [ useWalletBox
     , gettingStartedBox
     ]
 
@@ -77,8 +77,8 @@ welcomeCard state =
       ]
 
 ------------------------------------------------------------
-useWalletBox :: forall p. State -> HTML p Action
-useWalletBox state =
+useWalletBox :: forall p. HTML p Action
+useWalletBox =
   section
     [ classNames [ "row-start-2", "lg:col-start-2", "bg-white", "rounded-lg", "shadow-lg", "p-8", "lg:p-12", "max-w-sm", "mx-auto", "lg:max-w-none", "lg:w-welcome-box", "space-y-4" ] ]
     [ div [ classNames [ "p-2 pt-0" ] ]

--- a/marlowe-dashboard-client/src/Page/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/View.purs
@@ -214,6 +214,11 @@ restoreTestnetWalletCard state =
             $ Label.render
                 Label.defaultInput { for = "walletMnemonic", text = "Mnemonic phrase" }
       }
+
+    submitButtonEnabled =
+      isNothing (validate walletNicknameInput)
+        && isNothing (validate walletMnemonicInput)
+        && not enteringDashboardState
   in
     [ a
         [ classNames [ "absolute", "top-4", "right-4" ]
@@ -242,7 +247,7 @@ restoreTestnetWalletCard state =
                 { ref: "restore-wallet"
                 , caption: "Restore Wallet"
                 , styles: [ "flex-1" ]
-                , enabled: isNothing (validate walletNicknameInput) && not enteringDashboardState
+                , enabled: submitButtonEnabled
                 , handler: RestoreTestnetWallet
                 }
             ]

--- a/marlowe-dashboard-client/src/Page/Welcome/View.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/View.purs
@@ -228,6 +228,7 @@ restoreTestnetWalletCard state =
         , WalletMnemonicInputAction <$> renderInput walletMnemonicDisplayOptions walletMnemonicInput
         , p_
             [ b_ [ text "IMPORTANT:" ]
+            -- FIXME: as part of SCP-3173, Write a section in the Marlowe Run documentation and add a link to it
             , text "Do not use a real wallet phrase <read more>"
             ]
         , div

--- a/marlowe-dashboard-client/webpack.config.js
+++ b/marlowe-dashboard-client/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = {
                             bundle: !isDevelopment,
                             psc: "psa",
                             pscArgs: {
-                                strict: true,
+                                strict: false,
                                 censorLib: true,
                                 stash: isDevelopment,
                                 isLib: ["generated", ".spago"],

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Server.hs
@@ -75,6 +75,7 @@ callWBE client = do
     clientEnv <- ask
     liftIO $ runClientM client clientEnv
 
+-- [UC-WALLET-TESTNET-2][1] Restore a testnet wallet
 restoreWallet ::
      MonadIO m =>
      MonadReader Env m =>

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/input-output-hk/purescript-web-common/releases/download/v1.1.4/packages.dhall sha256:ab905184ee034c35867e73ace0475ce29d1a0b975581d355af6f35e680449749
+      https://github.com/input-output-hk/purescript-web-common/releases/download/v1.1.5/packages.dhall sha256:ddf79f54f80dbdaec6c7bce0bae4e583b3b035c9c9bfc7affdb10cc81c96b0f9
 
 let overrides = {=}
 


### PR DESCRIPTION
This PR adds a modal to restore a wallet from the centralized server using the endpoint created in [PR 27](https://github.com/input-output-hk/marlowe-cardano/pull/27). We can now advance to the Main screen but we can't create a contract yet.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
