### PR TITLE
SCP-3792 restart marloweapp

### DIFF
--- a/marlowe-dashboard-client/src/Capability/Marlowe.purs
+++ b/marlowe-dashboard-client/src/Capability/Marlowe.purs
@@ -1,6 +1,7 @@
 module Capability.Marlowe
-  ( ApplyInputError
+  ( ApplyInputError(..)
   , CreateError(..)
+  , RedeemError(..)
   , applyTransactionInput
   , class ManageMarlowe
   , initializeContract
@@ -10,16 +11,16 @@ module Capability.Marlowe
 import Prologue
 
 import AppM (AppM)
+import Capability.PAB (stopContract)
 import Capability.PlutusApps.MarloweApp (applyInputs, createContract, redeem) as MarloweApp
-import Capability.Toast (addToast)
 import Capability.Wallet (class ManageWallet)
 import Component.ContractSetup.Types (ContractParams)
 import Component.Template.State
   ( InstantiateContractErrorRow
   , instantiateExtendedContract
   )
-import Control.Logger.Structured (info, info')
-import Control.Monad.Error.Class (class MonadError, throwError)
+import Control.Logger.Structured (error, info, info', warning')
+import Control.Monad.Error.Class (class MonadError)
 import Control.Monad.Except (ExceptT(..), except, lift, runExceptT, withExceptT)
 import Control.Monad.Maybe.Trans (MaybeT)
 import Control.Monad.Reader (ReaderT)
@@ -34,23 +35,27 @@ import Data.PABConnectedWallet (PABConnectedWallet, _address, _marloweAppId)
 import Data.Tuple.Nested (type (/\), (/\))
 import Data.Variant (Variant)
 import Data.Variant.Generic (class Constructors, mkConstructors')
-import Effect.Aff (Aff, Error, error, forkAff, joinFiber)
+import Effect.Aff (Aff, Error, forkAff, joinFiber)
 import Effect.Aff.Class (liftAff)
-import Effect.Aff.Unlift (class MonadUnliftAff, askUnliftAff, unliftAff)
+import Effect.Aff.Unlift
+  ( class MonadUnliftAff
+  , UnliftAff
+  , askUnliftAff
+  , unliftAff
+  )
 import Errors.Debuggable (class Debuggable)
 import Errors.Explain (class Explain)
 import Halogen (HalogenM)
 import Halogen.Store.Monad (updateStore)
 import Language.Marlowe.Client (MarloweError)
-import Language.Marlowe.Client.Error (showContractError)
 import Marlowe.Extended.Metadata (ContractTemplate)
+import Marlowe.PAB (PlutusAppId)
 import Marlowe.Run.Server (Api) as MarloweApp
 import Marlowe.Semantics (MarloweParams, TokenName, TransactionInput)
 import Plutus.PAB.Webserver (Api) as PAB
 import Servant.PureScript (class MonadAjax)
 import Store as Store
 import Text.Pretty (text)
-import Toast.Types (errorToast)
 import Type.Proxy (Proxy(..))
 import Type.Row (type (+))
 import Types (AjaxResponse, JsonAjaxErrorRow)
@@ -87,7 +92,31 @@ class
     :: PABConnectedWallet
     -> MarloweParams
     -> TokenName
-    -> m (AjaxResponse (Aff Unit))
+    -> m (AjaxResponse (Aff (Either RedeemError Unit)))
+
+withRestartOnTimeout
+  :: forall m e a b
+   . MonadUnliftAff m
+  => MonadError Error m
+  => MonadAjax PAB.Api m
+  => MonadRec m
+  => PlutusAppId
+  -> UnliftAff (AppM m)
+  -> Aff (Maybe a)
+  -> e
+  -> (a -> AppM m (Either e b))
+  -> Aff (Either e b)
+withRestartOnTimeout marloweAppId u aff timeoutError f = do
+  mResult <- aff
+  unliftAff u case mResult of
+    Nothing -> do
+      warning' "MarloweApp timed out, stoping instance."
+      stopResult <- stopContract marloweAppId
+      case stopResult of
+        Left err -> error "Failed to stop MarloweApp" err
+        Right _ -> info' "MarloweApp stopped successfully."
+      pure $ Left timeoutError
+    Just result -> f result
 
 instance
   ( MonadUnliftAff m
@@ -129,33 +158,39 @@ instance
 
       -- Already fork and await the pending result here, so we don't have to
       -- wait for the caller to run it to update the store.
-      resultFiber <- liftAff $ forkAff do
-        mParams <- awaitContractCreation
-        -- Update the contract's representation in the store to use its
-        -- MarloweParams if successful, or show an error otherwise.
-        unliftAff u case mParams of
-          Left contractError -> do
-            updateStore $ Store.ContractStartFailed newContract contractError
-            pure $ Left $ CreateError contractError
-          Right marloweParams -> do
-            updateStore $ Store.ContractStarted newContract marloweParams
-            pure $ Right marloweParams
+      resultFiber <- liftAff $ forkAff $ withRestartOnTimeout
+        marloweAppId
+        u
+        awaitContractCreation
+        CreateTimeout
+        \mParams ->
+          do
+            -- Update the contract's representation in the store to use its
+            -- MarloweParams if successful, or show an error otherwise.
+            case mParams of
+              Left contractError -> do
+                updateStore $ Store.ContractStartFailed newContract
+                  contractError
+                pure $ Left $ CreateError contractError
+              Right marloweParams -> do
+                updateStore $ Store.ContractStarted newContract
+                  marloweParams
+                pure $ Right marloweParams
 
       pure $ newContract /\ joinFiber resultFiber
 
   -- "apply-inputs" to a Marlowe contract on the blockchain
   applyTransactionInput wallet marloweParams transactionInput = do
     info "Applying input " $ encodeJson { marloweParams, transactionInput }
-    let
-      marloweAppId = view _marloweAppId wallet
-
-      wrapError
-        :: AjaxResponse (Aff (Either MarloweError Unit))
-        -> AjaxResponse (Aff (Either ApplyInputError Unit))
-      wrapError = map $ map $ lmap ApplyInputError
-    MarloweApp.applyInputs marloweAppId marloweParams transactionInput
-      -- We wrap the MarloweError in an Explainable and Debuggable context
-      <#> wrapError
+    u <- askUnliftAff
+    runExceptT do
+      let marloweAppId = view _marloweAppId wallet
+      awaitResult <- ExceptT
+        $ MarloweApp.applyInputs marloweAppId marloweParams transactionInput
+      pure
+        $ withRestartOnTimeout marloweAppId u awaitResult ApplyInputTimeout
+        -- We wrap the MarloweError in an Explainable and Debuggable context
+        $ pure <<< lmap ApplyInputError
 
   -- "redeem" payments from a Marlowe contract on the blockchain
   redeem wallet marloweParams tokenName = do
@@ -166,18 +201,10 @@ instance
       let address = view _address wallet
       awaitResult <- ExceptT
         $ MarloweApp.redeem marloweAppId marloweParams tokenName address
-      pure do
-        mUnit <- awaitResult
-        case mUnit of
-          Left contractError -> do
-            unliftAff u
-              $ addToast
-              $ errorToast "Failed to redeem payment"
-              $ Just
-              $ showContractError contractError
-            throwError $ error $ "Failed to redeem payment: " <>
-              showContractError contractError
-          Right _ -> pure unit
+      pure
+        $ withRestartOnTimeout marloweAppId u awaitResult RedeemTimeout
+        -- We wrap the MarloweError in an Explainable and Debuggable context
+        $ pure <<< lmap RedeemError
 
 instance ManageMarlowe m => ManageMarlowe (HalogenM state action slots msg m) where
   initializeContract currentInstant template params wallet =
@@ -203,20 +230,38 @@ instance ManageMarlowe m => ManageMarlowe (ReaderT r m) where
   redeem walletDetails marloweParams tokenName =
     lift $ redeem walletDetails marloweParams tokenName
 
-newtype ApplyInputError = ApplyInputError MarloweError
+data ApplyInputError = ApplyInputTimeout | ApplyInputError MarloweError
 
 instance Explain ApplyInputError where
   -- TODO: SCP-3340 Convert the MarloweErrors into useful messages
+  explain ApplyInputTimeout = text
+    "The Marlowe control app is not responding. restarting now."
   explain _ = text "There was an unknown problem applying an input"
 
 instance Debuggable ApplyInputError where
   debuggable (ApplyInputError error) = encodeJson error
+  debuggable ApplyInputTimeout = encodeJson "ApplyInputTimeout"
 
-newtype CreateError = CreateError MarloweError
+data RedeemError = RedeemTimeout | RedeemError MarloweError
+
+instance Explain RedeemError where
+  -- TODO: SCP-3340 Convert the MarloweErrors into useful messages
+  explain RedeemTimeout = text
+    "The Marlowe control app is not responding. restarting now."
+  explain _ = text "There was an unknown problem redeeming a payment"
+
+instance Debuggable RedeemError where
+  debuggable (RedeemError error) = encodeJson error
+  debuggable RedeemTimeout = encodeJson "RedeemTimeout"
+
+data CreateError = CreateTimeout | CreateError MarloweError
 
 instance Explain CreateError where
   -- TODO: SCP-3340 Convert the MarloweErrors into useful messages
+  explain CreateTimeout = text
+    "The Marlowe control app is not responding. restarting now."
   explain _ = text "There was an unknown problem creating a contract"
 
 instance Debuggable CreateError where
   debuggable (CreateError error) = encodeJson error
+  debuggable CreateTimeout = encodeJson "CreateTimeout"

--- a/marlowe-dashboard-client/src/Capability/PAB.purs
+++ b/marlowe-dashboard-client/src/Capability/PAB.purs
@@ -1,6 +1,7 @@
 module Capability.PAB
   ( class ManagePAB
   , activateContract
+  , stopContract
   , getWalletContractInstances
   , invokeEndpoint
   , onNewActiveEndpoints
@@ -61,6 +62,7 @@ import Wallet.Emulator.Wallet (Wallet(..))
 class Monad m <= ManagePAB m where
   activateContract
     :: MarloweContract -> WalletId -> m (AjaxResponse PlutusAppId)
+  stopContract :: PlutusAppId -> m (AjaxResponse Unit)
   invokeEndpoint
     :: forall d
      . EncodeJson d
@@ -82,6 +84,7 @@ instance
   , MonadAjax PAB.Api m
   ) =>
   ManagePAB (AppM m) where
+  stopContract = PAB.putApiContractInstanceByContractinstanceidStop
   activateContract contractActivationId wallet =
     PAB.postApiContractActivate
       $ ContractActivationArgs
@@ -175,6 +178,7 @@ sendWsMessage msg = do
   liftEffect $ HS.notify pabWebsocket msg
 
 instance ManagePAB m => ManagePAB (HalogenM state action slots msg m) where
+  stopContract = lift <<< stopContract
   activateContract contractActivationId wallet = lift $ activateContract
     contractActivationId
     wallet
@@ -188,6 +192,7 @@ instance ManagePAB m => ManagePAB (HalogenM state action slots msg m) where
   unsubscribeFromPlutusApp = lift <<< unsubscribeFromPlutusApp
 
 instance ManagePAB m => ManagePAB (MaybeT m) where
+  stopContract = lift <<< stopContract
   activateContract contractActivationId wallet = lift $ activateContract
     contractActivationId
     wallet
@@ -201,6 +206,7 @@ instance ManagePAB m => ManagePAB (MaybeT m) where
   unsubscribeFromPlutusApp = lift <<< unsubscribeFromPlutusApp
 
 instance ManagePAB m => ManagePAB (ReaderT r m) where
+  stopContract = lift <<< stopContract
   activateContract contractActivationId wallet = lift $ activateContract
     contractActivationId
     wallet

--- a/marlowe-dashboard-client/src/Data/Slot.purs
+++ b/marlowe-dashboard-client/src/Data/Slot.purs
@@ -32,6 +32,10 @@ instance BoundedEnum Slot where
     | i < 0 || i >= top = Nothing
     | otherwise = Just $ Slot i
 
+-- There are a few valid semigroup instances that we could choose. We choose
+-- max-based semantics because it is the most convenient and frequently useful
+-- choice whendealing with time series data and absolute times. It allows the
+-- semigroup instance to select the most recent occurrance of an event.
 instance Semigroup Slot where
   append = max
 

--- a/marlowe-dashboard-client/src/Data/Slot.purs
+++ b/marlowe-dashboard-client/src/Data/Slot.purs
@@ -1,0 +1,39 @@
+module Data.Slot
+  ( Slot
+  ) where
+
+import Prologue
+
+import Data.Enum
+  ( class BoundedEnum
+  , class Enum
+  , Cardinality(..)
+  , fromEnum
+  , toEnum
+  )
+
+newtype Slot = Slot Int
+
+derive newtype instance Show Slot
+derive instance Eq Slot
+derive instance Ord Slot
+instance Bounded Slot where
+  bottom = Slot 0
+  top = Slot $ top - 1
+
+instance Enum Slot where
+  pred = toEnum <<< (_ - 1) <<< fromEnum
+  succ = toEnum <<< (_ + 1) <<< fromEnum
+
+instance BoundedEnum Slot where
+  cardinality = Cardinality top
+  fromEnum (Slot i) = i
+  toEnum i
+    | i < 0 || i >= top = Nothing
+    | otherwise = Just $ Slot i
+
+instance Semigroup Slot where
+  append = max
+
+instance Monoid Slot where
+  mempty = bottom

--- a/marlowe-dashboard-client/src/Env.purs
+++ b/marlowe-dashboard-client/src/Env.purs
@@ -10,6 +10,7 @@ import Data.Lens (Lens')
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Newtype (class Newtype)
+import Data.Time.Duration (Minutes)
 import Data.UUID.Argonaut (UUID)
 import Data.Wallet (SyncStatus)
 import Effect.AVar (AVar)
@@ -59,6 +60,7 @@ newtype Env = Env
   , sinks :: Sinks
   -- | All the inbound communication channels from the outside world
   , sources :: Sources
+  , marloweAppTimeout :: Minutes
   }
 
 derive instance newtypeEnv :: Newtype Env _
@@ -71,6 +73,9 @@ _applyInputBus = _Newtype <<< prop (Proxy :: _ "applyInputBus")
 
 _redeemBus :: Lens' Env (EventBus UUID (Either MarloweError Unit))
 _redeemBus = _Newtype <<< prop (Proxy :: _ "redeemBus")
+
+_marloweAppTimeout :: Lens' Env Minutes
+_marloweAppTimeout = _Newtype <<< prop (Proxy :: _ "marloweAppTimeout")
 
 _followerAVarMap :: Lens' Env (AVarMap MarloweParams Unit)
 _followerAVarMap = _Newtype <<< prop (Proxy :: _ "followerAVarMap")

--- a/marlowe-dashboard-client/src/Env.purs
+++ b/marlowe-dashboard-client/src/Env.purs
@@ -10,7 +10,6 @@ import Data.Lens (Lens')
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Newtype (class Newtype)
-import Data.Time.Duration (Minutes)
 import Data.UUID.Argonaut (UUID)
 import Data.Wallet (SyncStatus)
 import Effect.AVar (AVar)
@@ -60,7 +59,8 @@ newtype Env = Env
   , sinks :: Sinks
   -- | All the inbound communication channels from the outside world
   , sources :: Sources
-  , marloweAppTimeout :: Minutes
+  -- | The number of blocks to wait for a reply from the MarloweApp
+  , marloweAppTimeoutBlocks :: Int
   }
 
 derive instance newtypeEnv :: Newtype Env _
@@ -74,8 +74,9 @@ _applyInputBus = _Newtype <<< prop (Proxy :: _ "applyInputBus")
 _redeemBus :: Lens' Env (EventBus UUID (Either MarloweError Unit))
 _redeemBus = _Newtype <<< prop (Proxy :: _ "redeemBus")
 
-_marloweAppTimeout :: Lens' Env Minutes
-_marloweAppTimeout = _Newtype <<< prop (Proxy :: _ "marloweAppTimeout")
+_marloweAppTimeoutBlocks :: Lens' Env Int
+_marloweAppTimeoutBlocks =
+  _Newtype <<< prop (Proxy :: _ "marloweAppTimeoutBlocks")
 
 _followerAVarMap :: Lens' Env (AVarMap MarloweParams Unit)
 _followerAVarMap = _Newtype <<< prop (Proxy :: _ "followerAVarMap")

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -39,7 +39,7 @@ import Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Data.PABConnectedWallet (_walletDetails, _walletId)
 import Data.PaymentPubKeyHash (PaymentPubKeyHash)
-import Data.Time.Duration (Milliseconds(..))
+import Data.Time.Duration (Milliseconds(..), Minutes(..))
 import Data.Wallet
   ( SyncStatus(..)
   , WalletDetails
@@ -113,6 +113,7 @@ mkEnv sources sinks = do
     , redeemBus
     , sinks
     , sources
+    , marloweAppTimeout: Minutes 0.1
     }
 
 exitBadArgs :: forall a. JsonDecodeError -> Effect a

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -113,7 +113,7 @@ mkEnv sources sinks = do
     , redeemBus
     , sinks
     , sources
-    , marloweAppTimeout: Minutes 0.1
+    , marloweAppTimeout: Minutes 3.0
     }
 
 exitBadArgs :: forall a. JsonDecodeError -> Effect a

--- a/marlowe-dashboard-client/src/Main.purs
+++ b/marlowe-dashboard-client/src/Main.purs
@@ -39,7 +39,7 @@ import Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Data.PABConnectedWallet (_walletDetails, _walletId)
 import Data.PaymentPubKeyHash (PaymentPubKeyHash)
-import Data.Time.Duration (Milliseconds(..), Minutes(..))
+import Data.Time.Duration (Milliseconds(..))
 import Data.Wallet
   ( SyncStatus(..)
   , WalletDetails
@@ -113,7 +113,7 @@ mkEnv sources sinks = do
     , redeemBus
     , sinks
     , sources
-    , marloweAppTimeout: Minutes 3.0
+    , marloweAppTimeoutBlocks: 3
     }
 
 exitBadArgs :: forall a. JsonDecodeError -> Effect a

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -7,11 +7,17 @@ import API.Lenses
   , _cicCurrentState
   , _cicDefinition
   , _cicStatus
+  , _hooks
   , _observableState
+  , _rqRequest
   )
 import Capability.Marlowe (class ManageMarlowe)
 import Capability.PAB (class ManagePAB, subscribeToPlutusApp)
-import Capability.PAB (activateContract, getWalletContractInstances) as PAB
+import Capability.PAB
+  ( activateContract
+  , getWalletContractInstances
+  , stopContract
+  ) as PAB
 import Capability.PlutusApps.FollowerApp (class FollowerApp)
 import Capability.Toast (class Toast, addToast)
 import Clipboard (class MonadClipboard)
@@ -28,7 +34,7 @@ import Data.Array (filter, find) as Array
 import Data.Either (hush)
 import Data.Filterable (filterMap)
 import Data.Foldable (for_, traverse_)
-import Data.Lens (assign, lens, preview, set, use, view, (^.))
+import Data.Lens (assign, folded, hasn't, lens, preview, set, use, view, (^.))
 import Data.Lens.Extra (peruse)
 import Data.Maybe (fromMaybe)
 import Data.PABConnectedWallet (_syncStatus, connectWallet)
@@ -317,6 +323,11 @@ activateOrRestorePlutusCompanionContracts
 activateOrRestorePlutusCompanionContracts walletId plutusContracts = runExceptT
   do
     let
+      isHanging contract = case view _cicDefinition contract of
+        MarloweApp -> hasn't
+          (_cicCurrentState <<< _hooks <<< folded <<< _rqRequest)
+          contract
+        _ -> false
       isActiveContract contractType cic =
         let
           definition = view _cicDefinition cic
@@ -330,9 +341,14 @@ activateOrRestorePlutusCompanionContracts walletId plutusContracts = runExceptT
           Nothing ->
             -- If we cannot find it, activate a new one
             ExceptT $ PAB.activateContract contractType walletId
-          Just contract ->
-            -- If we find it, return the id
-            pure $ view _cicContract contract
+          Just contract
+            | not (isHanging contract) ->
+                -- If we find it, and it is not hanging, return the id
+                pure $ view _cicContract contract
+            | otherwise -> do
+                -- If we find it, and it is hanging, stop and restart it.
+                ExceptT $ PAB.stopContract $ view _cicContract contract
+                ExceptT $ PAB.activateContract contractType walletId
     { companionAppId: _, marloweAppId: _ }
       <$> findOrActivateContract WalletCompanion
       <*> findOrActivateContract MarloweApp

--- a/marlowe-dashboard-client/src/MainFrame/State.purs
+++ b/marlowe-dashboard-client/src/MainFrame/State.purs
@@ -261,6 +261,7 @@ enterDashboardState disconnectedWallet = do
   case ajaxPlutusApps of
     Left ajaxError -> do
       globalError "Failed to access the plutus contracts." ajaxError
+      updateStore $ Store.Wallet $ Wallet.OnDisconnected
     Right plutusApps -> do
       -- Get instances of the WalletCompanion and the MarloweApp control app.
       -- We try to reutilize an active plutus contract if possible,
@@ -269,9 +270,11 @@ enterDashboardState disconnectedWallet = do
         walletId
         plutusApps
       case ajaxCompanionContracts of
-        Left ajaxError -> globalError
-          "Failed to create the companion plutus contracts."
-          ajaxError
+        Left ajaxError -> do
+          globalError
+            "Failed to create the companion plutus contracts."
+            ajaxError
+          updateStore $ Store.Wallet $ Wallet.OnDisconnected
         Right { companionAppId, marloweAppId } -> do
           let
             initialFollowers = Set.fromFoldable

--- a/marlowe-dashboard-client/src/Page/Dashboard/State.purs
+++ b/marlowe-dashboard-client/src/Page/Dashboard/State.purs
@@ -14,7 +14,11 @@ import Capability.PAB
   , subscribeToPlutusApp
   , unsubscribeFromPlutusApp
   )
-import Capability.PAB (activateContract, getWalletContractInstances) as PAB
+import Capability.PAB
+  ( activateContract
+  , getWalletContractInstances
+  , subscribeToPlutusApp
+  ) as PAB
 import Capability.PlutusApps.FollowerApp (class FollowerApp, followContract)
 import Capability.PlutusApps.FollowerApp as FollowerApp
 import Capability.Toast (class Toast, addToast)
@@ -618,6 +622,7 @@ reactivatePlutusScript contractType mVal = do
       Logger.info
         ("Plutus script " <> show contractType <> " started.")
         (encodeJson instanceId)
+      PAB.subscribeToPlutusApp instanceId
       updateStore
         $ Store.Wallet
         $ Wallet.OnPlutusScriptChanged contractType instanceId

--- a/marlowe-dashboard-client/src/Page/Dashboard/Types.purs
+++ b/marlowe-dashboard-client/src/Page/Dashboard/Types.purs
@@ -18,6 +18,7 @@ import Data.DateTime.Instant (Instant)
 import Data.Map (Map)
 import Data.NewContract (NewContract)
 import Data.PABConnectedWallet (PABConnectedWallet)
+import Data.Slot as Slot
 import Data.Time.Duration (Minutes)
 import Data.UUID.Argonaut (UUID)
 import Data.UserNamedActions (UserNamedActions)
@@ -146,6 +147,7 @@ data Action
   | NewActiveEndpoints PlutusAppId (Array ActiveEndpoint)
   | MarloweAppClosed (Maybe Json)
   | WalletCompanionAppClosed (Maybe Json)
+  | SlotChanged Slot.Slot
 
 -- | Here we decide which top-level queries to track as GA events, and how to classify them.
 instance actionIsEvent :: IsEvent Action where

--- a/marlowe-dashboard-client/test/Main.purs
+++ b/marlowe-dashboard-client/test/Main.purs
@@ -27,6 +27,7 @@ import Test.Marlowe.Execution as Execution
 import Test.Marlowe.Run.Action.Scenarios.Contract (contractScenarios)
 import Test.Marlowe.Run.Action.Scenarios.Wallet
   ( createAndRestoreWallet
+  , enterDashboardMarloweAppHung
   , multipleCompanionUpdates
   )
 import Test.Spec (Spec, describe, it, parallel)
@@ -62,6 +63,7 @@ testScripts = describe "Scripted scenarios" do
   createAndRestoreWallet
   multipleCompanionUpdates
   contractScenarios
+  enterDashboardMarloweAppHung
 
 -------------------------------------------------------------------------------
 -- Demo tests for purescript-testing-library

--- a/marlowe-dashboard-client/test/Marlowe/Run.purs
+++ b/marlowe-dashboard-client/test/Marlowe/Run.purs
@@ -385,6 +385,7 @@ mkTestEnv = do
       , followerBus
       , sinks
       , sources
+      , marloweAppTimeout: Minutes 3.0
       }
     coenv =
       { pabWebsocketIn: pabWebsocketIn.listener

--- a/marlowe-dashboard-client/test/Marlowe/Run.purs
+++ b/marlowe-dashboard-client/test/Marlowe/Run.purs
@@ -385,7 +385,7 @@ mkTestEnv = do
       , followerBus
       , sinks
       , sources
-      , marloweAppTimeoutBlocks: 1
+      , marloweAppTimeoutBlocks: 2
       }
     coenv =
       { pabWebsocketIn: pabWebsocketIn.listener

--- a/marlowe-dashboard-client/test/Marlowe/Run.purs
+++ b/marlowe-dashboard-client/test/Marlowe/Run.purs
@@ -385,7 +385,7 @@ mkTestEnv = do
       , followerBus
       , sinks
       , sources
-      , marloweAppTimeout: Minutes 3.0
+      , marloweAppTimeoutBlocks: 1
       }
     coenv =
       { pabWebsocketIn: pabWebsocketIn.listener

--- a/marlowe-dashboard-client/test/Marlowe/Run/Commands.purs
+++ b/marlowe-dashboard-client/test/Marlowe/Run/Commands.purs
@@ -424,6 +424,17 @@ handleGetContractInstances walletId = handleHTTPRequest GET uri <<< pure
   where
   uri = "/pab/api/contract/instances/wallet/" <> WI.toString walletId <> "?"
 
+handlePutContractInstanceStop
+  :: forall m
+   . MonadLogger String m
+  => MonadMockHTTP m
+  => UUID
+  -> m Unit
+handlePutContractInstanceStop instanceId =
+  handleHTTPRequest PUT uri $ pure jsonEmptyArray
+  where
+  uri = "/pab/api/contract/instance/" <> UUID.toString instanceId <> "/stop"
+
 handlePostCreate
   :: forall m
    . MonadLogger String m

--- a/marlowe-dashboard-client/test/Marlowe/Run/Flows.purs
+++ b/marlowe-dashboard-client/test/Marlowe/Run/Flows.purs
@@ -191,13 +191,24 @@ restoreWallet walletName contracts = do
     let
       companionContracts =
         contracts ^.. traversed <<< takeBoth _chParams _chInitialData
-      marloweAppInstance =
-        appInstanceActive walletId MarloweApp marloweAppId jsonEmptyArray
+      marloweAppInstance = appInstanceActive
+        marloweAppEndpoints
+        walletId
+        MarloweApp
+        marloweAppId
+        jsonEmptyArray
       walletCompanionInstance =
-        appInstanceActive walletId WalletCompanion walletCompanionId
+        appInstanceActive
+          companionEndpoints
+          walletId
+          WalletCompanion
+          walletCompanionId
           $ walletCompantionState companionContracts
       followerInstances = map
-        (uncurry $ flip $ appInstanceActive walletId MarloweFollower)
+        ( uncurry
+            $ flip
+            $ appInstanceActive followerEndpoints walletId MarloweFollower
+        )
         followerIdsAndHistories
       followerAppIds = Map.fromFoldable
         $ map (lmap $ getMarloweParams) followerIdsAndHistories

--- a/marlowe-dashboard-client/test/Marlowe/Run/Scenarios/Wallet.purs
+++ b/marlowe-dashboard-client/test/Marlowe/Run/Scenarios/Wallet.purs
@@ -49,6 +49,7 @@ import Test.Marlowe.Run.Commands
   , handlePutContractInstanceStop
   , openMyWalletDialog
   , recvInstanceSubscribe
+  , sendContractFinished
   , sendNewActiveEndpoints
   , sendWalletCompanionUpdate
   )
@@ -58,7 +59,7 @@ import Test.Marlowe.Run.Queries
   , getWalletStatus
   )
 import Test.Network.HTTP (expectNoRequest)
-import Test.Spec (Spec, focus)
+import Test.Spec (Spec)
 import Test.Web.DOM.Assertions (shouldHaveText, shouldHaveTextM)
 
 createAndRestoreWallet :: Spec Unit
@@ -175,6 +176,7 @@ enterDashboardMarloweAppHung =
 
       -- Assert
       handlePutContractInstanceStop marloweAppId
+      sendContractFinished marloweAppId
       marloweAppId2 <- generateUUID
       handlePostActivate walletId MarloweApp marloweAppId2
       recvInstanceSubscribe walletCompanionId

--- a/marlowe-dashboard-client/test/Marlowe/Run/Scenarios/Wallet.purs
+++ b/marlowe-dashboard-client/test/Marlowe/Run/Scenarios/Wallet.purs
@@ -3,7 +3,10 @@ module Test.Marlowe.Run.Action.Scenarios.Wallet where
 import Prologue
 
 import Control.Monad.UUID (generateUUID)
+import Data.AddressBook (AddressBook(..))
+import Data.Argonaut (jsonEmptyArray)
 import Data.BigInt.Argonaut as BigInt
+import Data.Bimap as Bimap
 import Data.Map as Map
 import Data.WalletNickname as WN
 import Language.Marlowe.Client (ContractHistory(..))
@@ -14,20 +17,39 @@ import MarloweContract (MarloweContract(..))
 import Plutus.V1.Ledger.Address (Address(..))
 import Plutus.V1.Ledger.Credential (Credential(..))
 import Test.Data.Marlowe
-  ( expectJust
+  ( companionEndpoints
+  , expectJust
   , makeTestWalletNickname
+  , marloweAppEndpoints
   , marloweData
+  , newAddress
   , newMarloweParams
   , newMnemonicPhrase
   , newWalletInfo
   , semanticState
+  , walletCompantionState
   )
-import Test.Marlowe.Run (fundWallet, marloweRunTest)
-import Test.Marlowe.Run.Action.Flows (createWallet, dropWallet, restoreWallet)
+import Test.Data.Plutus (appInstanceActive)
+import Test.Marlowe.Run
+  ( defaultTestParameters
+  , fundWallet
+  , marloweRunTest
+  , marloweRunTestWith
+  , sendWalletFunds
+  )
+import Test.Marlowe.Run.Action.Flows
+  ( createWallet
+  , dropWallet
+  , restoreWallet
+  , restoreWalletWithoutUpdates
+  )
 import Test.Marlowe.Run.Commands
-  ( handlePostActivate
+  ( handleGetContractInstances
+  , handlePostActivate
+  , handlePutContractInstanceStop
   , openMyWalletDialog
   , recvInstanceSubscribe
+  , sendNewActiveEndpoints
   , sendWalletCompanionUpdate
   )
 import Test.Marlowe.Run.Queries
@@ -36,7 +58,7 @@ import Test.Marlowe.Run.Queries
   , getWalletStatus
   )
 import Test.Network.HTTP (expectNoRequest)
-import Test.Spec (Spec)
+import Test.Spec (Spec, focus)
 import Test.Web.DOM.Assertions (shouldHaveText, shouldHaveTextM)
 
 createAndRestoreWallet :: Spec Unit
@@ -121,3 +143,51 @@ multipleCompanionUpdates = marloweRunTest "Receiving multiple companion updates"
 
     --Assert
     expectNoRequest
+
+enterDashboardMarloweAppHung :: Spec Unit
+enterDashboardMarloweAppHung =
+  marloweRunTestWith "MarloweApp hung on entering dashboard" setupWallet
+    do
+      -- Arrange
+      walletNickname <- makeTestWalletNickname nicknameString
+
+      -- Act
+      { walletId } <- restoreWalletWithoutUpdates walletNickname
+
+      walletCompanionId <- generateUUID
+      marloweAppId <- generateUUID
+      let
+        marloweAppInstance = appInstanceActive
+          []
+          walletId
+          MarloweApp
+          marloweAppId
+          jsonEmptyArray
+        walletCompanionInstance =
+          appInstanceActive
+            companionEndpoints
+            walletId
+            WalletCompanion
+            walletCompanionId
+            $ walletCompantionState Map.empty
+        instances = [ marloweAppInstance, walletCompanionInstance ]
+      handleGetContractInstances walletId instances
+
+      -- Assert
+      handlePutContractInstanceStop marloweAppId
+      marloweAppId2 <- generateUUID
+      handlePostActivate walletId MarloweApp marloweAppId2
+      recvInstanceSubscribe walletCompanionId
+      sendNewActiveEndpoints walletCompanionId companionEndpoints
+      recvInstanceSubscribe marloweAppId2
+      sendNewActiveEndpoints marloweAppId2 marloweAppEndpoints
+      sendWalletCompanionUpdate walletCompanionId Map.empty
+      sendWalletFunds walletNickname
+  where
+  nicknameString = "Wallet"
+  setupWallet = do
+    nickname <- makeTestWalletNickname nicknameString
+    address <- newAddress
+    pure $ defaultTestParameters
+      { addressBook = AddressBook $ Bimap.singleton nickname address
+      }

--- a/marlowe-dashboard-client/test/Marlowe/Run/Scenarios/Wallet.purs
+++ b/marlowe-dashboard-client/test/Marlowe/Run/Scenarios/Wallet.purs
@@ -102,8 +102,8 @@ createAndRestoreWallet = marloweRunTest "Create and Restore Wallet" do
   dropWallet walletInfo
 
 multipleCompanionUpdates :: Spec Unit
-multipleCompanionUpdates = marloweRunTest "Receiving multiple companion updates"
-  do
+multipleCompanionUpdates =
+  marloweRunTest "Receiving multiple companion updates" do
     -- Arrange
     walletNickname <- makeTestWalletNickname "Wallet1"
     mnemonic <- newMnemonicPhrase
@@ -147,44 +147,43 @@ multipleCompanionUpdates = marloweRunTest "Receiving multiple companion updates"
 
 enterDashboardMarloweAppHung :: Spec Unit
 enterDashboardMarloweAppHung =
-  marloweRunTestWith "MarloweApp hung on entering dashboard" setupWallet
-    do
-      -- Arrange
-      walletNickname <- makeTestWalletNickname nicknameString
+  marloweRunTestWith "MarloweApp hung on entering dashboard" setupWallet do
+    -- Arrange
+    walletNickname <- makeTestWalletNickname nicknameString
 
-      -- Act
-      { walletId } <- restoreWalletWithoutUpdates walletNickname
+    -- Act
+    { walletId } <- restoreWalletWithoutUpdates walletNickname
 
-      walletCompanionId <- generateUUID
-      marloweAppId <- generateUUID
-      let
-        marloweAppInstance = appInstanceActive
-          []
+    walletCompanionId <- generateUUID
+    marloweAppId <- generateUUID
+    let
+      marloweAppInstance = appInstanceActive
+        []
+        walletId
+        MarloweApp
+        marloweAppId
+        jsonEmptyArray
+      walletCompanionInstance =
+        appInstanceActive
+          companionEndpoints
           walletId
-          MarloweApp
-          marloweAppId
-          jsonEmptyArray
-        walletCompanionInstance =
-          appInstanceActive
-            companionEndpoints
-            walletId
-            WalletCompanion
-            walletCompanionId
-            $ walletCompantionState Map.empty
-        instances = [ marloweAppInstance, walletCompanionInstance ]
-      handleGetContractInstances walletId instances
+          WalletCompanion
+          walletCompanionId
+          $ walletCompantionState Map.empty
+      instances = [ marloweAppInstance, walletCompanionInstance ]
+    handleGetContractInstances walletId instances
 
-      -- Assert
-      handlePutContractInstanceStop marloweAppId
-      sendContractFinished marloweAppId
-      marloweAppId2 <- generateUUID
-      handlePostActivate walletId MarloweApp marloweAppId2
-      recvInstanceSubscribe walletCompanionId
-      sendNewActiveEndpoints walletCompanionId companionEndpoints
-      recvInstanceSubscribe marloweAppId2
-      sendNewActiveEndpoints marloweAppId2 marloweAppEndpoints
-      sendWalletCompanionUpdate walletCompanionId Map.empty
-      sendWalletFunds walletNickname
+    -- Assert
+    handlePutContractInstanceStop marloweAppId
+    sendContractFinished marloweAppId
+    marloweAppId2 <- generateUUID
+    handlePostActivate walletId MarloweApp marloweAppId2
+    recvInstanceSubscribe walletCompanionId
+    sendNewActiveEndpoints walletCompanionId companionEndpoints
+    recvInstanceSubscribe marloweAppId2
+    sendNewActiveEndpoints marloweAppId2 marloweAppEndpoints
+    sendWalletCompanionUpdate walletCompanionId Map.empty
+    sendWalletFunds walletNickname
   where
   nicknameString = "Wallet"
   setupWallet = do

--- a/marlowe-dashboard-client/test/Network/HTTP.purs
+++ b/marlowe-dashboard-client/test/Network/HTTP.purs
@@ -101,14 +101,7 @@ import Effect.Aff.Unlift (class MonadUnliftAff)
 import Effect.Class (class MonadEffect)
 import Effect.Unlift (class MonadUnliftEffect)
 import Halogen.Store.Monad (class MonadStore)
-import Servant.PureScript
-  ( class MonadAjax
-  , AjaxError(..)
-  , ErrorDescription(..)
-  , prepareRequest
-  , prepareResponse
-  , printAjaxError
-  )
+import Servant.PureScript (class MonadAjax, prepareRequest, prepareResponse)
 import Test.Assertions (jsonDiffString)
 import Test.Data.Argonaut.Extra (bigIntEq)
 import Test.Halogen (class MonadHalogenTest)
@@ -211,13 +204,7 @@ instance MonadAff m => MonadAjax api (MockHttpM m) where
       let aReq = prepareRequest req
       Queue.write requests $ RequestBox \next -> next aReq responseA
       response <- AVar.take responseA
-      case prepareResponse req.decode aReq response of
-        Left e@(AjaxError { description: MalformedContent _ }) ->
-          throwError $ error $ joinWith "\n"
-            [ "Failed to decode HTTP response:"
-            , printAjaxError e
-            ]
-        x -> pure x
+      pure $ prepareResponse req.decode aReq response
 
 instance MonadKill e f m => MonadKill e f (MockHttpM m) where
   kill e = lift <<< kill e


### PR DESCRIPTION
Changes:

- Kill and restart MarloweApp after 3 ~minute~ block timeout (blocks are counted by the number of `SlotChange` messages we get from the PAB, ignoring any smaller slots than previously seen, e.g. when the PAB hits a rollback).
- Kill and restart MarloweApp on startup if it has no available endpoints