### PR TITLE
SCP-3132 Get total funds through WBE (part 1 - backend API)

### DIFF
--- a/marlowe-dashboard-client/src/API/Marlowe/Run/Wallet.purs
+++ b/marlowe-dashboard-client/src/API/Marlowe/Run/Wallet.purs
@@ -1,0 +1,24 @@
+module API.Marlowe.Run.Wallet
+  ( getTotalFunds
+  ) where
+
+import Prologue
+import API.Request (doGetRequest)
+import API.Url (toUrlPiece)
+import Component.Contacts.Types (WalletId)
+import Control.Monad.Error.Class (class MonadError)
+import Effect.Aff.Class (class MonadAff)
+import Marlowe.Run.Webserver.Wallet.Types (GetTotalFunds) as BE
+import Servant.PureScript (AjaxError)
+
+getTotalFunds ::
+  forall m.
+  MonadAff m =>
+  MonadError AjaxError m =>
+  WalletId ->
+  m BE.GetTotalFunds
+getTotalFunds wallet =
+  doGetRequest
+    $ "/api/wallet/"
+    <> toUrlPiece wallet
+    <> "/get-total-funds"

--- a/marlowe-dashboard-client/src/API/Marlowe/Run/Wallet/CentralizedTestnet.purs
+++ b/marlowe-dashboard-client/src/API/Marlowe/Run/Wallet/CentralizedTestnet.purs
@@ -1,4 +1,4 @@
-module API.Marlowe.Run.TestnetWallet
+module API.Marlowe.Run.Wallet.CentralizedTestnet
   ( restoreWallet
   , RestoreWalletOptions
   , RestoreError(..)
@@ -46,5 +46,5 @@ restoreWallet { walletName, mnemonicPhrase } = do
     $ runExceptT
     $ doPostRequestWith
         { encode: encodeJson, decode: D.decode (D.either D.value D.value) }
-        "/api/wallet/restore"
+        "/api/wallet/centralized-testnet/restore"
         body

--- a/marlowe-dashboard-client/src/API/Marlowe/Run/Wallet/CentralizedTestnet.purs
+++ b/marlowe-dashboard-client/src/API/Marlowe/Run/Wallet/CentralizedTestnet.purs
@@ -11,7 +11,7 @@ import Control.Monad.Except (runExceptT)
 import Data.Argonaut (encodeJson)
 import Data.Argonaut.Decode.Aeson as D
 import Effect.Aff.Class (class MonadAff)
-import Marlowe.Run.Webserver.Types (RestoreError(..), RestorePostData(..)) as BE
+import Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types (RestoreError(..), RestorePostData(..)) as BE
 import Servant.PureScript (AjaxError)
 
 type RestoreWalletOptions

--- a/marlowe-dashboard-client/src/API/Url.purs
+++ b/marlowe-dashboard-client/src/API/Url.purs
@@ -17,6 +17,9 @@ type URLPiece
 class ToUrlPiece a where
   toUrlPiece :: a -> URLPiece
 
+instance stringToUrlPiece :: ToUrlPiece String where
+  toUrlPiece str = str
+
 instance contractInstanceIdToUrlPiece :: ToUrlPiece ContractInstanceId where
   toUrlPiece (ContractInstanceId { unContractInstanceId: UUID uuid }) = UUID.toString uuid
 

--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -20,7 +20,7 @@ module Capability.Marlowe
 
 import Prologue
 import API.Lenses (_cicContract, _cicCurrentState, _cicDefinition, _cicWallet, _observableState)
-import API.Marlowe.Run.TestnetWallet (RestoreError(..), RestoreWalletOptions)
+import API.Marlowe.Run.Wallet.CentralizedTestnet (RestoreError(..), RestoreWalletOptions)
 import AppM (AppM)
 import Bridge (toBack, toFront)
 import Capability.Contract (activateContract, getContractInstanceClientState, getContractInstanceObservableState, getWalletContractInstances, invokeEndpoint) as Contract

--- a/marlowe-dashboard-client/src/Capability/Wallet.purs
+++ b/marlowe-dashboard-client/src/Capability/Wallet.purs
@@ -9,8 +9,8 @@ module Capability.Wallet
   ) where
 
 import Prologue
-import API.Marlowe.Run.TestnetWallet (RestoreError, RestoreWalletOptions)
-import API.Marlowe.Run.TestnetWallet as TestnetAPI
+import API.Marlowe.Run.Wallet.CentralizedTestnet (RestoreError, RestoreWalletOptions)
+import API.Marlowe.Run.Wallet.CentralizedTestnet as TestnetAPI
 import API.MockWallet as MockAPI
 import AppM (AppM)
 import Bridge (toBack, toFront)

--- a/marlowe-dashboard-client/src/Component/Contacts/Types.purs
+++ b/marlowe-dashboard-client/src/Component/Contacts/Types.purs
@@ -12,6 +12,7 @@ module Component.Contacts.Types
   ) where
 
 import Prologue
+import API.Url (class ToUrlPiece)
 import Analytics (class IsEvent, defaultEvent, toEvent)
 import Clipboard (Action) as Clipboard
 import Component.InputField.Types (Action, State) as InputField
@@ -81,6 +82,8 @@ derive instance genericWalletId :: Generic WalletId _
 derive newtype instance encodeJsonWalletId :: EncodeJson WalletId
 
 derive newtype instance decodeJsonWalletId :: DecodeJson WalletId
+
+derive newtype instance toUrlPieceWalletId :: ToUrlPiece WalletId
 
 data CardSection
   = Home

--- a/marlowe-dashboard-client/src/Page/Welcome/State.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/State.purs
@@ -5,7 +5,7 @@ module Page.Welcome.State
   ) where
 
 import Prologue
-import API.Marlowe.Run.TestnetWallet (RestoreError(..))
+import API.Marlowe.Run.Wallet.CentralizedTestnet (RestoreError(..))
 import Capability.MainFrameLoop (class MainFrameLoop, callMainFrameAction)
 import Capability.Marlowe (class ManageMarlowe, lookupWalletDetails, restoreWallet)
 import Capability.MarloweStorage (class ManageMarloweStorage, clearAllLocalStorage, insertIntoWalletLibrary)

--- a/marlowe-dashboard-server/app/PSGenerator.hs
+++ b/marlowe-dashboard-server/app/PSGenerator.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module PSGenerator
@@ -28,12 +27,12 @@ import           Language.PureScript.Bridge.PSTypes                    (psNumber
 import           Language.PureScript.Bridge.SumType                    (equal, genericShow, mkSumType, order)
 import           Marlowe.Run.Webserver.API                             (HTTPAPI)
 import           Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types (RestoreError, RestorePostData)
+import           Marlowe.Run.Webserver.Wallet.Types                    (GetTotalFunds)
 import           Marlowe.Run.Webserver.WebSocket                       (StreamToClient, StreamToServer)
 import qualified PSGenerator.Common
 import           Servant.PureScript                                    (HasBridge, Settings, apiModuleName,
                                                                         defaultBridge, defaultSettings, languageBridge,
                                                                         writeAPIModuleWithSettings)
-
 doubleBridge :: BridgePart
 doubleBridge = typeName ^== "Double" >> return psNumber
 
@@ -69,7 +68,8 @@ myTypes =
   [ equal . genericShow . argonaut $ mkSumType @StreamToServer,
     equal . genericShow . argonaut $ mkSumType @StreamToClient,
     equal . order . genericShow . argonaut $ mkSumType @RestoreError,
-    equal . genericShow . argonaut $ mkSumType @RestorePostData
+    equal . genericShow . argonaut $ mkSumType @RestorePostData,
+    equal . genericShow . argonaut $ mkSumType @GetTotalFunds
   ]
 
 mySettings :: Settings

--- a/marlowe-dashboard-server/app/PSGenerator.hs
+++ b/marlowe-dashboard-server/app/PSGenerator.hs
@@ -15,22 +15,24 @@ module PSGenerator
   )
 where
 
-import           Control.Applicative                ((<|>))
-import           Control.Lens                       (set, (&))
-import           Data.Monoid                        ()
-import           Data.Proxy                         (Proxy (Proxy))
-import qualified Data.Text.Encoding                 as T ()
-import qualified Data.Text.IO                       as T ()
-import           Language.PureScript.Bridge         (BridgePart, Language (Haskell), SumType, argonaut, buildBridge,
-                                                     typeName, writePSTypes, (^==))
-import           Language.PureScript.Bridge.PSTypes (psNumber, psString)
-import           Language.PureScript.Bridge.SumType (equal, genericShow, mkSumType, order)
-import           Marlowe.Run.Webserver.API          (HTTPAPI)
-import           Marlowe.Run.Webserver.Types        (RestoreError, RestorePostData)
-import           Marlowe.Run.Webserver.WebSocket    (StreamToClient, StreamToServer)
+import           Control.Applicative                                   ((<|>))
+import           Control.Lens                                          (set, (&))
+import           Data.Monoid                                           ()
+import           Data.Proxy                                            (Proxy (Proxy))
+import qualified Data.Text.Encoding                                    as T ()
+import qualified Data.Text.IO                                          as T ()
+import           Language.PureScript.Bridge                            (BridgePart, Language (Haskell), SumType,
+                                                                        argonaut, buildBridge, typeName, writePSTypes,
+                                                                        (^==))
+import           Language.PureScript.Bridge.PSTypes                    (psNumber, psString)
+import           Language.PureScript.Bridge.SumType                    (equal, genericShow, mkSumType, order)
+import           Marlowe.Run.Webserver.API                             (HTTPAPI)
+import           Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types (RestoreError, RestorePostData)
+import           Marlowe.Run.Webserver.WebSocket                       (StreamToClient, StreamToServer)
 import qualified PSGenerator.Common
-import           Servant.PureScript                 (HasBridge, Settings, apiModuleName, defaultBridge, defaultSettings,
-                                                     languageBridge, writeAPIModuleWithSettings)
+import           Servant.PureScript                                    (HasBridge, Settings, apiModuleName,
+                                                                        defaultBridge, defaultSettings, languageBridge,
+                                                                        writeAPIModuleWithSettings)
 
 doubleBridge :: BridgePart
 doubleBridge = typeName ^== "Double" >> return psNumber

--- a/marlowe-dashboard-server/marlowe-dashboard-server.cabal
+++ b/marlowe-dashboard-server/marlowe-dashboard-server.cabal
@@ -22,11 +22,13 @@ library
         Marlowe.Run.Webserver.API
         Marlowe.Run.Webserver.WebSocket
         Marlowe.Run.Webserver.Types
+        Marlowe.Run.Webserver.Wallet.Types
         Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types
         Marlowe.Run.Webserver.Wallet.Client
     other-modules:
         Paths_marlowe_dashboard_server
         Marlowe.Run.Webserver.Wallet.API
+        Marlowe.Run.Webserver.Wallet.Server
         Marlowe.Run.Webserver.Wallet.CentralizedTestnet.API
         Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server
     hs-source-dirs:

--- a/marlowe-dashboard-server/marlowe-dashboard-server.cabal
+++ b/marlowe-dashboard-server/marlowe-dashboard-server.cabal
@@ -22,8 +22,13 @@ library
         Marlowe.Run.Webserver.API
         Marlowe.Run.Webserver.WebSocket
         Marlowe.Run.Webserver.Types
+        Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types
+        Marlowe.Run.Webserver.Wallet.Client
     other-modules:
         Paths_marlowe_dashboard_server
+        Marlowe.Run.Webserver.Wallet.API
+        Marlowe.Run.Webserver.Wallet.CentralizedTestnet.API
+        Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server
     hs-source-dirs:
         src
     default-language: Haskell2010

--- a/marlowe-dashboard-server/marlowe-dashboard-server.cabal
+++ b/marlowe-dashboard-server/marlowe-dashboard-server.cabal
@@ -48,6 +48,7 @@ library
         mtl -any,
         playground-common -any,
         plutus-ledger -any,
+        plutus-ledger-api -any,
         plutus-tx -any,
         plutus-pab -any,
         plutus-contract -any,

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/API.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/API.hs
@@ -1,17 +1,12 @@
-{-# LANGUAGE DataKinds          #-}
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TypeOperators      #-}
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Marlowe.Run.Webserver.API where
 
 import           Cardano.Prelude
-import           Marlowe.Run.Webserver.Types (RestoreError, RestorePostData)
-import           Servant.API                 (Get, JSON, PlainText, Post, Raw, ReqBody, (:<|>), (:>))
-import           Servant.API.WebSocket       (WebSocketPending)
--- FIXME: I don't like to use a Mock type here, but we'd need to publish some changes upstream to the PAB to fix this
-import           Cardano.Wallet.Mock.Types   (WalletInfo)
+import qualified Marlowe.Run.Webserver.Wallet.API as Wallet
+import           Servant.API                      (Get, JSON, PlainText, Raw, (:<|>), (:>))
+import           Servant.API.WebSocket            (WebSocketPending)
 
 type API = WebSocketAPI
     :<|> HTTPAPI
@@ -19,9 +14,7 @@ type API = WebSocketAPI
 
 type HTTPAPI = "api" :>
     ("version" :> Get '[PlainText, JSON] Text
-    :<|> "wallet" :>
-        ("restore" :> ReqBody '[ JSON] RestorePostData :> Post '[JSON] (Either RestoreError WalletInfo)
-        )
+    :<|> "wallet" :> Wallet.API
     )
 
 type WebSocketAPI = "ws" :> WebSocketPending

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Server.hs
@@ -1,14 +1,7 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TypeApplications   #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Marlowe.Run.Webserver.Server
@@ -19,47 +12,31 @@ module Marlowe.Run.Webserver.Server
  )
  where
 
-import           Cardano.Mnemonic                           (mkSomeMnemonic)
-import           Cardano.Prelude                            hiding (Handler)
-import qualified Cardano.Wallet.Api.Client                  as WBE.Api
-import           Cardano.Wallet.Api.Types                   (ApiVerificationKeyShelley (..))
-import qualified Cardano.Wallet.Api.Types                   as WBE
-import           Marlowe.Run.Webserver.API                  (API)
-import           Prelude                                    (userError)
+import           Cardano.Prelude                                        hiding (Handler)
+import           Marlowe.Run.Webserver.API                              (API)
+import           Prelude                                                (userError)
 
-import           Cardano.Wallet.Api                         (WalletKeys)
-import           Cardano.Wallet.Mock.Types                  (WalletInfo (..))
-import qualified Cardano.Wallet.Primitive.AddressDerivation as WBE
-import qualified Cardano.Wallet.Primitive.Types             as WBE
 
-import           Data.Aeson                                 as Aeson
-import qualified Data.Aeson.Types                           as Aeson
+import           Data.Aeson                                             as Aeson
 
-import           Cardano.Wallet.Primitive.AddressDerivation (Passphrase (Passphrase))
-import qualified Data.ByteString.Lazy                       as BL
 
-import           Data.String                                as S
-import qualified Data.Text                                  as Text
-import           Data.Text.Class                            (FromText (..))
-import           Data.Version                               (showVersion)
-import           Ledger                                     (PubKeyHash (..))
-import           Marlowe.Run.Webserver.Types                (Env, RestoreError (..), RestorePostData (..))
-import qualified Marlowe.Run.Webserver.WebSocket            as WS
-import qualified Paths_marlowe_dashboard_server             as Package.Paths
-import           PlutusTx.Builtins.Internal                 (BuiltinByteString (..))
-import           Servant                                    (Handler (Handler), Server, ServerError, hoistServer,
-                                                             serveDirectoryFileServer, (:<|>) ((:<|>)), (:>))
-import           Servant.Client                             (ClientError (FailureResponse), ClientM,
-                                                             ResponseF (responseBody), client, runClientM)
-import           Text.Regex                                 (Regex)
-import qualified Text.Regex                                 as Regex
-import qualified Wallet.Emulator.Wallet                     as Pab.Wallet
+import           Data.String                                            as S
+import qualified Data.Text                                              as Text
+import           Data.Version                                           (showVersion)
+import           Marlowe.Run.Webserver.Types                            (Env)
+import qualified Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server as Wallet
+import qualified Marlowe.Run.Webserver.WebSocket                        as WS
+import qualified Paths_marlowe_dashboard_server                         as Package.Paths
+import           Servant                                                (Handler (Handler), Server, ServerError,
+                                                                         hoistServer, serveDirectoryFileServer,
+                                                                         (:<|>) ((:<|>)))
+
 handlers :: FilePath -> Env -> Server API
 handlers staticPath env =
     hoistServer (Proxy @API) liftHandler
         ( WS.handle
             :<|> (handleVersion
-                   :<|> restoreWallet
+                   :<|> Wallet.handlers
                  )
             :<|> serveDirectoryFileServer staticPath
         )
@@ -69,115 +46,6 @@ handlers staticPath env =
 
 handleVersion :: Applicative m => m Text
 handleVersion = pure $ Text.pack $ showVersion Package.Paths.version
-
-callWBE :: MonadIO m => MonadReader Env m => ClientM a -> m (Either ClientError a)
-callWBE client = do
-    clientEnv <- ask
-    liftIO $ runClientM client clientEnv
-
--- [UC-WALLET-TESTNET-2][1] Restore a testnet wallet
-restoreWallet ::
-     MonadIO m =>
-     MonadReader Env m =>
-     RestorePostData ->
-     m (Either RestoreError WalletInfo)
-restoreWallet postData = runExceptT $ do
-    let
-        phrase = getMnemonicPhrase postData
-
-    -- Try to decode the passphrase into a mnemonic or fail with InvalidMnemonic
-    mnemonic <- withExceptT (const InvalidMnemonic)
-        ( ExceptT $
-            pure (WBE.ApiMnemonicT <$> mkSomeMnemonic @'[15, 18, 21, 24] phrase)
-        )
-
-    -- Call the WBE trying to restore the wallet, and take error 409 Conflict as a success
-    walletId <- withExceptT (const RestoreWalletError)
-        (ExceptT $ createOrRestoreWallet postData mnemonic)
-
-    -- Get the pubKeyHash of the first wallet derivation
-    pubKeyHash <- withExceptT (const FetchPubKeyHashError) $
-        ExceptT $ getPubKeyHashFromWallet walletId
-
-    pure $ WalletInfo{wiWallet=Pab.Wallet.Wallet (Pab.Wallet.WalletId walletId), wiPubKeyHash = pubKeyHash }
-
-getPubKeyHashFromWallet ::
-    MonadIO m =>
-    MonadReader Env m =>
-    WBE.WalletId ->
-    m (Either ClientError PubKeyHash)
-getPubKeyHashFromWallet walletId = let
-    -- This endpoint is not exposed directly by the WBE, I took this helper from the plutus-pab code.
-    getWalletKey :: WBE.ApiT WBE.WalletId -> WBE.ApiT WBE.Role -> WBE.ApiT WBE.DerivationIndex -> Maybe Bool -> ClientM WBE.ApiVerificationKeyShelley
-    getWalletKey :<|> _ :<|> _ :<|> _ = client (Proxy @("v2" :> WalletKeys))
-
-    makeRequest = callWBE $
-       getWalletKey
-        (WBE.ApiT walletId)
-        -- Role: External, to receive funds
-        (WBE.ApiT WBE.UtxoExternal)
-        -- DerivationIndex: first address
-        (WBE.ApiT (WBE.DerivationIndex 0))
-        -- Return hashed version
-        (Just True)
-
-    transformResponse = (fmap . fmap) (PubKeyHash . BuiltinByteString . fst . getApiVerificationKey)
-  in
-    transformResponse makeRequest
-
-createOrRestoreWallet ::
-    MonadIO m =>
-    MonadReader Env m =>
-    RestorePostData ->
-    WBE.ApiMnemonicT '[15, 18, 21, 24] ->
-    m (Either ClientError WBE.WalletId)
-createOrRestoreWallet postData mnemonic = do
-    let
-        passphrase = Text.unpack $ getPassphrase postData
-        walletName = getWalletName postData
-
-        walletPostData = WBE.WalletOrAccountPostData $ Left $ WBE.WalletPostData
-            Nothing
-            mnemonic
-            Nothing
-            (WBE.ApiT $ WBE.WalletName walletName)
-            (WBE.ApiT $ Passphrase $ fromString passphrase )
-
-    result <- callWBE $ WBE.Api.postWallet WBE.Api.walletClient walletPostData
-    case result of
-        Left err@(FailureResponse _ r) -> do
-            let
-                matchDuplicateWallet :: Regex
-                matchDuplicateWallet = Regex.mkRegex "wallet with the following id: ([a-z0-9]{40})"
-
-                mWalletIdFromErr :: Maybe WBE.WalletId
-                mWalletIdFromErr = do
-                    msg <- decodeError $ responseBody r
-                    matches <- Regex.matchRegex matchDuplicateWallet $ Text.unpack msg
-                    walletIdStr <- headMay matches
-                    rightToMaybe $ fromText $ Text.pack walletIdStr
-            case mWalletIdFromErr of
-                Just walletId -> pure $ Right walletId
-                Nothing       ->  do
-                    putStrLn ("restoreWallet failed" :: Text)
-                    putStrLn $ "Error: " <> (show err :: Text)
-                    pure $ Left err
-        Left err -> do
-            -- FIXME: Define a better logging mechanism
-            putStrLn ("restoreWallet failed" :: Text)
-            putStrLn $ "Error: " <> (show err :: Text)
-            pure $ Left err
-        Right (WBE.ApiWallet (WBE.ApiT walletId) _ _ _ _ _ _ _ _) -> do
-            putStrLn $ "Restored wallet: " <> (show walletId :: Text)
-            pure $ Right walletId
-
--- NOTE: This was copied from Cardano-wallet/Cardano.Cli
-decodeError
-    :: BL.ByteString
-    -> Maybe Text
-decodeError bytes = do
-    obj <- Aeson.decode bytes
-    Aeson.parseMaybe (Aeson.withObject "Error" (.: "message")) obj
 
 data WBEConfig = WBEConfig { _wbeHost :: String, _wbePort :: Int }
     deriving stock (Eq, Generic, Show)

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Server.hs
@@ -12,24 +12,23 @@ module Marlowe.Run.Webserver.Server
  )
  where
 
-import           Cardano.Prelude                                        hiding (Handler)
-import           Marlowe.Run.Webserver.API                              (API)
-import           Prelude                                                (userError)
+import           Cardano.Prelude                     hiding (Handler)
+import           Marlowe.Run.Webserver.API           (API)
+import           Prelude                             (userError)
 
 
-import           Data.Aeson                                             as Aeson
+import           Data.Aeson                          as Aeson
 
 
-import           Data.String                                            as S
-import qualified Data.Text                                              as Text
-import           Data.Version                                           (showVersion)
-import           Marlowe.Run.Webserver.Types                            (Env)
-import qualified Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server as Wallet
-import qualified Marlowe.Run.Webserver.WebSocket                        as WS
-import qualified Paths_marlowe_dashboard_server                         as Package.Paths
-import           Servant                                                (Handler (Handler), Server, ServerError,
-                                                                         hoistServer, serveDirectoryFileServer,
-                                                                         (:<|>) ((:<|>)))
+import           Data.String                         as S
+import qualified Data.Text                           as Text
+import           Data.Version                        (showVersion)
+import           Marlowe.Run.Webserver.Types         (Env)
+import qualified Marlowe.Run.Webserver.Wallet.Server as Wallet
+import qualified Marlowe.Run.Webserver.WebSocket     as WS
+import qualified Paths_marlowe_dashboard_server      as Package.Paths
+import           Servant                             (Handler (Handler), Server, ServerError, hoistServer,
+                                                      serveDirectoryFileServer, (:<|>) ((:<|>)))
 
 handlers :: FilePath -> Env -> Server API
 handlers staticPath env =

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Types.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Types.hs
@@ -1,30 +1,7 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingStrategies #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Marlowe.Run.Webserver.Types where
 
-import           Cardano.Prelude
-import           Data.Aeson.Types (FromJSON, ToJSON)
-import           Servant.Client   (ClientEnv)
-
-
-data RestorePostData =
-    RestorePostData
-        { getMnemonicPhrase :: [Text]
-        , getPassphrase     :: Text
-        , getWalletName     :: Text
-        }
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
-
-data RestoreError =
-    InvalidMnemonic
-    | RestoreWalletError
-    | FetchPubKeyHashError
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (ToJSON)
+import           Servant.Client (ClientEnv)
 
 type Env = ClientEnv

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/API.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/API.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Marlowe.Run.Webserver.Wallet.API where
+
+import qualified Marlowe.Run.Webserver.Wallet.CentralizedTestnet.API as CentralizedTestnet
+import           Servant.API                                         ((:>))
+
+type API = "centralized-testnet" :>
+        CentralizedTestnet.API
+

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/API.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/API.hs
@@ -4,9 +4,9 @@
 module Marlowe.Run.Webserver.Wallet.API where
 
 import qualified Marlowe.Run.Webserver.Wallet.CentralizedTestnet.API as CentralizedTestnet
+import           Marlowe.Run.Webserver.Wallet.Types                  (GetTotalFunds)
 import           Servant.API                                         (Capture, Get, JSON, (:<|>), (:>))
 -- FIXME: I don't like to use a Emulator type here, but we'd need to publish some changes upstream to the PAB to fix this
-import           Marlowe.Run.Webserver.Wallet.Types                  (GetTotalFunds)
 import           Wallet.Emulator                                     (WalletId)
 
 

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/API.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/API.hs
@@ -4,8 +4,14 @@
 module Marlowe.Run.Webserver.Wallet.API where
 
 import qualified Marlowe.Run.Webserver.Wallet.CentralizedTestnet.API as CentralizedTestnet
-import           Servant.API                                         ((:>))
+import           Servant.API                                         (Capture, Get, JSON, (:<|>), (:>))
+-- FIXME: I don't like to use a Emulator type here, but we'd need to publish some changes upstream to the PAB to fix this
+import           Marlowe.Run.Webserver.Wallet.Types                  (GetTotalFunds)
+import           Wallet.Emulator                                     (WalletId)
 
-type API = "centralized-testnet" :>
-        CentralizedTestnet.API
+
+
+type API =
+    (Capture "wallet-id" WalletId :> "get-total-funds" :> Get '[JSON] GetTotalFunds)
+    :<|> ("centralized-testnet" :> CentralizedTestnet.API)
 

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/API.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/API.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | This module holds the API to access the centralized testnet
+module Marlowe.Run.Webserver.Wallet.CentralizedTestnet.API where
+
+import           Cardano.Prelude
+import           Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types (RestoreError, RestorePostData)
+import           Servant.API                                           (JSON, Post, ReqBody, (:>))
+-- FIXME: I don't like to use a Mock type here, but we'd need to publish some changes upstream to the PAB to fix this
+import           Cardano.Wallet.Mock.Types                             (WalletInfo)
+
+type API =
+        ("restore" :> ReqBody '[ JSON] RestorePostData :> Post '[JSON] (Either RestoreError WalletInfo)
+        )
+

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeOperators         #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server
@@ -138,6 +140,6 @@ createOrRestoreWallet postData mnemonic = do
             putStrLn ("restoreWallet failed" :: Text)
             putStrLn $ "Error: " <> (show err :: Text)
             pure $ Left err
-        Right (WBE.ApiWallet (WBE.ApiT walletId) _ _ _ _ _ _ _ _) -> do
+        Right WBE.ApiWallet{WBE.id = WBE.ApiT walletId} -> do
             putStrLn $ "Restored wallet: " <> (show walletId :: Text)
             pure $ Right walletId

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeOperators     #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server
+ ( handlers
+ )
+ where
+
+import           Cardano.Mnemonic                                      (mkSomeMnemonic)
+import           Cardano.Prelude                                       hiding (Handler)
+import qualified Cardano.Wallet.Api.Client                             as WBE.Api
+import           Cardano.Wallet.Api.Types                              (ApiVerificationKeyShelley (..))
+import qualified Cardano.Wallet.Api.Types                              as WBE
+import           Marlowe.Run.Webserver.Wallet.CentralizedTestnet.API   (API)
+
+import           Cardano.Wallet.Api                                    (WalletKeys)
+import           Cardano.Wallet.Mock.Types                             (WalletInfo (..))
+import qualified Cardano.Wallet.Primitive.AddressDerivation            as WBE
+import qualified Cardano.Wallet.Primitive.Types                        as WBE
+
+
+import           Cardano.Wallet.Primitive.AddressDerivation            (Passphrase (Passphrase))
+
+import           Data.String                                           as S
+import qualified Data.Text                                             as Text
+import           Data.Text.Class                                       (FromText (..))
+import           Ledger                                                (PubKeyHash (..))
+import           Marlowe.Run.Webserver.Types                           (Env)
+import           Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types (RestoreError (..), RestorePostData (..))
+import           Marlowe.Run.Webserver.Wallet.Client                   (callWBE, decodeError)
+import           PlutusTx.Builtins.Internal                            (BuiltinByteString (..))
+import           Servant                                               (ServerT, (:<|>) ((:<|>)), (:>))
+import           Servant.Client                                        (ClientError (FailureResponse), ClientM,
+                                                                        ResponseF (responseBody), client)
+import           Text.Regex                                            (Regex)
+import qualified Text.Regex                                            as Regex
+import qualified Wallet.Emulator.Wallet                                as Pab.Wallet
+
+handlers ::
+    MonadIO m =>
+    MonadReader Env m =>
+    ServerT API m
+handlers = restoreWallet
+
+-- [UC-WALLET-TESTNET-2][1] Restore a testnet wallet
+restoreWallet ::
+     MonadIO m =>
+     MonadReader Env m =>
+     RestorePostData ->
+     m (Either RestoreError WalletInfo)
+restoreWallet postData = runExceptT $ do
+    let
+        phrase = getMnemonicPhrase postData
+
+    -- Try to decode the passphrase into a mnemonic or fail with InvalidMnemonic
+    mnemonic <- withExceptT (const InvalidMnemonic)
+        ( ExceptT $
+            pure (WBE.ApiMnemonicT <$> mkSomeMnemonic @'[15, 18, 21, 24] phrase)
+        )
+
+    -- Call the WBE trying to restore the wallet, and take error 409 Conflict as a success
+    walletId <- withExceptT (const RestoreWalletError)
+        (ExceptT $ createOrRestoreWallet postData mnemonic)
+
+    -- Get the pubKeyHash of the first wallet derivation
+    pubKeyHash <- withExceptT (const FetchPubKeyHashError) $
+        ExceptT $ getPubKeyHashFromWallet walletId
+
+    pure $ WalletInfo{wiWallet=Pab.Wallet.Wallet (Pab.Wallet.WalletId walletId), wiPubKeyHash = pubKeyHash }
+
+getPubKeyHashFromWallet ::
+    MonadIO m =>
+    MonadReader Env m =>
+    WBE.WalletId ->
+    m (Either ClientError PubKeyHash)
+getPubKeyHashFromWallet walletId = let
+    -- This endpoint is not exposed directly by the WBE, I took this helper from the plutus-pab code.
+    getWalletKey :: WBE.ApiT WBE.WalletId -> WBE.ApiT WBE.Role -> WBE.ApiT WBE.DerivationIndex -> Maybe Bool -> ClientM WBE.ApiVerificationKeyShelley
+    getWalletKey :<|> _ :<|> _ :<|> _ = client (Proxy @("v2" :> WalletKeys))
+
+    makeRequest = callWBE $
+       getWalletKey
+        (WBE.ApiT walletId)
+        -- Role: External, to receive funds
+        (WBE.ApiT WBE.UtxoExternal)
+        -- DerivationIndex: first address
+        (WBE.ApiT (WBE.DerivationIndex 0))
+        -- Return hashed version
+        (Just True)
+
+    transformResponse = (fmap . fmap) (PubKeyHash . BuiltinByteString . fst . getApiVerificationKey)
+  in
+    transformResponse makeRequest
+
+createOrRestoreWallet ::
+    MonadIO m =>
+    MonadReader Env m =>
+    RestorePostData ->
+    WBE.ApiMnemonicT '[15, 18, 21, 24] ->
+    m (Either ClientError WBE.WalletId)
+createOrRestoreWallet postData mnemonic = do
+    let
+        passphrase = Text.unpack $ getPassphrase postData
+        walletName = getWalletName postData
+
+        walletPostData = WBE.WalletOrAccountPostData $ Left $ WBE.WalletPostData
+            Nothing
+            mnemonic
+            Nothing
+            (WBE.ApiT $ WBE.WalletName walletName)
+            (WBE.ApiT $ Passphrase $ fromString passphrase )
+
+    result <- callWBE $ WBE.Api.postWallet WBE.Api.walletClient walletPostData
+    case result of
+        Left err@(FailureResponse _ r) -> do
+            let
+                matchDuplicateWallet :: Regex
+                matchDuplicateWallet = Regex.mkRegex "wallet with the following id: ([a-z0-9]{40})"
+
+                mWalletIdFromErr :: Maybe WBE.WalletId
+                mWalletIdFromErr = do
+                    msg <- decodeError $ responseBody r
+                    matches <- Regex.matchRegex matchDuplicateWallet $ Text.unpack msg
+                    walletIdStr <- headMay matches
+                    rightToMaybe $ fromText $ Text.pack walletIdStr
+            case mWalletIdFromErr of
+                Just walletId -> pure $ Right walletId
+                Nothing       ->  do
+                    putStrLn ("restoreWallet failed" :: Text)
+                    putStrLn $ "Error: " <> (show err :: Text)
+                    pure $ Left err
+        Left err -> do
+            -- FIXME: Define a better logging mechanism
+            putStrLn ("restoreWallet failed" :: Text)
+            putStrLn $ "Error: " <> (show err :: Text)
+            pure $ Left err
+        Right (WBE.ApiWallet (WBE.ApiT walletId) _ _ _ _ _ _ _ _) -> do
+            putStrLn $ "Restored wallet: " <> (show walletId :: Text)
+            pure $ Right walletId

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Types.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types where

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Types.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Types.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Types where
+
+import           Cardano.Prelude
+import           Data.Aeson.Types (FromJSON, ToJSON)
+
+
+data RestorePostData =
+    RestorePostData
+        { getMnemonicPhrase :: [Text]
+        , getPassphrase     :: Text
+        , getWalletName     :: Text
+        }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+data RestoreError =
+    InvalidMnemonic
+    | RestoreWalletError
+    | FetchPubKeyHashError
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (ToJSON)
+

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Client.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Client.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Marlowe.Run.Webserver.Wallet.Client
+ ( callWBE
+ , decodeError
+ )
+ where
+
+import           Cardano.Prelude             hiding (Handler)
+
+
+import           Data.Aeson                  as Aeson
+import qualified Data.Aeson.Types            as Aeson
+
+import qualified Data.ByteString.Lazy        as BL
+
+import           Marlowe.Run.Webserver.Types (Env)
+import           Servant.Client              (ClientError, ClientM, runClientM)
+
+callWBE :: MonadIO m => MonadReader Env m => ClientM a -> m (Either ClientError a)
+callWBE client = do
+    clientEnv <- ask
+    liftIO $ runClientM client clientEnv
+
+-- NOTE: This was copied from Cardano-wallet/Cardano.Cli
+decodeError
+    :: BL.ByteString
+    -> Maybe Text
+decodeError bytes = do
+    obj <- Aeson.decode bytes
+    Aeson.parseMaybe (Aeson.withObject "Error" (.: "message")) obj

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Server.hs
@@ -26,10 +26,15 @@ import           Servant                                                (ServerT
 import           Wallet.Emulator                                        (WalletId (..))
 
 import           Cardano.Wallet.Primitive.SyncProgress                  (SyncProgress (..))
+import           Cardano.Wallet.Primitive.Types.Hash                    (getHash)
+import           Cardano.Wallet.Primitive.Types.TokenMap                (AssetId (..), TokenMap, toFlatList)
+import           Cardano.Wallet.Primitive.Types.TokenPolicy             (unTokenName, unTokenPolicyId)
+import           Cardano.Wallet.Primitive.Types.TokenQuantity           (TokenQuantity (..))
 import           Data.Quantity                                          (getPercentage, getQuantity)
 import           GHC.Natural                                            (naturalToInteger)
 import           Marlowe.Run.Webserver.Wallet.Client                    (callWBE)
-
+import qualified Plutus.V1.Ledger.Ada                                   as Ledger
+import qualified Plutus.V1.Ledger.Value                                 as Ledger
 
 handlers ::
     MonadIO m =>
@@ -37,22 +42,43 @@ handlers ::
     ServerT API m
 handlers = getTotalFunds :<|> CentralizedTestnet.handlers
 
+-- The Wallet BackEnd uses TokenMap while Marlowe Run uses the Ledger MultiAsset Value
+wbeTokenMapToLedgerValue ::
+    TokenMap -> Ledger.Value
+wbeTokenMapToLedgerValue tokenMap =
+    let
+        convertTokenName = Ledger.tokenName . unTokenName
+        convertCurrencySymbol = Ledger.currencySymbol . getHash . unTokenPolicyId
+    in
+        mconcat $ fmap
+            (\(AssetId wbePolicyId wbeTokenName, TokenQuantity quantity) ->
+                Ledger.singleton
+                    (convertCurrencySymbol wbePolicyId)
+                    (convertTokenName wbeTokenName)
+                    (naturalToInteger quantity)
+            )
+            (toFlatList tokenMap)
+
 getTotalFunds ::
     MonadIO m =>
     MonadReader Env m =>
     WalletId ->
     m GetTotalFunds
 getTotalFunds (WalletId walletId) = do
-
     result <- callWBE $ WBE.Api.getWallet WBE.Api.walletClient (WBE.ApiT walletId)
     case result of
-        Left err -> pure $ GetTotalFunds 0 0
-        Right WBE.ApiWallet{WBE.id = WBE.ApiT walletId, WBE.balance = balance, WBE.state = WBE.ApiT state} ->
+        Left err -> pure $ GetTotalFunds mempty 0
+        Right WBE.ApiWallet{WBE.id = WBE.ApiT walletId, WBE.balance = balance, WBE.state = WBE.ApiT state, WBE.assets = assets} ->
             let
-                totalBalance = naturalToInteger $ getQuantity $ WBE.total (balance :: WBE.ApiWalletBalance)
+                WBE.ApiT tokenMap = WBE.total (assets :: WBE.ApiWalletAssetsBalance)
+
+                assetsAsValues = wbeTokenMapToLedgerValue tokenMap
+
+                adaValue = Ledger.lovelaceValueOf $ naturalToInteger $ getQuantity $ WBE.total (balance :: WBE.ApiWalletBalance)
+
                 syncStatus = case state of
                     Ready     -> 1
                     Syncing q -> fromRational $ getPercentage $ getQuantity q
                     _         -> 0
             in
-                pure $ GetTotalFunds totalBalance syncStatus
+                pure $ GetTotalFunds (adaValue <> assetsAsValues) syncStatus

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Server.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Marlowe.Run.Webserver.Wallet.Server
@@ -23,7 +22,6 @@ import           Marlowe.Run.Webserver.Wallet.API                       (API)
 import qualified Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server as CentralizedTestnet
 import           Marlowe.Run.Webserver.Wallet.Types                     (GetTotalFunds (..))
 import           Servant                                                (ServerT, (:<|>) ((:<|>)))
--- import Cardano.Wallet.Primitive.Types (WalletId)
 -- FIXME: I don't like to use a Emulator type here, but we'd need to publish some changes upstream to the PAB to fix this
 import           Wallet.Emulator                                        (WalletId (..))
 

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Server.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Server.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Marlowe.Run.Webserver.Wallet.Server
+ ( handlers
+ )
+ where
+
+import           Cardano.Prelude                                        hiding (Handler)
+
+
+import qualified Cardano.Wallet.Api.Client                              as WBE.Api
+import qualified Cardano.Wallet.Api.Types                               as WBE
+import           Marlowe.Run.Webserver.Types                            (Env)
+import           Marlowe.Run.Webserver.Wallet.API                       (API)
+import qualified Marlowe.Run.Webserver.Wallet.CentralizedTestnet.Server as CentralizedTestnet
+import           Marlowe.Run.Webserver.Wallet.Types                     (GetTotalFunds (..))
+import           Servant                                                (ServerT, (:<|>) ((:<|>)))
+-- import Cardano.Wallet.Primitive.Types (WalletId)
+-- FIXME: I don't like to use a Emulator type here, but we'd need to publish some changes upstream to the PAB to fix this
+import           Wallet.Emulator                                        (WalletId (..))
+
+import           Cardano.Wallet.Primitive.SyncProgress                  (SyncProgress (..))
+import           Data.Quantity                                          (getPercentage, getQuantity)
+import           GHC.Natural                                            (naturalToInteger)
+import           Marlowe.Run.Webserver.Wallet.Client                    (callWBE)
+
+
+handlers ::
+    MonadIO m =>
+    MonadReader Env m =>
+    ServerT API m
+handlers = getTotalFunds :<|> CentralizedTestnet.handlers
+
+getTotalFunds ::
+    MonadIO m =>
+    MonadReader Env m =>
+    WalletId ->
+    m GetTotalFunds
+getTotalFunds (WalletId walletId) = do
+
+    result <- callWBE $ WBE.Api.getWallet WBE.Api.walletClient (WBE.ApiT walletId)
+    case result of
+        Left err -> pure $ GetTotalFunds 0 0
+        Right WBE.ApiWallet{WBE.id = WBE.ApiT walletId, WBE.balance = balance, WBE.state = WBE.ApiT state} ->
+            let
+                totalBalance = naturalToInteger $ getQuantity $ WBE.total (balance :: WBE.ApiWalletBalance)
+                syncStatus = case state of
+                    Ready     -> 1
+                    Syncing q -> fromRational $ getPercentage $ getQuantity q
+                    _         -> 0
+            in
+                pure $ GetTotalFunds totalBalance syncStatus

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Types.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Types.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Marlowe.Run.Webserver.Wallet.Types where
+
+import           Cardano.Prelude
+import           Data.Aeson.Types (ToJSON)
+
+data GetTotalFunds =
+    GetTotalFunds
+        { balance :: Integer
+        , sync    :: Double
+        }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (ToJSON)
+

--- a/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Types.hs
+++ b/marlowe-dashboard-server/src/Marlowe/Run/Webserver/Wallet/Types.hs
@@ -7,12 +7,12 @@
 module Marlowe.Run.Webserver.Wallet.Types where
 
 import           Cardano.Prelude
-import           Data.Aeson.Types (ToJSON)
-
+import           Data.Aeson.Types       (ToJSON)
+import           Plutus.V1.Ledger.Value (Value)
 data GetTotalFunds =
     GetTotalFunds
-        { balance :: Integer
-        , sync    :: Double
+        { assets :: Value
+        , sync   :: Double
         }
     deriving stock (Eq, Generic, Show)
     deriving anyclass (ToJSON)

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-dashboard-server.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-dashboard-server.nix
@@ -64,10 +64,17 @@
         buildable = true;
         modules = [
           "Paths_marlowe_dashboard_server"
+          "Marlowe/Run/Webserver/Wallet/API"
+          "Marlowe/Run/Webserver/Wallet/Server"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/API"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server"
           "Marlowe/Run/Webserver/Server"
           "Marlowe/Run/Webserver/API"
           "Marlowe/Run/Webserver/WebSocket"
           "Marlowe/Run/Webserver/Types"
+          "Marlowe/Run/Webserver/Wallet/Types"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Types"
+          "Marlowe/Run/Webserver/Wallet/Client"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-dashboard-server.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-dashboard-server.nix
@@ -45,6 +45,7 @@
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
           (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
           (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
           (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-dashboard-server.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-dashboard-server.nix
@@ -64,10 +64,17 @@
         buildable = true;
         modules = [
           "Paths_marlowe_dashboard_server"
+          "Marlowe/Run/Webserver/Wallet/API"
+          "Marlowe/Run/Webserver/Wallet/Server"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/API"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server"
           "Marlowe/Run/Webserver/Server"
           "Marlowe/Run/Webserver/API"
           "Marlowe/Run/Webserver/WebSocket"
           "Marlowe/Run/Webserver/Types"
+          "Marlowe/Run/Webserver/Wallet/Types"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Types"
+          "Marlowe/Run/Webserver/Wallet/Client"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-dashboard-server.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-dashboard-server.nix
@@ -45,6 +45,7 @@
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
           (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
           (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
           (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-dashboard-server.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-dashboard-server.nix
@@ -64,10 +64,17 @@
         buildable = true;
         modules = [
           "Paths_marlowe_dashboard_server"
+          "Marlowe/Run/Webserver/Wallet/API"
+          "Marlowe/Run/Webserver/Wallet/Server"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/API"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Server"
           "Marlowe/Run/Webserver/Server"
           "Marlowe/Run/Webserver/API"
           "Marlowe/Run/Webserver/WebSocket"
           "Marlowe/Run/Webserver/Types"
+          "Marlowe/Run/Webserver/Wallet/Types"
+          "Marlowe/Run/Webserver/Wallet/CentralizedTestnet/Types"
+          "Marlowe/Run/Webserver/Wallet/Client"
           ];
         hsSourceDirs = [ "src" ];
         };

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-dashboard-server.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-dashboard-server.nix
@@ -45,6 +45,7 @@
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."playground-common" or (errorHandler.buildDepError "playground-common"))
           (hsPkgs."plutus-ledger" or (errorHandler.buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
           (hsPkgs."plutus-pab" or (errorHandler.buildDepError "plutus-pab"))
           (hsPkgs."plutus-contract" or (errorHandler.buildDepError "plutus-contract"))


### PR DESCRIPTION
This PR refactors the current backend to modularize endpoints.
It also adds a new endpoint for get the total funds from the WBE.

Note that the `restoreWallet` is placed under a `CentralizedTestnet` module, indicating that this endpoint is only useful in that architecture, but the getTotalFunds is placed in plain Wallet, as its going to be useful for this architecture and also the full node one.

The previous `restoreWallet` endpoint is now under
```
POST /api/wallet/centralized-testnet/restore
  {  "getMnemonicPhrase" : ["word1", "word2", "...", "word24"]
  ,  "getPassphrase": "something"
  , "getWalletName": "my-wallet"
  }
```
The new `getTotalFunds is under

```
GET /api/wallet/<wallet-id>/get-total-funds
```

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
