### PR TITLE
Strong Domain types for WalletNickname, Address, and AddressBook

### DIFF
--- a/marlowe-dashboard-client/spago.dhall
+++ b/marlowe-dashboard-client/spago.dhall
@@ -50,7 +50,6 @@ You can edit this file as you like.
   , "transformers"
   , "tuples"
   , "unfoldable"
-  , "unicode"
   , "uuid"
   , "validation"
   , "web-common"

--- a/marlowe-dashboard-client/src/Bridge.purs
+++ b/marlowe-dashboard-client/src/Bridge.purs
@@ -150,11 +150,6 @@ instance bridgeAddress :: Bridge Back.PubKeyHash Address where
     fromRight A.empty $ A.fromString mempty getPubKeyHash
   toBack address = Back.PubKeyHash { getPubKeyHash: A.toString address }
 
--- TODO: Marlowe.Semantics.PubKeyHash is currently just an alias for String
-instance pubKeyHashBridge :: Bridge Back.PubKeyHash String where
-  toFront (Back.PubKeyHash { getPubKeyHash }) = getPubKeyHash
-  toBack getPubKeyHash = Back.PubKeyHash { getPubKeyHash }
-
 instance bridgePlutusAppId :: Bridge ContractInstanceId PlutusAppId where
   toFront (ContractInstanceId { unContractInstanceId }) = PlutusAppId
     unContractInstanceId

--- a/marlowe-dashboard-client/src/Bridge.purs
+++ b/marlowe-dashboard-client/src/Bridge.purs
@@ -9,8 +9,11 @@ import Prologue
 
 import Cardano.Wallet.Mock.Types (WalletInfo(..)) as Back
 import Component.Contacts.Types (WalletId(..), WalletInfo(..)) as Front
+import Data.Address (Address)
+import Data.Address as A
 import Data.Bifunctor (bimap)
 import Data.BigInt.Argonaut (BigInt)
+import Data.Either (fromRight)
 import Data.Lens (Iso', iso)
 import Data.Map (Map, fromFoldable, toUnfoldable) as Front
 import Data.Newtype (unwrap)
@@ -141,6 +144,11 @@ instance walletInfoBridge :: Bridge Back.WalletInfo Front.WalletInfo where
 instance walletBridge :: Bridge Back.Wallet Front.WalletId where
   toFront (Back.Wallet { getWalletId }) = Front.WalletId getWalletId
   toBack (Front.WalletId getWalletId) = Back.Wallet { getWalletId }
+
+instance bridgeAddress :: Bridge Back.PubKeyHash Address where
+  toFront (Back.PubKeyHash { getPubKeyHash }) =
+    fromRight A.empty $ A.fromString mempty getPubKeyHash
+  toBack address = Back.PubKeyHash { getPubKeyHash: A.toString address }
 
 -- TODO: Marlowe.Semantics.PubKeyHash is currently just an alias for String
 instance pubKeyHashBridge :: Bridge Back.PubKeyHash String where

--- a/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp.purs
+++ b/marlowe-dashboard-client/src/Capability/PlutusApps/MarloweApp.purs
@@ -32,6 +32,7 @@ import Capability.PlutusApps.MarloweApp.Types
   , LastResult(..)
   )
 import Control.Monad.Reader (class MonadAsk, asks)
+import Data.Address (Address)
 import Data.Argonaut.Core (Json)
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Array (findMap, take, (:))
@@ -52,7 +53,6 @@ import Marlowe.PAB (PlutusAppId)
 import Marlowe.Semantics
   ( Contract
   , MarloweParams
-  , PubKeyHash
   , SlotInterval(..)
   , TokenName
   , TransactionInput(..)
@@ -69,7 +69,7 @@ import Wallet.Types (_EndpointDescription)
 class MarloweApp m where
   createContract
     :: PlutusAppId
-    -> Map TokenName PubKeyHash
+    -> Map TokenName Address
     -> Contract
     -> m (AjaxResponse Unit)
   applyInputs
@@ -80,7 +80,7 @@ class MarloweApp m where
     :: PlutusAppId
     -> MarloweParams
     -> TokenName
-    -> PubKeyHash
+    -> Address
     -> m (AjaxResponse Unit)
 
 instance marloweAppM :: MarloweApp AppM where

--- a/marlowe-dashboard-client/src/Component/Address/Types.purs
+++ b/marlowe-dashboard-client/src/Component/Address/Types.purs
@@ -1,10 +1,9 @@
 module Component.Address.Types (Input) where
 
-import Marlowe.Semantics (PubKeyHash)
+import Data.Address (Address)
 
 type Input =
   { inputId :: String
   , label :: String
-  -- TODO: as part of SCP-3145 we should change this for a BECH32 address
-  , value :: PubKeyHash
+  , value :: Address
   }

--- a/marlowe-dashboard-client/src/Component/Address/View.purs
+++ b/marlowe-dashboard-client/src/Component/Address/View.purs
@@ -3,29 +3,28 @@ module Component.Address.View
   , render
   ) where
 
-import Prologue
-
 import Component.Address.Types (Input)
 import Component.Icons (icon)
 import Component.Icons as Icon
 import Component.Input.View as Input
 import Component.Label.View as Label
+import Data.Address (Address)
+import Data.Address as A
 import Halogen.Css (classNames)
 import Halogen.HTML as HH
 import Halogen.HTML.Events.Extra (onClick_)
-import Marlowe.Semantics (PubKeyHash)
 
-defaultInput :: Input
-defaultInput =
-  { inputId: "walletId"
-  , label: "Wallet ID"
-  , value: mempty
+defaultInput :: Address -> Input
+defaultInput value =
+  { inputId: "address"
+  , label: "Wallet address"
+  , value
   }
 
-render :: forall w. Input -> HH.HTML w PubKeyHash
+render :: forall w. Input -> HH.HTML w Address
 render { inputId, label, value } =
   let
-    inputInput = Input.defaultInput { id = inputId, value = value }
+    inputInput = Input.defaultInput { id = inputId, value = A.toString value }
   in
     Input.renderWithChildren inputInput \input ->
       [ Label.render Label.defaultInput { for = inputId, text = label }

--- a/marlowe-dashboard-client/src/Component/ConfirmInput/Types.purs
+++ b/marlowe-dashboard-client/src/Component/ConfirmInput/Types.purs
@@ -1,16 +1,16 @@
 module Component.ConfirmInput.Types where
 
 import Data.BigInt.Argonaut (BigInt)
+import Data.WalletNickname (WalletNickname)
 import Marlowe.Execution.Types (NamedAction)
 import Marlowe.Semantics (Slot) as Semantics
 import Page.Contract.Types as Contract
 
-type Input
-  =
+type Input =
   { action :: NamedAction
   , contractState :: Contract.StartedState
   , currentSlot :: Semantics.Slot
   , transactionFeeQuote :: BigInt
-  , userNickname :: String
+  , userNickname :: WalletNickname
   , walletBalance :: BigInt
   }

--- a/marlowe-dashboard-client/src/Component/Contacts/Lenses.purs
+++ b/marlowe-dashboard-client/src/Component/Contacts/Lenses.purs
@@ -1,6 +1,5 @@
 module Component.Contacts.Lenses
-  ( _addressBook
-  , _cardSection
+  ( _cardSection
   , _walletNicknameInput
   , _addressInput
   , _walletNickname
@@ -16,27 +15,24 @@ module Component.Contacts.Lenses
 import Prologue
 
 import Component.Contacts.Types
-  ( AddressBook
-  , AddressError
+  ( AddressError
   , CardSection
   , State
   , WalletDetails
   , WalletId
   , WalletInfo
-  , WalletNickname
   , WalletNicknameError
   )
 import Component.InputField.Types (State) as InputField
+import Data.Address (Address)
 import Data.Lens (Lens')
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Map (Map)
+import Data.WalletNickname (WalletNickname)
 import Marlowe.PAB (PlutusAppId)
-import Marlowe.Semantics (Assets, MarloweData, MarloweParams, PubKeyHash)
+import Marlowe.Semantics (Assets, MarloweData, MarloweParams)
 import Type.Proxy (Proxy(..))
-
-_addressBook :: Lens' State AddressBook
-_addressBook = prop (Proxy :: _ "addressBook")
 
 _cardSection :: Lens' State CardSection
 _cardSection = prop (Proxy :: _ "cardSection")
@@ -71,5 +67,5 @@ _previousCompanionAppState = prop (Proxy :: _ "previousCompanionAppState")
 _walletId :: Lens' WalletInfo WalletId
 _walletId = _Newtype <<< prop (Proxy :: _ "walletId")
 
-_pubKeyHash :: Lens' WalletInfo PubKeyHash
+_pubKeyHash :: Lens' WalletInfo Address
 _pubKeyHash = _Newtype <<< prop (Proxy :: _ "pubKeyHash")

--- a/marlowe-dashboard-client/src/Component/Contacts/Types.purs
+++ b/marlowe-dashboard-client/src/Component/Contacts/Types.purs
@@ -1,7 +1,5 @@
 module Component.Contacts.Types
   ( State
-  , AddressBook
-  , WalletNickname
   , WalletDetails
   , WalletInfo(..)
   , WalletId(..)
@@ -18,27 +16,21 @@ import Analytics (class IsEvent, defaultEvent, toEvent)
 import Clipboard (Action) as Clipboard
 import Component.InputField.Types (class InputFieldError)
 import Component.InputField.Types (Action, State) as InputField
+import Data.Address (Address)
 import Data.Argonaut.Decode (class DecodeJson)
 import Data.Argonaut.Encode (class EncodeJson)
 import Data.Generic.Rep (class Generic)
 import Data.Map (Map)
 import Data.Newtype (class Newtype)
+import Data.WalletNickname (WalletNickname)
 import Marlowe.PAB (PlutusAppId)
-import Marlowe.Semantics (Assets, MarloweData, MarloweParams, PubKeyHash)
+import Marlowe.Semantics (Assets, MarloweData, MarloweParams)
 
 type State =
-  { addressBook :: AddressBook
-  , cardSection :: CardSection
+  { cardSection :: CardSection
   , walletNicknameInput :: InputField.State WalletNicknameError
   , addressInput :: InputField.State AddressError
   }
-
--- TODO: The changes to this code take us closer to
---       "SCP-3145 Use addresses instead of WalletId in the UI", but we still need to show
---       an actual BECH32 address instead of a PubKeyHash (which is only a subpart of the address)
-type AddressBook = Map WalletNickname PubKeyHash
-
-type WalletNickname = String
 
 -- TODO: Move this data type away from the Contacts module and possibly rename.
 --       A good location might just be a global Wallet module, and the name
@@ -59,7 +51,7 @@ type WalletDetails =
 -- its "own-public-key"
 newtype WalletInfo = WalletInfo
   { walletId :: WalletId
-  , pubKeyHash :: PubKeyHash
+  , pubKeyHash :: Address
   }
 
 derive instance newtypeWalletInfo :: Newtype WalletInfo _
@@ -88,8 +80,7 @@ derive newtype instance toUrlPieceWalletId :: ToUrlPiece WalletId
 
 data CardSection
   = Home
-  -- TODO: as part of SCP-3145 change PubKeyHash to BECH32 address
-  | ViewWallet WalletNickname PubKeyHash
+  | ViewWallet WalletNickname Address
   | NewWallet (Maybe String)
 
 derive instance eqCardSection :: Eq CardSection

--- a/marlowe-dashboard-client/src/Component/Template/Types.purs
+++ b/marlowe-dashboard-client/src/Component/Template/Types.purs
@@ -12,9 +12,9 @@ module Component.Template.Types
 import Prologue
 
 import Analytics (class IsEvent, defaultEvent, toEvent)
-import Component.Contacts.Types (AddressBook)
 import Component.InputField.Types (class InputFieldError)
 import Component.InputField.Types (Action, State) as InputField
+import Data.AddressBook (AddressBook)
 import Data.Map (Map)
 import Marlowe.Extended.Metadata (ContractTemplate)
 import Marlowe.Semantics (TokenName)

--- a/marlowe-dashboard-client/src/Component/Template/View.purs
+++ b/marlowe-dashboard-client/src/Component/Template/View.purs
@@ -1,8 +1,8 @@
 module Component.Template.View (contractTemplateCard) where
 
 import Prologue hiding (Either(..), div)
+
 import Component.Contacts.State (adaToken, getAda)
-import Component.Contacts.Types (AddressBook)
 import Component.Hint.State (hint)
 import Component.Icons (Icon(..)) as Icon
 import Component.Icons (Icon, icon, icon_)
@@ -30,13 +30,18 @@ import Component.Template.Types
   , State
   , ValueError
   )
+import Component.Tooltip.State (tooltip)
+import Component.Tooltip.Types (ReferenceId(..))
 import Css as Css
+import Data.AddressBook (AddressBook)
+import Data.AddressBook as AB
 import Data.Lens (view)
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Map.Ordered.OMap as OMap
 import Data.Maybe (fromMaybe)
 import Data.Tuple.Nested ((/\))
+import Data.WalletNickname as WN
 import Effect.Aff.Class (class MonadAff)
 import Halogen.Css (classNames)
 import Halogen.HTML
@@ -81,8 +86,6 @@ import Marlowe.PAB (contractCreationFee)
 import Marlowe.Semantics (Assets, TokenName)
 import Marlowe.Template (orderContentUsingMetadata)
 import Text.Markdown.TrimmedInline (markdownToHTML)
-import Component.Tooltip.State (tooltip)
-import Component.Tooltip.Types (ReferenceId(..))
 
 contractTemplateCard
   :: forall m
@@ -554,7 +557,7 @@ roleInputs addressBook metaData roleWalletInputs =
     , placeholder: "Choose any nickname"
     , readOnly: false
     , numberFormat: Nothing
-    , valueOptions: fst <$> Map.toUnfoldable addressBook
+    , valueOptions: WN.toString <<< fst <$> AB.toUnfoldable addressBook
     , after: Nothing
     , before: Nothing
     }

--- a/marlowe-dashboard-client/src/Component/Transfer/Types.purs
+++ b/marlowe-dashboard-client/src/Component/Transfer/Types.purs
@@ -1,7 +1,9 @@
 module Component.Transfer.Types where
 
 import Prologue
+
 import Data.BigInt.Argonaut (BigInt)
+import Data.WalletNickname (WalletNickname)
 import Marlowe.Semantics (AccountId, Party, Token)
 
 -- Here's my justification for why this module should exist:
@@ -17,8 +19,7 @@ import Marlowe.Semantics (AccountId, Party, Token)
 --
 -- Note that all the types are basically the same. The additional data
 -- constructors are purely to make the model more self-documenting
-type Transfer
-  =
+type Transfer =
   { sender :: Participant
   , recipient :: Participant
   , token :: Token
@@ -31,11 +32,7 @@ data Termini
   | AccountToWallet AccountId Party
   | WalletToAccount Party AccountId
 
-type Participant
-  =
-  { nickname :: Maybe String
+type Participant =
+  { nickname :: Maybe WalletNickname
   , isCurrentUser :: Boolean
   }
-
-type Nickname
-  = String

--- a/marlowe-dashboard-client/src/Component/Transfer/View.purs
+++ b/marlowe-dashboard-client/src/Component/Transfer/View.purs
@@ -1,6 +1,7 @@
 module Component.Transfer.View (transfer) where
 
 import Prologue
+
 import Component.Amount (amount)
 import Component.Avatar.Types (Size(..)) as Avatar
 import Component.Avatar.View (avatar)
@@ -14,6 +15,7 @@ import Component.Transfer.Types (Participant, Termini(..), Transfer)
 import Data.Maybe (fromMaybe)
 import Data.String (Pattern(..))
 import Data.String.Extra (capitalize, endsWith)
+import Data.WalletNickname as WN
 import Halogen.Css (classNames)
 import Halogen.HTML (HTML, span, text)
 import Marlowe.Semantics (Party(..))
@@ -40,7 +42,7 @@ account :: forall w i. Party -> Participant -> String -> HTML w i
 account party { nickname, isCurrentUser } accountTypeLabel =
   row Row.Cramped [ "items-center" ]
     [ avatar
-        { nickname: fromMaybe defaultName nickname
+        { nickname: fromMaybe defaultName $ WN.toString <$> nickname
         , background: [ "bg-gradient-to-r", "from-purple", "to-lightpurple" ]
         , size: Avatar.Small
         }

--- a/marlowe-dashboard-client/src/Data/Address.purs
+++ b/marlowe-dashboard-client/src/Data/Address.purs
@@ -1,0 +1,97 @@
+module Data.Address
+  ( Address
+  , AddressError(..)
+  , dual
+  , fromString
+  , toString
+  , validator
+  ) where
+
+import Prologue
+
+import Data.Bounded.Generic (genericBottom, genericTop)
+import Data.Enum (class BoundedEnum, class Enum)
+import Data.Enum.Generic
+  ( genericCardinality
+  , genericFromEnum
+  , genericPred
+  , genericSucc
+  , genericToEnum
+  )
+import Data.Generic.Rep (class Generic)
+import Data.Set (Set)
+import Data.Set as Set
+import Data.Show.Generic (genericShow)
+import Data.String as String
+import Data.Validation.Semigroup (V(..))
+import Polyform (Validator)
+import Polyform.Dual as Dual
+import Polyform.Validator (liftFnV)
+import Polyform.Validator.Dual (Dual)
+
+data AddressError
+  = Empty
+  | Invalid
+  | Exists
+
+derive instance Generic AddressError _
+derive instance Eq AddressError
+derive instance Ord AddressError
+
+instance Semigroup AddressError where
+  append Empty _ = Empty
+  append _ Empty = Empty
+  append Invalid _ = Invalid
+  append _ Invalid = Invalid
+  append Exists Exists = Exists
+
+instance Bounded AddressError where
+  bottom = genericBottom
+  top = genericTop
+
+instance Enum AddressError where
+  succ = genericSucc
+  pred = genericPred
+
+instance BoundedEnum AddressError where
+  cardinality = genericCardinality
+  toEnum = genericToEnum
+  fromEnum = genericFromEnum
+
+instance Show AddressError where
+  show = genericShow
+
+-- TODO use bech-32 addresses (SCP-3145)
+newtype Address = Address String
+
+derive instance Eq Address
+derive instance Ord Address
+derive newtype instance Show Address
+
+fromString :: Set Address -> String -> Either AddressError Address
+fromString used s
+  | String.null s = Left Empty
+  | Set.member (Address s) used = Left Exists
+  | String.length s /= 56 = Right $ Address s
+  | otherwise = Left Invalid
+
+toString :: Address -> String
+toString (Address s) = s
+
+-------------------------------------------------------------------------------
+-- Polyform adapters
+-------------------------------------------------------------------------------
+
+validator
+  :: forall m
+   . Applicative m
+  => Set Address
+  -> Validator m AddressError String Address
+validator used = liftFnV \s -> V $ fromString used s
+
+dual
+  :: forall m
+   . Applicative m
+  => Set Address
+  -> Dual m AddressError String Address
+dual used = Dual.dual (validator used) (pure <<< toString)

--- a/marlowe-dashboard-client/src/Data/Address.purs
+++ b/marlowe-dashboard-client/src/Data/Address.purs
@@ -9,6 +9,7 @@ module Data.Address
 
 import Prologue
 
+import Data.Argonaut (class DecodeJson, class EncodeJson)
 import Data.Bounded.Generic (genericBottom, genericTop)
 import Data.Enum (class BoundedEnum, class Enum)
 import Data.Enum.Generic
@@ -67,6 +68,8 @@ newtype Address = Address String
 derive instance Eq Address
 derive instance Ord Address
 derive newtype instance Show Address
+derive newtype instance DecodeJson Address
+derive newtype instance EncodeJson Address
 
 fromString :: Set Address -> String -> Either AddressError Address
 fromString used s

--- a/marlowe-dashboard-client/src/Data/Address.purs
+++ b/marlowe-dashboard-client/src/Data/Address.purs
@@ -2,6 +2,7 @@ module Data.Address
   ( Address
   , AddressError(..)
   , dual
+  , empty
   , fromString
   , toString
   , validator
@@ -9,7 +10,13 @@ module Data.Address
 
 import Prologue
 
-import Data.Argonaut (class DecodeJson, class EncodeJson)
+import Data.Argonaut
+  ( class DecodeJson
+  , class EncodeJson
+  , JsonDecodeError(..)
+  , decodeJson
+  )
+import Data.Bifunctor (lmap)
 import Data.Bounded.Generic (genericBottom, genericTop)
 import Data.Enum (class BoundedEnum, class Enum)
 import Data.Enum.Generic
@@ -68,8 +75,15 @@ newtype Address = Address String
 derive instance Eq Address
 derive instance Ord Address
 derive newtype instance Show Address
-derive newtype instance DecodeJson Address
 derive newtype instance EncodeJson Address
+
+instance DecodeJson Address where
+  decodeJson =
+    lmap (const $ TypeMismatch "Address") <<< fromString Set.empty
+      <=< decodeJson
+
+empty :: Address
+empty = Address "00000000000000000000000000000000000000000000000000000000"
 
 fromString :: Set Address -> String -> Either AddressError Address
 fromString used s

--- a/marlowe-dashboard-client/src/Data/AddressBook.purs
+++ b/marlowe-dashboard-client/src/Data/AddressBook.purs
@@ -1,0 +1,20 @@
+module Data.AddressBook where
+
+import Prologue
+
+import Data.Address (Address)
+import Data.Argonaut (class DecodeJson, class EncodeJson)
+import Data.Bimap (Bimap)
+import Data.Generic.Rep (class Generic)
+import Data.Newtype (class Newtype)
+import Data.WalletNickname (WalletNickname)
+
+newtype AddressBook = AddressBook (Bimap WalletNickname Address)
+
+derive instance Generic AddressBook _
+derive instance Newtype AddressBook _
+derive instance Eq AddressBook
+derive instance Ord AddressBook
+derive newtype instance Show AddressBook
+derive newtype instance DecodeJson AddressBook
+derive newtype instance EncodeJson AddressBook

--- a/marlowe-dashboard-client/src/Data/AddressBook.purs
+++ b/marlowe-dashboard-client/src/Data/AddressBook.purs
@@ -5,8 +5,11 @@ import Prologue
 import Data.Address (Address)
 import Data.Argonaut (class DecodeJson, class EncodeJson)
 import Data.Bimap (Bimap)
+import Data.Bimap as BM
 import Data.Generic.Rep (class Generic)
-import Data.Newtype (class Newtype)
+import Data.Newtype (class Newtype, over, unwrap)
+import Data.Set (Set)
+import Data.Unfoldable (class Unfoldable)
 import Data.WalletNickname (WalletNickname)
 
 newtype AddressBook = AddressBook (Bimap WalletNickname Address)
@@ -18,3 +21,34 @@ derive instance Ord AddressBook
 derive newtype instance Show AddressBook
 derive newtype instance DecodeJson AddressBook
 derive newtype instance EncodeJson AddressBook
+
+isEmpty :: AddressBook -> Boolean
+isEmpty = BM.null <<< unwrap
+
+empty :: AddressBook
+empty = AddressBook BM.empty
+
+insert :: WalletNickname -> Address -> AddressBook -> AddressBook
+insert nickname = over AddressBook <<< BM.insert nickname
+
+containsNickname :: WalletNickname -> AddressBook -> Boolean
+containsNickname nickname = BM.memberL nickname <<< unwrap
+
+containsAddress :: Address -> AddressBook -> Boolean
+containsAddress address = BM.memberR address <<< unwrap
+
+nicknames :: AddressBook -> Set WalletNickname
+nicknames = BM.keysL <<< unwrap
+
+addresses :: AddressBook -> Set Address
+addresses = BM.keysR <<< unwrap
+
+lookupNickname :: Address -> AddressBook -> Maybe WalletNickname
+lookupNickname address = BM.lookupR address <<< unwrap
+
+lookupAddress :: WalletNickname -> AddressBook -> Maybe Address
+lookupAddress nickname = BM.lookupL nickname <<< unwrap
+
+toUnfoldable
+  :: forall t. Unfoldable t => AddressBook -> t (Tuple WalletNickname Address)
+toUnfoldable = BM.toUnfoldable <<< unwrap

--- a/marlowe-dashboard-client/src/Data/Bimap.purs
+++ b/marlowe-dashboard-client/src/Data/Bimap.purs
@@ -1,0 +1,142 @@
+module Data.Bimap
+  ( Bimap
+  , associated
+  , deleteL
+  , deleteR
+  , fromFoldable
+  , insert
+  , keysL
+  , keysR
+  , lookupL
+  , lookupR
+  , memberL
+  , memberR
+  , null
+  , singleton
+  , size
+  , swap
+  , swapped
+  , toUnfoldable
+  , tryInsert
+  ) where
+
+import Prologue
+
+import Data.Argonaut
+  ( class DecodeJson
+  , class EncodeJson
+  , decodeJson
+  , encodeJson
+  )
+import Data.Foldable (class Foldable, foldMap, foldl, foldr)
+import Data.FoldableWithIndex
+  ( class FoldableWithIndex
+  , foldMapWithIndex
+  , foldlWithIndex
+  , foldrWithIndex
+  )
+import Data.Map (Map)
+import Data.Map as M
+import Data.Maybe (maybe)
+import Data.Set (Set)
+import Data.Tuple (uncurry)
+import Data.Unfoldable (class Unfoldable)
+
+data Bimap k v = UnsafeBimap (Map k v) (Map v k)
+
+derive instance (Eq k, Eq v) => Eq (Bimap k v)
+derive instance (Ord k, Ord v) => Ord (Bimap k v)
+
+instance (Show k, Show v) => Show (Bimap k v) where
+  show (UnsafeBimap left _) = show left
+
+instance (DecodeJson k, DecodeJson v, Ord k, Ord v) => DecodeJson (Bimap k v) where
+  decodeJson = map fromMap <<< decodeJson
+    where
+    fromMap =
+      (fromFoldable :: Array (Tuple k v) -> Bimap k v) <<< M.toUnfoldable
+
+instance (EncodeJson k, EncodeJson v, Ord k, Ord v) => EncodeJson (Bimap k v) where
+  encodeJson (UnsafeBimap left _) = encodeJson left
+
+instance Foldable (Bimap k) where
+  foldMap f (UnsafeBimap left _) = foldMap f left
+  foldl f b (UnsafeBimap left _) = foldl f b left
+  foldr f b (UnsafeBimap left _) = foldr f b left
+
+instance FoldableWithIndex k (Bimap k) where
+  foldMapWithIndex f (UnsafeBimap left _) = foldMapWithIndex f left
+  foldlWithIndex f b (UnsafeBimap left _) = foldlWithIndex f b left
+  foldrWithIndex f b (UnsafeBimap left _) = foldrWithIndex f b left
+
+empty :: forall k v. Bimap k v
+empty = UnsafeBimap M.empty M.empty
+
+singleton :: forall k v. k -> v -> Bimap k v
+singleton k v = UnsafeBimap (M.singleton k v) (M.singleton v k)
+
+null :: forall k v. Bimap k v -> Boolean
+null (UnsafeBimap left _) = M.isEmpty left
+
+size :: forall k v. Bimap k v -> Int
+size (UnsafeBimap left _) = M.size left
+
+insert :: forall k v. Ord k => Ord v => k -> v -> Bimap k v -> Bimap k v
+insert k v = unsafeInsert k v <<< deleteL k <<< deleteR v
+
+tryInsert :: forall k v. Ord k => Ord v => k -> v -> Bimap k v -> Bimap k v
+tryInsert k v bm
+  | memberL k bm || memberR v bm = bm
+  | otherwise = unsafeInsert k v bm
+
+associated :: forall k v. Ord k => Ord v => Tuple k v -> Bimap k v -> Boolean
+associated (Tuple k v) (UnsafeBimap left _) =
+  maybe false (v == _) $ M.lookup k left
+
+keysL :: forall k v. Bimap k v -> Set k
+keysL (UnsafeBimap left _) = M.keys left
+
+keysR :: forall k v. Bimap k v -> Set v
+keysR (UnsafeBimap _ right) = M.keys right
+
+memberL :: forall k v. Ord k => k -> Bimap k v -> Boolean
+memberL k (UnsafeBimap left _) = M.member k left
+
+memberR :: forall k v. Ord v => v -> Bimap k v -> Boolean
+memberR v (UnsafeBimap _ right) = M.member v right
+
+deleteL :: forall k v. Ord k => Ord v => k -> Bimap k v -> Bimap k v
+deleteL k bm@(UnsafeBimap left right) =
+  case M.pop k left of
+    Nothing -> bm
+    Just (Tuple v left') -> UnsafeBimap left' $ M.delete v right
+
+deleteR :: forall k v. Ord k => Ord v => v -> Bimap k v -> Bimap k v
+deleteR v bm@(UnsafeBimap left right) =
+  case M.pop v right of
+    Nothing -> bm
+    Just (Tuple k right') -> UnsafeBimap (M.delete k left) right'
+
+unsafeInsert :: forall k v. Ord k => Ord v => k -> v -> Bimap k v -> Bimap k v
+unsafeInsert k v (UnsafeBimap left right) =
+  UnsafeBimap (M.insert k v left) (M.insert v k right)
+
+lookupL :: forall k v. Ord k => Ord v => k -> Bimap k v -> Maybe v
+lookupL k (UnsafeBimap left _) = M.lookup k left
+
+lookupR :: forall k v. Ord k => Ord v => v -> Bimap k v -> Maybe k
+lookupR v (UnsafeBimap _ right) = M.lookup v right
+
+fromFoldable
+  :: forall t k v. Foldable t => Ord k => Ord v => t (Tuple k v) -> Bimap k v
+fromFoldable = foldl (flip <<< uncurry $ insert) empty
+
+toUnfoldable
+  :: forall t k v. Unfoldable t => Bimap k v -> t (Tuple k v)
+toUnfoldable (UnsafeBimap left _) = M.toUnfoldable left
+
+swap :: forall k v. Bimap k v -> Bimap v k
+swap (UnsafeBimap left right) = UnsafeBimap right left
+
+swapped :: forall k v. (Bimap k v -> Bimap k v) -> Bimap v k -> Bimap v k
+swapped f = swap <<< f <<< swap

--- a/marlowe-dashboard-client/src/Data/Bimap.purs
+++ b/marlowe-dashboard-client/src/Data/Bimap.purs
@@ -4,6 +4,7 @@ module Data.Bimap
   , deleteL
   , deleteR
   , fromFoldable
+  , empty
   , insert
   , keysL
   , keysR

--- a/marlowe-dashboard-client/src/Data/WalletNickname.purs
+++ b/marlowe-dashboard-client/src/Data/WalletNickname.purs
@@ -10,6 +10,7 @@ module Data.WalletNickname
 
 import Prologue
 
+import Data.Argonaut (class DecodeJson, class EncodeJson)
 import Data.Bounded.Generic (genericBottom, genericTop)
 import Data.Enum (class BoundedEnum, class Enum)
 import Data.Enum.Generic
@@ -72,6 +73,8 @@ newtype WalletNickname = WalletNickname String
 derive instance eqWalletNickname :: Eq WalletNickname
 derive instance ordWalletNickname :: Ord WalletNickname
 derive newtype instance showWalletNickname :: Show WalletNickname
+derive newtype instance DecodeJson WalletNickname
+derive newtype instance EncodeJson WalletNickname
 
 nicknameRegex :: Regex
 nicknameRegex = unsafeRegex "^[a-z0-9]+$" ignoreCase

--- a/marlowe-dashboard-client/src/Data/WalletNickname.purs
+++ b/marlowe-dashboard-client/src/Data/WalletNickname.purs
@@ -4,13 +4,20 @@ module Data.WalletNickname
   , dual
   , fromFoldable
   , fromString
+  , new
   , validator
   , toString
   ) where
 
 import Prologue
 
-import Data.Argonaut (class DecodeJson, class EncodeJson)
+import Data.Argonaut
+  ( class DecodeJson
+  , class EncodeJson
+  , JsonDecodeError(..)
+  , decodeJson
+  )
+import Data.Bifunctor (lmap)
 import Data.Bounded.Generic (genericBottom, genericTop)
 import Data.Enum (class BoundedEnum, class Enum)
 import Data.Enum.Generic
@@ -70,14 +77,21 @@ instance showWalletNicknameError :: Show WalletNicknameError where
 
 newtype WalletNickname = WalletNickname String
 
-derive instance eqWalletNickname :: Eq WalletNickname
-derive instance ordWalletNickname :: Ord WalletNickname
-derive newtype instance showWalletNickname :: Show WalletNickname
-derive newtype instance DecodeJson WalletNickname
+derive instance Eq WalletNickname
+derive instance Ord WalletNickname
+derive newtype instance Show WalletNickname
 derive newtype instance EncodeJson WalletNickname
+
+instance DecodeJson WalletNickname where
+  decodeJson =
+    lmap (const $ TypeMismatch "WalletId") <<< fromString Set.empty
+      <=< decodeJson
 
 nicknameRegex :: Regex
 nicknameRegex = unsafeRegex "^[a-z0-9]+$" ignoreCase
+
+new :: WalletNickname
+new = WalletNickname "newWallet"
 
 fromFoldable :: forall f. Foldable f => f String -> Set WalletNickname
 fromFoldable = Set.map WalletNickname <<< Set.fromFoldable

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -5,7 +5,12 @@ module Main
 import Prologue
 
 import AppM (runAppM)
+import Capability.MarloweStorage (addressBookLocalStorageKey)
 import Capability.PlutusApps.MarloweApp as MarloweApp
+import Data.AddressBook as AddressBook
+import Data.Argonaut.Extra (parseDecodeJson)
+import Data.Either (hush)
+import Data.Maybe (fromMaybe)
 import Effect (Effect)
 import Effect.AVar as AVar
 import Effect.Aff (forkAff, launchAff_)
@@ -14,6 +19,8 @@ import Env (Env(..), WebSocketManager)
 import Halogen.Aff (awaitBody, runHalogenAff)
 import Halogen.Subscription as HS
 import Halogen.VDom.Driver (runUI)
+import Humanize (getTimezoneOffset)
+import LocalStorage (getItem)
 import MainFrame.State (mkMainFrame)
 import MainFrame.Types (Msg(..), Query(..))
 import WebSocket.Support as WS
@@ -31,13 +38,19 @@ mkEnv wsManager = do
 
 main :: Effect Unit
 main = do
+  tzOffset <- getTimezoneOffset
+  addressBookJson <- getItem addressBookLocalStorageKey
+  let
+    addressBook =
+      fromMaybe AddressBook.empty $ hush <<< parseDecodeJson =<< addressBookJson
+
   runHalogenAff do
     wsManager <- WS.mkWebSocketManager
     env <- liftEffect $ mkEnv wsManager
-    let store = { currentSlot: zero, toast: Nothing }
+    let store = { addressBook, currentSlot: zero, toast: Nothing }
     body <- awaitBody
     rootComponent <- runAppM env store mkMainFrame
-    driver <- runUI rootComponent unit body
+    driver <- runUI rootComponent { tzOffset } body
     void
       $ forkAff
       $ WS.runWebSocketManager

--- a/marlowe-dashboard-client/src/MainFrame/Lenses.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Lenses.purs
@@ -1,14 +1,8 @@
-module MainFrame.Lenses
-  ( _webSocketStatus
-  , _currentSlot
-  , _tzOffset
-  , _subState
-  , _welcomeState
-  , _dashboardState
-  ) where
+module MainFrame.Lenses where
 
 import Prologue
 
+import Data.AddressBook (AddressBook)
 import Data.Lens (Lens', Traversal')
 import Data.Lens.Prism.Either (_Left, _Right)
 import Data.Lens.Record (prop)
@@ -24,6 +18,9 @@ _webSocketStatus = prop (Proxy :: _ "webSocketStatus")
 
 _currentSlot :: Lens' State Slot
 _currentSlot = prop (Proxy :: _ "currentSlot")
+
+_addressBook :: Lens' State AddressBook
+_addressBook = prop (Proxy :: _ "addressBook")
 
 _tzOffset :: Lens' State Minutes
 _tzOffset = prop (Proxy :: _ "tzOffset")

--- a/marlowe-dashboard-client/src/MainFrame/Types.purs
+++ b/marlowe-dashboard-client/src/MainFrame/Types.purs
@@ -4,15 +4,17 @@ import Prologue
 
 import Analytics (class IsEvent, defaultEvent, toEvent)
 import Componenet.RestoreWalletForm as RestoreWalletForm
-import Component.Contacts.Types (AddressBook, WalletDetails)
+import Component.Contacts.Types (WalletDetails)
 import Component.Expand as Expand
 import Component.LoadingSubmitButton.Types as LoadingSubmitButton
 import Component.Tooltip.Types (ReferenceId)
+import Data.AddressBook (AddressBook)
 import Data.Generic.Rep (class Generic)
 import Data.Map (Map)
 import Data.Time.Duration (Minutes)
 import Halogen as H
 import Halogen.Extra (LifecycleEvent)
+import Halogen.Store.Connect (Connected)
 import Marlowe.PAB (PlutusAppId)
 import Marlowe.Semantics (Slot)
 import Page.Contract.Types (State) as Contract
@@ -23,12 +25,17 @@ import Type.Proxy (Proxy(..))
 import Web.Socket.Event.CloseEvent (CloseEvent, reason) as WS
 import WebSocket.Support (FromSocket) as WS
 
+type Input =
+  { tzOffset :: Minutes
+  }
+
 -- The app exists in one of two main subStates: the "welcome" state for when you have
 -- no wallet, and all you can do is generate one or create a new one; and the "dashboard"
 -- state for when you have selected a wallet, and can do all of the things.
 type State =
-  { webSocketStatus :: WebSocketStatus
-  -- TODO: Both currentSlot and tzOffset should be stored in the global store rather than here, but in order
+  { addressBook :: AddressBook
+  , webSocketStatus :: WebSocketStatus
+  -- TODO: currentSlot, tzOffset, and addressBook should be stored in the global store rather than here, but in order
   --       to remove it from here we need to first change the sub-components that use this into proper components
   , currentSlot :: Slot
   , tzOffset :: Minutes
@@ -71,20 +78,17 @@ data Msg
 
 ------------------------------------------------------------
 data Action
-  = Init
-  | EnterWelcomeState
-      AddressBook
-      WalletDetails
-      (Map PlutusAppId Contract.State)
-  | EnterDashboardState AddressBook WalletDetails
+  = EnterWelcomeState WalletDetails (Map PlutusAppId Contract.State)
+  | EnterDashboardState WalletDetails
   | WelcomeAction Welcome.Action
   | DashboardAction Dashboard.Action
+  | Receive (Connected AddressBook Input)
 
 -- | Here we decide which top-level queries to track as GA events, and
 -- how to classify them.
 instance actionIsEvent :: IsEvent Action where
-  toEvent Init = Just $ defaultEvent "Init"
-  toEvent (EnterWelcomeState _ _ _) = Just $ defaultEvent "EnterWelcomeState"
-  toEvent (EnterDashboardState _ _) = Just $ defaultEvent "EnterDashboardState"
+  toEvent (EnterWelcomeState _ _) = Just $ defaultEvent "EnterWelcomeState"
+  toEvent (EnterDashboardState _) = Just $ defaultEvent "EnterDashboardState"
+  toEvent (Receive _) = Just $ defaultEvent "Receive"
   toEvent (WelcomeAction welcomeAction) = toEvent welcomeAction
   toEvent (DashboardAction dashboardAction) = toEvent dashboardAction

--- a/marlowe-dashboard-client/src/MainFrame/View.purs
+++ b/marlowe-dashboard-client/src/MainFrame/View.purs
@@ -13,7 +13,8 @@ import Halogen.HTML (div)
 import Halogen.HTML as H
 import Halogen.Store.Monad (class MonadStore)
 import MainFrame.Lenses
-  ( _currentSlot
+  ( _addressBook
+  , _currentSlot
   , _dashboardState
   , _subState
   , _tzOffset
@@ -35,6 +36,8 @@ render
   -> ComponentHTML Action ChildSlots m
 render state =
   let
+    addressBook = state ^. _addressBook
+
     currentSlot = state ^. _currentSlot
 
     tzOffset = state ^. _tzOffset
@@ -44,13 +47,22 @@ render state =
         case view _subState state of
           Left _ ->
             [ renderSubmodule _welcomeState WelcomeAction welcomeScreen state
-            , renderSubmodule _welcomeState WelcomeAction welcomeCard state
+            , renderSubmodule
+                _welcomeState
+                WelcomeAction
+                (welcomeCard addressBook)
+                state
             ]
           Right _ ->
-            [ renderSubmodule _dashboardState DashboardAction
-                (dashboardScreen { currentSlot, tzOffset })
+            [ renderSubmodule
+                _dashboardState
+                DashboardAction
+                (dashboardScreen { addressBook, currentSlot, tzOffset })
                 state
-            , renderSubmodule _dashboardState DashboardAction dashboardCard
+            , renderSubmodule
+                _dashboardState
+                DashboardAction
+                (dashboardCard addressBook)
                 state
             ]
           <> [ H.slot_ _toaster unit Toast.component unit ]

--- a/marlowe-dashboard-client/src/Page/Contract/Lenses.purs
+++ b/marlowe-dashboard-client/src/Page/Contract/Lenses.purs
@@ -20,15 +20,16 @@ module Page.Contract.Lenses
   ) where
 
 import Prologue
-import Component.Contacts.Types (WalletNickname)
+
 import Data.Lens (Lens', Prism', lens', prism')
 import Data.Lens.Record (prop)
 import Data.Map (Map)
-import Type.Proxy (Proxy(..))
 import Data.Tuple.Nested ((/\))
+import Data.WalletNickname (WalletNickname)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Semantics (Party)
-import Page.Contract.Types (StartedState, State(..), StartingState)
+import Page.Contract.Types (StartedState, StartingState, State(..))
+import Type.Proxy (Proxy(..))
 
 _Starting :: Prism' State StartingState
 _Starting =

--- a/marlowe-dashboard-client/src/Page/Contract/State.purs
+++ b/marlowe-dashboard-client/src/Page/Contract/State.purs
@@ -24,10 +24,11 @@ import Capability.MarloweStorage
 import Capability.Toast (class Toast, addToast)
 import Component.Contacts.Lenses (_assets, _pubKeyHash, _walletInfo)
 import Component.Contacts.State (adaToken, getAda)
-import Component.Contacts.Types (WalletDetails, WalletNickname)
+import Component.Contacts.Types (WalletDetails)
 import Component.LoadingSubmitButton.Types (Query(..), _submitButtonSlot)
 import Component.Transfer.Types (Participant, Termini(..), Transfer)
 import Control.Monad.Reader (class MonadAsk, asks)
+import Data.Address as A
 import Data.Array
   ( difference
   , filter
@@ -70,6 +71,7 @@ import Data.Time.Duration (Milliseconds(..))
 import Data.Traversable (traverse, traverse_)
 import Data.Tuple.Nested ((/\))
 import Data.Unfoldable as Unfoldable
+import Data.WalletNickname (WalletNickname)
 import Effect (Effect)
 import Effect.Aff.AVar as AVar
 import Effect.Aff.Class (class MonadAff, liftAff)
@@ -324,7 +326,7 @@ getUserParties walletDetails marloweParams =
     roleTokens = foldMap (Set.map Role <<< Map.keys <<< Map.filter ((/=) zero))
       mCurrencyTokens
   in
-    Set.insert (PK pubKeyHash) roleTokens
+    Set.insert (PK $ A.toString pubKeyHash) roleTokens
 
 withStarted
   :: forall action slots msg m

--- a/marlowe-dashboard-client/src/Page/Contract/Types.purs
+++ b/marlowe-dashboard-client/src/Page/Contract/Types.purs
@@ -13,11 +13,13 @@ module Page.Contract.Types
   ) where
 
 import Prologue
+
 import Analytics (class IsEvent, defaultEvent)
-import Component.Contacts.Types (WalletDetails, WalletNickname)
+import Component.Contacts.Types (WalletDetails)
 import Data.Map (Map)
 import Data.Set (Set)
 import Data.Time.Duration (Minutes)
+import Data.WalletNickname (WalletNickname)
 import Halogen (RefLabel(..))
 import Marlowe.Execution.Types (NamedAction)
 import Marlowe.Execution.Types (State) as Execution
@@ -38,15 +40,13 @@ data State
   = Starting StartingState
   | Started StartedState
 
-type StartingState
-  =
+type StartingState =
   { nickname :: String
   , metadata :: MetaData
   , participants :: Map Party (Maybe WalletNickname)
   }
 
-type StartedState
-  =
+type StartedState =
   { nickname :: String
   , tab :: Tab -- this is the tab of the current (latest) step - previous steps have their own tabs
   , executionState :: Execution.State
@@ -69,15 +69,13 @@ type StartedState
   , namedActions :: Array (Tuple Party (Array NamedAction))
   }
 
-type StepBalance
-  =
+type StepBalance =
   { atStart :: Accounts
   , atEnd :: Maybe Accounts
   }
 
 -- Represents a historical step in a contract's life.
-type PreviousStep
-  =
+type PreviousStep =
   { tab :: Tab
   , expandPayments :: Boolean
   , resultingPayments :: Array Payment
@@ -101,8 +99,7 @@ data Tab
 
 derive instance eqTab :: Eq Tab
 
-type Input
-  =
+type Input =
   { currentSlot :: Slot
   , tzOffset :: Minutes
   , walletDetails :: WalletDetails
@@ -111,7 +108,7 @@ type Input
 
 data Action
   = SelectSelf
-  | SetNickname String
+  | SetNickname String -- NOT a wallet nickname. todo add ContractNickname type
   | ConfirmAction NamedAction
   | ChangeChoice ChoiceId (Maybe ChosenNum)
   | SelectTab Int Tab

--- a/marlowe-dashboard-client/src/Page/Contract/View.purs
+++ b/marlowe-dashboard-client/src/Page/Contract/View.purs
@@ -4,6 +4,7 @@ module Page.Contract.View
   ) where
 
 import Prologue hiding (div)
+
 import Component.Contacts.State (adaToken)
 import Component.Hint.State (hint)
 import Component.Icons (Icon(..)) as Icon
@@ -32,10 +33,11 @@ import Data.String (take, trim)
 import Data.String.Extra (capitalize)
 import Data.Tuple (uncurry)
 import Data.Tuple.Nested ((/\))
+import Data.WalletNickname as WN
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
 import Halogen.Css (applyWhen, classNames)
-import Halogen.Extra (lifeCycleSlot, LifecycleEvent(..))
+import Halogen.Extra (LifecycleEvent(..), lifeCycleSlot)
 import Halogen.HTML
   ( HTML
   , a
@@ -857,13 +859,13 @@ currentStepActions _ state =
 participantWithNickname :: StartedState -> Party -> String
 participantWithNickname state party =
   let
-    mNickname :: Maybe String
     mNickname = join $ Map.lookup party (state ^. _participants)
   in
     capitalize case party, mNickname of
       -- TODO: For the demo we wont have PK, but eventually we probably want to limit the amount of characters
       PK publicKey, _ -> publicKey
-      Role roleName, Just nickname -> roleName <> " (" <> nickname <> ")"
+      Role roleName, Just nickname -> roleName <> " (" <> WN.toString nickname
+        <> ")"
       Role roleName, Nothing -> roleName
 
 accountIndicator

--- a/marlowe-dashboard-client/src/Page/Dashboard/Lenses.purs
+++ b/marlowe-dashboard-client/src/Page/Dashboard/Lenses.purs
@@ -14,6 +14,7 @@ module Page.Dashboard.Lenses
   ) where
 
 import Prologue
+
 import Component.Contacts.Types (State) as Contacts
 import Component.Contacts.Types (WalletDetails)
 import Component.Template.Types (State) as Template

--- a/marlowe-dashboard-client/src/Page/Dashboard/Types.purs
+++ b/marlowe-dashboard-client/src/Page/Dashboard/Types.purs
@@ -13,11 +13,13 @@ import Analytics (class IsEvent, defaultEvent, toEvent)
 import Clipboard (Action) as Clipboard
 import Component.ConfirmInput.Types as ConfirmInput
 import Component.Contacts.Types (Action, State) as Contacts
-import Component.Contacts.Types (WalletDetails, WalletNickname)
+import Component.Contacts.Types (WalletDetails)
 import Component.Template.Types (Action, State) as Template
+import Data.AddressBook (AddressBook)
 import Data.Map (Map)
 import Data.Set (Set)
 import Data.Time.Duration (Minutes)
+import Data.WalletNickname (WalletNickname)
 import Marlowe.Client (ContractHistory)
 import Marlowe.PAB (PlutusAppId)
 import Marlowe.Semantics (MarloweData, MarloweParams, Slot)
@@ -57,9 +59,9 @@ data ContractFilter
 
 derive instance eqContractFilter :: Eq ContractFilter
 
-type Input
-  =
-  { currentSlot :: Slot
+type Input =
+  { addressBook :: AddressBook
+  , currentSlot :: Slot
   , tzOffset :: Minutes
   }
 

--- a/marlowe-dashboard-client/src/Page/Welcome/Lenses.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/Lenses.purs
@@ -2,10 +2,8 @@ module Page.Welcome.Lenses where
 
 import Prologue
 
-import Component.Contacts.Types (AddressBook)
 import Data.Lens (Lens')
 import Data.Lens.Record (prop)
-import Marlowe.PAB (PlutusAppId)
 import Page.Welcome.Types (Card, State)
 import Type.Proxy (Proxy(..))
 
@@ -14,12 +12,6 @@ _card = prop (Proxy :: _ "card")
 
 _cardOpen :: Lens' State Boolean
 _cardOpen = prop (Proxy :: _ "cardOpen")
-
-_addressBook :: Lens' State AddressBook
-_addressBook = prop (Proxy :: _ "addressBook")
-
-_walletId :: Lens' State PlutusAppId
-_walletId = prop (Proxy :: _ "walletId")
 
 _enteringDashboardState :: Lens' State Boolean
 _enteringDashboardState = prop (Proxy :: _ "enteringDashboardState")

--- a/marlowe-dashboard-client/src/Page/Welcome/State.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/State.purs
@@ -1,6 +1,5 @@
 module Page.Welcome.State
-  ( dummyState
-  , mkInitialState
+  ( initialState
   , handleAction
   ) where
 
@@ -11,49 +10,32 @@ import Capability.Marlowe (class ManageMarlowe)
 import Capability.MarloweStorage
   ( class ManageMarloweStorage
   , clearAllLocalStorage
-  , insertIntoAddressBook
+  , modifyAddressBook_
   )
 import Capability.Toast (class Toast, addToast)
 import Clipboard (class MonadClipboard)
 import Clipboard (handleAction) as Clipboard
 import Component.Contacts.Lenses (_pubKeyHash, _walletInfo, _walletNickname)
-import Component.Contacts.Types (AddressBook)
 import Control.Monad.Reader (class MonadAsk)
-import Data.Lens (assign, modifying, set, use, view)
-import Data.Map (insert)
-import Data.Map as Map
-import Data.UUID.Argonaut (emptyUUID) as UUID
-import Data.WalletNickname as WN
+import Data.AddressBook as AddressBook
+import Data.Lens (assign, set, view)
 import Effect.Aff.Class (class MonadAff)
 import Env (Env)
 import Halogen (HalogenM, liftEffect, modify_)
 import Halogen.Query.HalogenM (mapAction)
 import MainFrame.Types (Action(..)) as MainFrame
 import MainFrame.Types (ChildSlots, Msg)
-import Marlowe.PAB (PlutusAppId(..))
-import Page.Welcome.Lenses
-  ( _addressBook
-  , _card
-  , _cardOpen
-  , _enteringDashboardState
-  , _walletId
-  )
+import Page.Welcome.Lenses (_enteringDashboardState)
 import Page.Welcome.Types (Action(..), State)
 import Toast.Types (successToast)
 import Web.HTML (window)
 import Web.HTML.Location (reload)
 import Web.HTML.Window (location)
 
--- see note [dummyState] in MainFrame.State
-dummyState :: State
-dummyState = mkInitialState Map.empty
-
-mkInitialState :: AddressBook -> State
-mkInitialState addressBook =
-  { addressBook
-  , card: Nothing
+initialState :: State
+initialState =
+  { card: Nothing
   , cardOpen: false
-  , walletId: PlutusAppId UUID.emptyUUID
   , enteringDashboardState: false
   }
 
@@ -70,14 +52,11 @@ handleAction
   => MonadClipboard m
   => Action
   -> HalogenM State Action ChildSlots Msg m Unit
-handleAction (OpenCard card) = do
-  modify_ $ set _card (Just card) <<< set _cardOpen true
+handleAction (OpenCard card) =
+  modify_ _ { card = Just card, cardOpen = true }
 
-handleAction CloseCard = do
-  modify_
-    $ set _enteringDashboardState false
-        <<< set _cardOpen false
-        <<< set _walletId dummyState.walletId
+handleAction CloseCard =
+  modify_ _ { enteringDashboardState = false, cardOpen = false }
 
 {- [UC-WALLET-TESTNET-1][0] Create a new testnet wallet
 Here we attempt to create a new demo wallet (with everything that entails), and - if successful -
@@ -93,28 +72,6 @@ that wallet: a `WalletCompanion` and a `MarloweApp`.
 -- TODO: This functionality is disabled, I'll re-enable it as part of SCP-3170.
 handleAction GenerateWallet = pure unit
 
--- TODO: SCP-3218 We'll most likely won't need the [Workflow 2][X] connect wallet features, but I'll remove them
---       once the new flow is fully functional.
-{- [Workflow 2][1] Connect a wallet
-If we are connecting a wallet that was selected by the user inputting a wallet nickname, then we
-will have a cache of it's `WalletDetails` in LocalStorage. But those details may well be out of
-date. This intermediate step makes sure we have the current details before proceeding.
-This is also factored out into a separate handler so that it can be called directly when the user
-selects a wallet nickname from the dropdown menu (as well as indirectly via the previous handler).
--}
--- handleAction (OpenUseWalletCardWithDetails walletDetails) = do
---   assign _remoteWalletDetails Loading
---   ajaxWalletDetails <- lookupWalletDetails $ view _companionAppId walletDetails
---   assign _remoteWalletDetails $ fromEither ajaxWalletDetails
---   case ajaxWalletDetails of
---     Left _ -> handleAction $ OpenCard LocalWalletMissingCard
---     Right _ -> do
---       handleAction $ WalletNicknameInputAction $ InputField.SetValue $ view
---         _walletNickname
---         walletDetails
---       assign _walletId $ walletDetails ^. _companionAppId
---       handleAction $ OpenCard UseWalletCard
-
 {- [Workflow 2][2] Connect a wallet
 This action is triggered by clicking the confirmation button on the UseWalletCard or
 UseNewWalletCard. It saves the wallet nickname to LocalStorage, and then calls the
@@ -123,16 +80,11 @@ UseNewWalletCard. It saves the wallet nickname to LocalStorage, and then calls t
 handleAction (ConnectWallet walletNickname walletDetails) = do
   assign _enteringDashboardState true
   let
-    walletDetailsWithNickname = set _walletNickname
-      (WN.toString walletNickname)
-      walletDetails
+    walletDetailsWithNickname = set _walletNickname walletNickname walletDetails
 
     address = view (_walletInfo <<< _pubKeyHash) walletDetailsWithNickname
-  modifying _addressBook $ insert (WN.toString walletNickname) address
-  insertIntoAddressBook (WN.toString walletNickname) address
-  addressBook <- use _addressBook
-  callMainFrameAction $ MainFrame.EnterDashboardState addressBook
-    walletDetailsWithNickname
+  modifyAddressBook_ (AddressBook.insert walletNickname address)
+  callMainFrameAction $ MainFrame.EnterDashboardState walletDetailsWithNickname
 
 handleAction ClearLocalStorage = do
   clearAllLocalStorage

--- a/marlowe-dashboard-client/src/Page/Welcome/Types.purs
+++ b/marlowe-dashboard-client/src/Page/Welcome/Types.purs
@@ -8,9 +8,8 @@ import Prologue
 
 import Analytics (class IsEvent, defaultEvent)
 import Clipboard (Action) as Clipboard
-import Component.Contacts.Types (AddressBook, WalletDetails)
+import Component.Contacts.Types (WalletDetails)
 import Data.WalletNickname (WalletNickname)
-import Marlowe.PAB (PlutusAppId)
 
 -- TODO (possibly): The Contacts submodule used in the Dashboard has some properties and
 -- functionality that's similar to some of what goes on here. It might be worth generalising it so
@@ -25,8 +24,6 @@ type State =
   -- cards has to be different for different screen sizes (on large screens some cards slide in
   -- from the right) - and that's much easier to do with media queries.
   , cardOpen :: Boolean
-  , addressBook :: AddressBook
-  , walletId :: PlutusAppId
   , enteringDashboardState :: Boolean
   }
 

--- a/marlowe-dashboard-client/src/Store.purs
+++ b/marlowe-dashboard-client/src/Store.purs
@@ -6,17 +6,20 @@ module Store
 
 import Prologue
 
+import Data.AddressBook (AddressBook)
 import Marlowe.Semantics (Slot)
 import Toast.Types (ToastMessage)
 
 type Store =
-  { currentSlot :: Slot
+  { addressBook :: AddressBook
+  , currentSlot :: Slot
   , toast :: Maybe ToastMessage
   }
 
 data Action
   = AdvanceToSlot Slot
   | ShowToast ToastMessage
+  | ModifyAddressBook (AddressBook -> AddressBook)
   | ClearToast
 
 reduce :: Store -> Action -> Store
@@ -27,3 +30,4 @@ reduce store = case _ of
   AdvanceToSlot newSlot -> store { currentSlot = newSlot }
   ShowToast msg -> store { toast = Just msg }
   ClearToast -> store { toast = Nothing }
+  ModifyAddressBook f -> store { addressBook = f store.addressBook }

--- a/web-common-marlowe/src/Marlowe/Semantics.purs
+++ b/web-common-marlowe/src/Marlowe/Semantics.purs
@@ -1,6 +1,7 @@
 module Marlowe.Semantics where
 
 import Prologue
+
 import Control.Alt ((<|>))
 import Control.Monad.RWS (RWSResult(..), RWST(..), evalRWST)
 import Control.Monad.Reader (ReaderT(..), runReaderT)
@@ -120,9 +121,6 @@ next =
       <*> pure unit
 
 type PubKey
-  = String
-
-type PubKeyHash
   = String
 
 data Party


### PR DESCRIPTION
This refactor is a first pass at addressing a particular code smell that is pervasive throughout Marlowe Run which makes the codebase more tightly coupled an more prone to bugs: primitive obsession.

Previously, `WalletNickname` and `MnemonicPhrase` modules with smart constructors were introduced. This PR extends the use of `WalletNickname` throughout the app. It also adds an `Address` type which currently wraps just a string (a pub key hash), but will soon be used to represent a bech32 address. I removed a dozen or so `TODO` comments across several files regarding switching from pub key hashes to bech 32 addresses. I did this because we should now be able to accomplish this entirely in the `Data.Address` module without having to change its API. This is precisely what we stand to gain by addressing primitive obsession.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
