### PR TITLE
SCP-3195 - Re implement get total funds through WBE (part 2 frontend)

### DIFF
--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -89,24 +89,16 @@ instance manageMarloweAppM :: ManageMarlowe AppM where
         -- create the WalletCompanion and MarloweApp for this wallet
         ajaxCompanionAppId <- Contract.activateContract WalletCompanion walletId
         ajaxMarloweAppId <- Contract.activateContract MarloweApp walletId
-        -- get the wallet's current funds
-        -- Note that, because it can take a moment for the initial demo funds to be added, at
-        -- this point the funds might be zero. It doesn't matter though - if we connect this
-        -- wallet, we'll get a WebSocket notification when the funds are added (and if we don't
-        -- connect it, we don't need to know what they are.)
-        -- TODO(?): Because of that, we could potentially forget about this call and just set
-        -- assets to `mempty`.
-        ajaxAssets <- Wallet.getWalletTotalFunds walletId
         let
-          createWalletDetails companionAppId marloweAppId assets =
+          createWalletDetails companionAppId marloweAppId =
             { walletNickname: ""
             , companionAppId
             , marloweAppId
             , walletInfo
-            , assets
+            , assets: mempty
             , previousCompanionAppState: Nothing
             }
-        pure $ createWalletDetails <$> ajaxCompanionAppId <*> ajaxMarloweAppId <*> ajaxAssets
+        pure $ createWalletDetails <$> ajaxCompanionAppId <*> ajaxMarloweAppId
   restoreWallet options = do
     mWalletInfo <- Wallet.restoreWallet options
     case mWalletInfo of

--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -205,7 +205,6 @@ instance manageMarloweAppM :: ManageMarlowe AppM where
             wallet = toFront $ view _cicWallet clientState
           walletContracts <- withExceptT Just $ ExceptT $ Contract.getWalletContractInstances wallet
           walletInfo <- withExceptT Just $ ExceptT $ Wallet.getWalletInfo wallet
-          assets <- withExceptT Just $ ExceptT $ Wallet.getWalletTotalFunds wallet
           case find (\state -> view _cicDefinition state == MarloweApp) walletContracts of
             Just marloweApp ->
               pure
@@ -213,7 +212,7 @@ instance manageMarloweAppM :: ManageMarlowe AppM where
                 , companionAppId
                 , marloweAppId: toFront $ view _cicContract marloweApp
                 , walletInfo
-                , assets
+                , assets: mempty
                 , previousCompanionAppState: Nothing
                 }
             Nothing -> except $ Left Nothing

--- a/marlowe-dashboard-client/src/Capability/Wallet.purs
+++ b/marlowe-dashboard-client/src/Capability/Wallet.purs
@@ -11,17 +11,17 @@ module Capability.Wallet
 import Prologue
 import API.Marlowe.Run.Wallet.CentralizedTestnet (RestoreError, RestoreWalletOptions)
 import API.Marlowe.Run.Wallet.CentralizedTestnet as TestnetAPI
+import API.Marlowe.Run.Wallet as WBE
 import API.MockWallet as MockAPI
 import AppM (AppM)
 import Bridge (toBack, toFront)
 import Component.Contacts.Types (WalletId, WalletInfo)
 import Control.Monad.Except (lift, runExceptT)
 import Halogen (HalogenM)
-import Marlowe.Semantics (Assets)
+import Marlowe.Run.Webserver.Wallet.Types (GetTotalFunds)
 import Plutus.V1.Ledger.Tx (Tx)
 import Types (AjaxResponse)
 
--- TODO (possibly): make `AppM` a `MonadError` and remove all the `runExceptT`s
 class
   Monad m <= ManageWallet m where
   -- FIXME: Abstract from AjaxResponse
@@ -29,7 +29,7 @@ class
   restoreWallet :: RestoreWalletOptions -> m (Either RestoreError WalletInfo)
   submitWalletTransaction :: WalletId -> Tx -> m (AjaxResponse Unit)
   getWalletInfo :: WalletId -> m (AjaxResponse WalletInfo)
-  getWalletTotalFunds :: WalletId -> m (AjaxResponse Assets)
+  getWalletTotalFunds :: WalletId -> m (AjaxResponse GetTotalFunds)
   signTransaction :: WalletId -> Tx -> m (AjaxResponse Tx)
 
 instance monadWalletAppM :: ManageWallet AppM where
@@ -37,7 +37,7 @@ instance monadWalletAppM :: ManageWallet AppM where
   restoreWallet options = map (map toFront) $ TestnetAPI.restoreWallet options
   submitWalletTransaction wallet tx = runExceptT $ MockAPI.submitWalletTransaction (toBack wallet) tx
   getWalletInfo wallet = map (map toFront) $ runExceptT $ MockAPI.getWalletInfo (toBack wallet)
-  getWalletTotalFunds wallet = map (map toFront) $ runExceptT $ MockAPI.getWalletTotalFunds (toBack wallet)
+  getWalletTotalFunds walletId = runExceptT $ WBE.getTotalFunds walletId
   signTransaction wallet tx = runExceptT $ MockAPI.signTransaction (toBack wallet) tx
 
 instance monadWalletHalogenM :: ManageWallet m => ManageWallet (HalogenM state action slots msg m) where

--- a/marlowe-dashboard-client/src/Component/Contacts/Types.purs
+++ b/marlowe-dashboard-client/src/Component/Contacts/Types.purs
@@ -127,7 +127,6 @@ data Action
   | CancelNewContactForRole
   | WalletNicknameInputAction (InputField.Action WalletNicknameError)
   | WalletIdInputAction (InputField.Action WalletIdError)
-  | SetRemoteWalletInfo (NotFoundWebData WalletInfo)
   | ConnectWallet WalletNickname PlutusAppId
   | ClipboardAction Clipboard.Action
 
@@ -138,6 +137,5 @@ instance actionIsEvent :: IsEvent Action where
   toEvent CancelNewContactForRole = Nothing
   toEvent (WalletNicknameInputAction inputFieldAction) = toEvent inputFieldAction
   toEvent (WalletIdInputAction inputFieldAction) = toEvent inputFieldAction
-  toEvent (SetRemoteWalletInfo _) = Nothing
   toEvent (ConnectWallet _ _) = Just $ defaultEvent "ConnectWallet"
   toEvent (ClipboardAction _) = Just $ defaultEvent "ClipboardAction"

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -43,8 +43,8 @@ import WebSocket.Support as WS
 {-
 The Marlowe Run app consists of six main workflows:
 
-1. Generate a demo wallet (this will become redundant when we integrate with real wallets).
-2. Connect a wallet (this will change when we integrate with real wallets).
+1. UC-WALLET-TESTNET-1 Create a testnet wallet (this only make sense for the centralized testnet site and may become redundant when we integrate with light wallets).
+2. UC-WALLET-TESTNET-2 Restore a testnet wallet (same note as before).
 3. Disconnect a wallet.
 4. Start a contract.
 5. Move a contract forward.
@@ -125,16 +125,6 @@ handleQuery (ReceiveWebSocketMessage msg next) = do
       SlotChange slot -> do
         assign _currentSlot $ toFront slot
         handleAction $ DashboardAction Dashboard.AdvanceTimedoutSteps
-      -- TODO We need to rewrite this to query the funds periodically instead, see https://github.com/input-output-hk/plutus-apps/pull/50
-      -- update the wallet funds (if the change is to the current wallet)
-      -- note: we should only ever be notified of changes to the current wallet, since we subscribe to
-      -- this update when we pick it up, and unsubscribe when we put it down - but we check here
-      -- anyway in case
-      -- WalletFundsChange wallet value -> do
-      --   mCurrentWallet <- peruse (_dashboardState <<< _walletDetails <<< _walletInfo <<< _wallet)
-      --   for_ mCurrentWallet \currentWallet -> do
-      --     when (currentWallet == toFront wallet)
-      --       $ assign (_dashboardState <<< _walletDetails <<< _assets) (toFront value)
       -- update the state when a contract instance changes
       -- note: we should be subscribed to updates from all (and only) the current wallet's contract
       -- instances, including its wallet companion contract

--- a/marlowe-dashboard-client/src/Page/Dashboard/Lenses.purs
+++ b/marlowe-dashboard-client/src/Page/Dashboard/Lenses.purs
@@ -17,15 +17,15 @@ import Prologue
 import Component.Contacts.Types (State) as Contacts
 import Component.Contacts.Types (WalletDetails)
 import Component.Template.Types (State) as Template
-import Page.Dashboard.Types (Card, ContractFilter, State, WalletCompanionStatus)
 import Data.Lens (Lens', Traversal', set, wander)
 import Data.Lens.At (at)
 import Data.Lens.Prism.Maybe (_Just)
 import Data.Lens.Record (prop)
 import Data.Map (Map, insert, lookup)
-import Type.Proxy (Proxy(..))
 import Marlowe.PAB (PlutusAppId)
 import Page.Contract.Types (State) as Contract
+import Page.Dashboard.Types (Card, ContractFilter, State, WalletCompanionStatus)
+import Type.Proxy (Proxy(..))
 
 _contactsState :: Lens' State Contacts.State
 _contactsState = prop (Proxy :: _ "contactsState")

--- a/marlowe-dashboard-client/src/Page/Dashboard/Types.purs
+++ b/marlowe-dashboard-client/src/Page/Dashboard/Types.purs
@@ -11,9 +11,9 @@ import Prologue
 import Analytics (class IsEvent, defaultEvent, toEvent)
 import Clipboard (Action) as Clipboard
 import Component.ConfirmInput.Types as ConfirmInput
-import Component.Template.Types (Action, State) as Template
 import Component.Contacts.Types (Action, State) as Contacts
 import Component.Contacts.Types (WalletDetails, WalletNickname)
+import Component.Template.Types (Action, State) as Template
 import Data.Map (Map)
 import Data.Set (Set)
 import Data.Time.Duration (Minutes)

--- a/marlowe-dashboard-client/src/Page/Welcome/State.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/State.purs
@@ -149,7 +149,6 @@ handleAction RestoreTestnetWallet = do
     Right walletDetails -> do
       tell _submitButtonSlot "restore-wallet" $ SubmitResult (Milliseconds 1200.0) (Right "Wallet restored")
       assign _remoteWalletDetails $ pure walletDetails
-      -- TODO: SCP-3132 Fire logic to sync total funds
       handleAction $ ConnectWallet walletName
 
 -- TODO: We'll most likely won't need the [Workflow 2][X] connect wallet features, but I'll remove them


### PR DESCRIPTION
This is part 2 of [this PR](https://github.com/input-output-hk/marlowe-cardano/pull/37). It gets both the ada value and the custom tokens (including role tokens) from the WalletBackEnd.

There is an important warning under the `Note [polling updateTotalFunds]` which may cause some bugs while the wallet is syncing. I created two issues to solve that SCP-3211 (add global polling to getTotalFunds) and SCP-3212 (Show wallet sync status in the UI) 

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
