### PR TITLE
Drop unnecessary Proxy from Marlowe.Hole constructor

### DIFF
--- a/marlowe-playground-client/src/Component/Blockly/State.purs
+++ b/marlowe-playground-client/src/Component/Blockly/State.purs
@@ -71,7 +71,7 @@ handleQuery (SetCode code next) = do
     let
       contract =
         either
-          (const $ Hole blocklyState.rootBlockName Proxy NoLocation)
+          (const $ Hole blocklyState.rootBlockName NoLocation)
           identity
           $ Parser.parseContract (Text.stripParens code)
     -- Create the blocks temporarily disabling the blockly events until they settle

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -31,7 +31,6 @@ import Foreign.Object as Object
 import Marlowe.Holes (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Location(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Timeout(..), Token(..), Value(..), ValueId(..))
 import Prologue (class Bounded, class Eq, class Ord, class Show, Either, Maybe(..), Tuple(..), Unit, bind, bottom, discard, map, pure, show, unit, ($), (<#>), (<$>), (<<<), (<>), (=<<), (==), (>>=))
 import Record (merge)
-import Type.Proxy (Proxy(..))
 
 rootBlockName :: String
 rootBlockName = "root_contract"
@@ -1243,7 +1242,7 @@ mkTermFromChild childToBlock attr block = case Object.lookup attr block.children
   -- FIXME: Check if I can use something relating to the term type `a` instead of
   --        attr to generate the hole name. That way I could rename the blockly attributes
   --        without problem
-  Nothing -> pure $ Hole attr Proxy (BlockId block.id)
+  Nothing -> pure $ Hole attr (BlockId block.id)
   Just child ->
     catchError
       (blockToTerm =<< childToBlock child)
@@ -1314,7 +1313,7 @@ fieldAsBigInt attr block =
 
 instance blockToTermContract :: BlockToTerm Contract where
   blockToTerm { type: "BaseContractType", children, id } = case Object.lookup "BaseContractType" children of
-    Nothing -> pure $ Hole "contract" Proxy (BlockId id)
+    Nothing -> pure $ Hole "contract" (BlockId id)
     Just child -> blockToTerm =<< asSingleStatement child
   blockToTerm { type: "CloseContractType", id } = pure $ Term Close (BlockId id)
   blockToTerm b@({ type: "PayContractType", id }) = do
@@ -1599,7 +1598,7 @@ nextBound :: NewBlockFunction -> Workspace -> Connection -> Array (Term Bound) -
 nextBound newBlock workspace fromConnection bounds = do
   case uncons bounds of
     Nothing -> pure unit
-    Just { head: (Hole _ _ _) } -> pure unit
+    Just { head: (Hole _ _) } -> pure unit
     Just { head: (Term (Bound from to) _), tail } -> do
       block <- newBlock workspace (show BoundsType)
       setField block "from" (BigInt.toString from)
@@ -1615,7 +1614,7 @@ instance toBlocklyBounds :: ToBlockly (Array (Term Bound)) where
   toBlockly newBlock workspace input bounds = do
     case uncons bounds of
       Nothing -> pure unit
-      Just { head: (Hole _ _ _) } -> pure unit
+      Just { head: (Hole _ _) } -> pure unit
       Just { head: (Term (Bound from to) _), tail } -> do
         block <- newBlock workspace (show BoundsType)
         setField block "from" (BigInt.toString from)
@@ -1660,7 +1659,7 @@ nextCase :: NewBlockFunction -> Workspace -> Connection -> Array (Term Case) -> 
 nextCase newBlock workspace fromConnection cases = do
   case uncons cases of
     Nothing -> pure unit
-    Just { head: (Hole _ _ _) } -> pure unit
+    Just { head: (Hole _ _) } -> pure unit
     Just { head: (Term (Case action contract) _), tail } -> do
       block <- oneCaseToBlockly newBlock workspace (Case action contract)
       let
@@ -1674,7 +1673,7 @@ instance toBlocklyCases :: ToBlockly (Array (Term Case)) where
   toBlockly newBlock workspace input cases = do
     case uncons cases of
       Nothing -> pure unit
-      Just { head: (Hole _ _ _) } -> pure unit
+      Just { head: (Hole _ _) } -> pure unit
       Just { head: (Term (Case action contract) _), tail } -> do
         block <- oneCaseToBlockly newBlock workspace (Case action contract)
         connectToPrevious block input

--- a/marlowe-playground-client/src/Marlowe/Gen.purs
+++ b/marlowe-playground-client/src/Marlowe/Gen.purs
@@ -21,7 +21,6 @@ import Marlowe.Holes (Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..
 import Marlowe.Holes as H
 import Marlowe.Semantics (CurrencySymbol, Input(..), PubKey, Rational(..), Slot(..), SlotInterval(..), TokenName, TransactionInput(..), TransactionWarning(..))
 import Marlowe.Semantics as S
-import Type.Proxy (Proxy(..))
 
 newtype GenerationOptions
   = GenerationOptions { withHoles :: Boolean, withExtendedConstructs :: Boolean }
@@ -129,9 +128,8 @@ genRange = do
 genHole :: forall m a. MonadGen m => MonadRec m => String -> m (Term a)
 genHole name = do
   -- name <- suchThat genString (\s -> s /= "")
-  proxy <- pure (Proxy :: Proxy a)
   range <- genRange
-  pure $ Hole name proxy range
+  pure $ Hole name range
 
 genTerm :: forall m a. MonadGen m => MonadRec m => MonadReader GenerationOptions m => String -> m a -> m (Term a)
 genTerm name g = do

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -455,7 +455,7 @@ lintContract env (Term (Let (TermWrapper valueId pos) value cont) _) = do
   newEnv <- stepPrefixMapEnv_ tmpEnv LetPath
   lintContract newEnv cont
 
-lintContract _ hole@(Hole _ _ _) = do
+lintContract _ hole@(Hole _ _) = do
   modifying _holes (insertHole hole)
   pure unit
 
@@ -557,7 +557,7 @@ lintObservation _ (Term TrueObs pos) = pure (ConstantSimp pos false true)
 
 lintObservation _ (Term FalseObs pos) = pure (ConstantSimp pos false false)
 
-lintObservation _ hole@(Hole _ _ pos) = do
+lintObservation _ hole@(Hole _ pos) = do
   modifying _holes (insertHole hole)
   pure (ValueSimp pos false hole)
 
@@ -674,7 +674,7 @@ lintValue env t@(Term (UseValue (TermWrapper valueId _)) pos) = do
     (addWarning UndefinedUse pos)
   pure (ValueSimp pos false t)
 
-lintValue _ hole@(Hole _ _ pos) = do
+lintValue _ hole@(Hole _ pos) = do
   modifying _holes (insertHole hole)
   pure (ValueSimp pos false hole)
 
@@ -715,12 +715,12 @@ lintCase iniEnv n (Term (Case action contract) pos) = do
   lintContract newEnv contract
   pure unit
 
-lintCase _ _ hole@(Hole _ _ _) = do
+lintCase _ _ hole@(Hole _ _) = do
   modifying _holes (insertHole hole)
   pure unit
 
 lintBounds :: Boolean -> Term Bound -> CMS.State State Boolean
-lintBounds _ (Hole _ _ _) = do
+lintBounds _ (Hole _ _) = do
   pure false
 
 lintBounds restAreInvalid (Term (Bound l h) pos) = do
@@ -782,7 +782,7 @@ lintAction env (Term (Notify obs) pos) = do
       pure isReachable
   pure $ NoEffect /\ newIsReachable
 
-lintAction env hole@(Hole _ _ _) = do
+lintAction env hole@(Hole _ _) = do
   let
     isReachable = view _isReachable env
   modifying _holes (insertHole hole)


### PR DESCRIPTION
The `Proxy a` in `Hole a` carries no information as `a` type is already in the `Hole` type itself. I've simplified the implementation and provided the `Proxy a` in a place where it is required based on the `a` parameter from the `Hole a` type.

This work was done alongside SCP-3164 which works with `Marlowe.Holes`.