### PR TITLE
Include Z3 executable in marlowe-contracts-test build

### DIFF
--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -163,6 +163,10 @@ let
             PATH=${lib.makeBinPath [ z3 ]}:$PATH
           '';
 
+          marlowe-contracts.components.tests.marlowe-contracts-test.preCheck = ''
+            PATH=${lib.makeBinPath [ z3 ]}:$PATH
+          '';
+
           # Relies on cabal-doctest, just turn it off in the Nix build
           prettyprinter-configurable.components.tests.prettyprinter-configurable-doctest.buildable = lib.mkForce false;
 


### PR DESCRIPTION
- Include Z3 executable in marlowe-contracts-test build to fix failures in Hydra CI for that component.

I'm not working on this repo, but I was debugging a failure in this repo earlier. This should fix the Hydra CI failures currently occurring on the sprint-50 branch. Hope this is helpful.
