### PR TITLE
[Draft] Universal Marlowe Script: combine Validator and MintingPolicy in a single script

### DIFF
--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -179,6 +179,7 @@ test-suite marlowe-test
         template-haskell -any,
         streaming -any,
         plutus-pab -any,
+        plutus-core,
         async -any,
         prettyprinter -any,
         purescript-bridge -any,

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -258,7 +258,7 @@ type MarloweContractState = Maybe MarloweEndpointResponse
 
 
 mkMarloweTypedValidator :: MarloweParams -> SmallTypedValidator
-mkMarloweTypedValidator = universalMarloweValidator
+mkMarloweTypedValidator = smallUntypedValidator
 
 
 minLovelaceDeposit :: Integer
@@ -693,7 +693,9 @@ applyInputs params typedValidator timeInterval inputs = mapError (review _Marlow
 marloweParams :: CurrencySymbol -> MarloweParams
 marloweParams rolesCurrency = MarloweParams
     { rolesCurrency = rolesCurrency
-    , rolePayoutValidatorHash = mkRolePayoutValidatorHash rolesCurrency}
+    , rolePayoutValidatorHash = mkRolePayoutValidatorHash rolesCurrency
+    , uniqueTxOutRef = ("", 0)
+    }
 
 
 defaultMarloweParams :: MarloweParams

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -258,7 +258,7 @@ type MarloweContractState = Maybe MarloweEndpointResponse
 
 
 mkMarloweTypedValidator :: MarloweParams -> SmallTypedValidator
-mkMarloweTypedValidator = smallUntypedValidator
+mkMarloweTypedValidator = universalMarloweValidator
 
 
 minLovelaceDeposit :: Integer

--- a/marlowe/src/Language/Marlowe/Client/History.hs
+++ b/marlowe/src/Language/Marlowe/Client/History.hs
@@ -44,7 +44,7 @@ import Data.List (nub)
 import Data.Maybe (catMaybes, isJust, isNothing, mapMaybe)
 import Data.Tuple.Extra (secondM)
 import GHC.Generics (Generic)
-import Language.Marlowe.Scripts (SmallTypedValidator, TypedMarloweValidator, smallUntypedValidator)
+import Language.Marlowe.Scripts (SmallTypedValidator, TypedMarloweValidator, mkRolesCurrency, smallUntypedValidator)
 import Language.Marlowe.Semantics (MarloweData, MarloweParams (..), TransactionInput (TransactionInput))
 import Ledger (ChainIndexTxOut (..), ciTxOutAddress, toTxOut)
 import Ledger.TimeSlot (slotRangeToPOSIXTimeRange)
@@ -281,8 +281,9 @@ creationTxOut :: MarloweParams          -- ^ The Marlowe validator parameters.
               -> Address                -- ^ The Marlowe validator address.
               -> ChainIndexTx           -- ^ The transaction to be checked.
               -> Maybe MarloweTxOutRef  -- ^ The creation-transaction output and the contract, if any.
-creationTxOut MarloweParams{..} address citx =
+creationTxOut params address citx =
   do
+    let rolesCurrency = mkRolesCurrency params
     -- Ensure that the transaction minted the role currency.
     guard
       . elem (ScriptHash $ unCurrencySymbol rolesCurrency)

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -108,168 +108,13 @@ defaultRolePayoutValidatorHash = mkRolePayoutValidatorHash adaSymbol
 {-# INLINABLE smallMarloweValidator #-}
 smallMarloweValidator
     :: MarloweParams
-    -> MarloweData
-    -> MarloweInput
-    -> ScriptContext
-    -> Bool
-smallMarloweValidator MarloweParams{rolesCurrency, rolePayoutValidatorHash}
-    MarloweData{..}
-    marloweTxInputs
-    ctx@ScriptContext{scriptContextTxInfo} = do
-
-    let scriptInValue = txOutValue $ txInInfoResolved ownInput
-    let interval =
-            case txInfoValidRange scriptContextTxInfo of
-                -- FIXME: Recheck this, but it appears that any inclusiveness can appear at either bound when milliseconds
-                --        of POSIX time is converted from slot number.
-                Interval.Interval (Interval.LowerBound (Interval.Finite l) _) (Interval.UpperBound (Interval.Finite h) _) -> (l, h)
-                _ -> traceError "R0"
-    let positiveBalances = traceIfFalse "B0" $ validateBalances marloweState
-
-    {- Find Contract continuation in TxInfo datums by hash or fail with error -}
-    let inputs = fmap marloweTxInputToInput marloweTxInputs
-    {-  We do not check that a transaction contains exact input payments.
-        We only require an evidence from a party, e.g. a signature for PubKey party,
-        or a spend of a 'party role' token.
-        This gives huge flexibility by allowing parties to provide multiple
-        inputs (either other contracts or P2PKH).
-        Then, we check scriptOutput to be correct.
-     -}
-    let inputsOk = validateInputs inputs
-
-    -- total balance of all accounts in State
-    -- accounts must be positive, and we checked it above
-    let inputBalance = totalBalance (accounts marloweState)
-
-    -- ensure that a contract TxOut has what it suppose to have
-    let balancesOk = traceIfFalse "B1" $ inputBalance == scriptInValue
-
-    let preconditionsOk = positiveBalances && balancesOk
-
-    let txInput = TransactionInput {
-            txInterval = interval,
-            txInputs = inputs }
-
-    let computedResult = computeTransaction txInput marloweState marloweContract
-    -- let computedResult = TransactionOutput [] [] (emptyState minSlot) Close
-    case computedResult of
-        TransactionOutput {txOutPayments, txOutState, txOutContract} -> do
-            let marloweData = MarloweData {
-                    marloweContract = txOutContract,
-                    marloweState = txOutState }
-
-                payoutsByParty = AssocMap.toList $ foldMap payoutByParty txOutPayments
-                payoutsOk = payoutConstraints payoutsByParty
-                checkContinuation = case txOutContract of
-                    Close -> True
-                    _ -> let
-                        totalIncome = foldMap (collectDeposits . getInputContent) inputs
-                        totalPayouts = foldMap snd payoutsByParty
-                        finalBalance = inputBalance + totalIncome - totalPayouts
-                        in checkOwnOutputConstraint marloweData finalBalance
-            preconditionsOk && inputsOk && payoutsOk && checkContinuation
-        Error TEAmbiguousTimeIntervalError -> traceError "E1"
-        Error TEApplyNoMatchError -> traceError "E2"
-        Error (TEIntervalError (InvalidInterval _)) -> traceError "E3"
-        Error (TEIntervalError (IntervalInPastError _ _)) -> traceError "E4"
-        Error TEUselessTransaction -> traceError "E5"
-        Error TEHashMismatch -> traceError "E6"
-
-  where
-    findOwnInput :: ScriptContext -> Maybe TxInInfo
-    findOwnInput ScriptContext{scriptContextTxInfo=TxInfo{txInfoInputs}, scriptContextPurpose=Spending txOutRef} =
-        find (\TxInInfo{txInInfoOutRef} -> txInInfoOutRef == txOutRef) txInfoInputs
-    findOwnInput _ = Nothing
-
-    ownInput :: TxInInfo
-    ownInput@TxInInfo{txInInfoResolved=TxOut{txOutAddress=ownAddress}} =
-        case findOwnInput ctx of
-            Just ownTxInInfo ->
-                case filter (sameValidatorHash ownTxInInfo) (txInfoInputs scriptContextTxInfo) of
-                    [i] -> i
-                    _   -> traceError "I1" -- multiple Marlowe contract inputs with the same address, it's forbidden
-            _ -> traceError "I0" {-"Can't find validation input"-}
-
-    sameValidatorHash:: TxInInfo -> TxInInfo -> Bool
-    sameValidatorHash
-        TxInInfo{txInInfoResolved=TxOut{txOutAddress=Address (ScriptCredential vh1) _}}
-        TxInInfo{txInInfoResolved=TxOut{txOutAddress=Address (ScriptCredential vh2) _}} = vh1 == vh2
-    sameValidatorHash _ _ = False
-
-
-    findDatumHash' :: PlutusTx.ToData o => o -> Maybe DatumHash
-    findDatumHash' datum = findDatumHash (Datum $ PlutusTx.toBuiltinData datum) scriptContextTxInfo
-
-    checkOwnOutputConstraint :: MarloweData -> Val.Value -> Bool
-    checkOwnOutputConstraint ocDatum ocValue =
-        let hsh = findDatumHash' ocDatum
-        in traceIfFalse "L1" -- "Output constraint"
-        $ checkScriptOutput ownAddress hsh ocValue getContinuingOutput
-
-    getContinuingOutput :: TxOut
-    getContinuingOutput = case filter (\TxOut{txOutAddress} -> ownAddress == txOutAddress) allOutputs of
-        [out] -> out
-        _     -> traceError "O0" -- no continuation or multiple Marlowe contract outputs, it's forbidden
-
-    checkScriptOutput addr hsh value TxOut{txOutAddress, txOutValue, txOutDatumHash=Just svh} =
-                    txOutValue == value && hsh == Just svh && txOutAddress == addr
-    checkScriptOutput _ _ _ _ = False
-
-    allOutputs :: [TxOut]
-    allOutputs = txInfoOutputs scriptContextTxInfo
-
-    marloweTxInputToInput :: MarloweTxInput -> Input
-    marloweTxInputToInput (MerkleizedTxInput input hash) =
-        case findDatum (DatumHash hash) scriptContextTxInfo of
-            Just (Datum d) -> let
-                continuation = PlutusTx.unsafeFromBuiltinData d
-                in MerkleizedInput input hash continuation
-            Nothing -> traceError "H"
-    marloweTxInputToInput (Input input) = NormalInput input
-
-    validateInputs :: [Input] -> Bool
-    validateInputs inputs = all (validateInputWitness . getInputContent) inputs
-      where
-        validateInputWitness :: InputContent -> Bool
-        validateInputWitness input =
-            case input of
-                IDeposit _ party _ _         -> validatePartyWitness party
-                IChoice (ChoiceId _ party) _ -> validatePartyWitness party
-                INotify                      -> True
-          where
-            validatePartyWitness (PK pk)     = traceIfFalse "S" $ scriptContextTxInfo `txSignedBy` pk
-            validatePartyWitness (Role role) = traceIfFalse "T" -- "Spent value not OK"
-                                               $ Val.singleton rolesCurrency role 1 `Val.leq` valueSpent scriptContextTxInfo
-
-    collectDeposits :: InputContent -> Val.Value
-    collectDeposits (IDeposit _ _ (Token cur tok) amount) = Val.singleton cur tok amount
-    collectDeposits _                                     = zero
-
-    payoutByParty :: Payment -> AssocMap.Map Party Val.Value
-    payoutByParty (Payment _ (Party party) money) = AssocMap.singleton party money
-    payoutByParty (Payment _ (Account _) _)       = AssocMap.empty
-
-    payoutConstraints :: [(Party, Val.Value)] -> Bool
-    payoutConstraints payoutsByParty = all payoutToTxOut payoutsByParty
-      where
-        payoutToTxOut (party, value) = case party of
-            PK pk  -> traceIfFalse "P" $ value `Val.leq` valuePaidTo scriptContextTxInfo pk
-            Role role -> let
-                hsh = findDatumHash' role
-                addr = Ledger.scriptHashAddress rolePayoutValidatorHash
-                in traceIfFalse "R" $ any (checkScriptOutput addr hsh value) allOutputs
-
-
-{-# INLINABLE smallMarloweValidator2 #-}
-smallMarloweValidator2
-    :: MarloweParams
     -> (BuiltinData -> Contract)
     -> (BuiltinData -> ScriptContext)
     -> MarloweData
     -> MarloweInput
     -> BuiltinData
     -> ()
-smallMarloweValidator2 MarloweParams{rolesCurrency, rolePayoutValidatorHash}
+smallMarloweValidator MarloweParams{rolesCurrency, rolePayoutValidatorHash}
     fromDataToContract
     fromDataToScriptContext
     MarloweData{..}
@@ -423,18 +268,10 @@ smallMarloweValidator2 MarloweParams{rolesCurrency, rolePayoutValidatorHash}
         Error TEHashMismatch -> traceError "E6"
 
 
-smallTypedValidator :: MarloweParams -> Scripts.TypedValidator TypedMarloweValidator
-smallTypedValidator = Scripts.mkTypedValidatorParam @TypedMarloweValidator
-    $$(PlutusTx.compile [|| smallMarloweValidator ||])
-    $$(PlutusTx.compile [|| wrap ||])
-    where
-        wrap = Scripts.wrapValidator
-
-
 smallUntypedValidator :: MarloweParams -> Scripts.TypedValidator TypedMarloweValidator
 smallUntypedValidator params = let
     -- wrapped s = Scripts.wrapValidator (smallMarloweValidator s)
-    wrapped s = asdf3 (smallMarloweValidator2 s)
+    wrapped s = asdf3 (smallMarloweValidator s)
     typed = mkValidatorScript ($$(PlutusTx.compile [|| wrapped ||]) `PlutusTx.applyCode` PlutusTx.liftCode params)
     -- Yeah, I know. It works, though.
     -- Remove this when Typed Validator has the same size as untyped.
@@ -443,7 +280,7 @@ smallUntypedValidator params = let
 smallUntypedValidatorScript2 :: MarloweParams -> Scripts.Script
 smallUntypedValidatorScript2 params = Scripts.fromCompiledCode code
   where
-    code = ($$(PlutusTx.compile [|| smallMarloweValidator2 ||]) `PlutusTx.applyCode` PlutusTx.liftCode params)
+    code = ($$(PlutusTx.compile [|| smallMarloweValidator ||]) `PlutusTx.applyCode` PlutusTx.liftCode params)
 
 
 
@@ -458,7 +295,7 @@ wrapper1 = Scripts.fromCompiledCode $$(PlutusTx.compile [|| wrapped ||])
     --   typed = mkValidatorScript ($$(PlutusTx.compile [|| wrapped ||]) `PlutusTx.applyCode` PlutusTx.liftCode params)
 
 
-unwrapped1 = Scripts.fromCompiledCode $$(PlutusTx.compile [|| smallMarloweValidator2 ||])
+unwrapped1 = Scripts.fromCompiledCode $$(PlutusTx.compile [|| smallMarloweValidator ||])
 
 
 applyScript :: Script -> Script -> Script

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -211,7 +211,6 @@ data MarloweData = MarloweData {
 
 data MarloweParams = MarloweParams {
         rolePayoutValidatorHash :: ValidatorHash,
-        rolesCurrency           :: CurrencySymbol,
         uniqueTxOutRef          :: (TxId, Integer)
     }
   deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -56,7 +56,7 @@ import Language.Marlowe.SemanticsTypes (AccountId, Accounts, Action (..), Case (
                                         Input (..), InputContent (..), IntervalError (..), IntervalResult (..), Money,
                                         Observation (..), Party, Payee (..), State (..), TimeInterval, Token (..),
                                         Value (..), ValueId, emptyState, getAction, getInputContent, inBounds)
-import Ledger (POSIXTime (..), ValidatorHash)
+import Ledger (POSIXTime (..), TxId, ValidatorHash)
 import Ledger.Value (CurrencySymbol (..))
 import qualified Ledger.Value as Val
 import PlutusTx (makeIsDataIndexed)
@@ -211,7 +211,8 @@ data MarloweData = MarloweData {
 
 data MarloweParams = MarloweParams {
         rolePayoutValidatorHash :: ValidatorHash,
-        rolesCurrency           :: CurrencySymbol
+        rolesCurrency           :: CurrencySymbol,
+        uniqueTxOutRef          :: (TxId, Integer)
     }
   deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (FromJSON,ToJSON)

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -46,7 +46,7 @@ import qualified Language.Marlowe as M ((%))
 import Language.Marlowe.Analysis.FSSemantics
 import Language.Marlowe.Client
 import Language.Marlowe.Scripts (MarloweInput, marloweMPS, rolePayoutScript, smallTypedValidator, smallUntypedValidator,
-                                 universalMarloweScript)
+                                 universalMarloweScript, unwrapped1, wrapper1)
 import Language.Marlowe.Semantics
 import Language.Marlowe.SemanticsTypes
 import Language.Marlowe.Util
@@ -367,11 +367,17 @@ untypedValidatorSize = do
     let validator = Scripts.validatorScript $ smallUntypedValidator defaultMarloweParams
     let validator2 = universalMarloweScript defaultMarloweParams
     let Script plc = marloweMPS
+    let Script wpr = wrapper1
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
     let vsize2 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator2
     let vsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise marloweMPS
-    print $ prettyPlcReadableDebug plc
+    let wsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise wrapper1
+    let wsize4 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise unwrapped1
+    -- print $ prettyPlcReadableDebug plc
+    print $ prettyPlcReadableDebug wpr
     putStrLn $ "smallUntypedValidator " <> show vsize <> ", universalMarloweScript " <> show vsize2 <> ", marloweMPS " <> show vsize3
+    print wsize3
+    print wsize4
     assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 15200)
 
 extractContractRolesTest :: IO ()

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -45,11 +45,12 @@ import Language.Haskell.Interpreter (Extension (OverloadedStrings), MonadInterpr
 import qualified Language.Marlowe as M ((%))
 import Language.Marlowe.Analysis.FSSemantics
 import Language.Marlowe.Client
-import Language.Marlowe.Scripts (MarloweInput, rolePayoutScript, smallTypedValidator, smallUntypedValidator)
+import Language.Marlowe.Scripts (MarloweInput, marloweMPS, rolePayoutScript, smallTypedValidator, smallUntypedValidator,
+                                 universalMarloweScript)
 import Language.Marlowe.Semantics
 import Language.Marlowe.SemanticsTypes
 import Language.Marlowe.Util
-import Ledger (POSIXTime (..), PaymentPubKeyHash (..), PubKeyHash (..), pubKeyHash, validatorHash)
+import Ledger (POSIXTime (..), PaymentPubKeyHash (..), PubKeyHash (..), Script (..), pubKeyHash, validatorHash)
 import Ledger.Ada (adaValueOf, lovelaceValueOf)
 import Ledger.Constraints.TxConstraints (TxConstraints)
 import Ledger.TimeSlot (SlotConfig (..))
@@ -61,6 +62,7 @@ import qualified Plutus.Contract.Test as T
 import Plutus.Contract.Types (_observableState)
 import qualified Plutus.Trace.Emulator as Trace
 import Plutus.Trace.Emulator.Types (instContractState)
+import PlutusCore.Pretty
 import qualified PlutusTx.AssocMap as AssocMap
 import PlutusTx.Builtins (emptyByteString, sha2_256)
 import PlutusTx.Lattice
@@ -363,7 +365,13 @@ typedValidatorSize = do
 untypedValidatorSize :: IO ()
 untypedValidatorSize = do
     let validator = Scripts.validatorScript $ smallUntypedValidator defaultMarloweParams
+    let validator2 = universalMarloweScript defaultMarloweParams
+    let Script plc = marloweMPS
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
+    let vsize2 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator2
+    let vsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise marloweMPS
+    print $ prettyPlcReadableDebug plc
+    putStrLn $ "smallUntypedValidator " <> show vsize <> ", universalMarloweScript " <> show vsize2 <> ", marloweMPS " <> show vsize3
     assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 15200)
 
 extractContractRolesTest :: IO ()

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -45,7 +45,7 @@ import Language.Haskell.Interpreter (Extension (OverloadedStrings), MonadInterpr
 import qualified Language.Marlowe as M ((%))
 import Language.Marlowe.Analysis.FSSemantics
 import Language.Marlowe.Client
-import Language.Marlowe.Scripts (MarloweInput, marloweMPS, rolePayoutScript, smallTypedValidator, smallUntypedValidator,
+import Language.Marlowe.Scripts (MarloweInput, marloweMPS, rolePayoutScript, smallUntypedValidator,
                                  universalMarloweScript, unwrapped1, wrapper1)
 import Language.Marlowe.Semantics
 import Language.Marlowe.SemanticsTypes
@@ -87,8 +87,7 @@ tests = testGroup "Marlowe"
     , testCase "State serializes into valid JSON" stateSerialization
     , testCase "Input serializes into valid JSON" inputSerialization
     , testGroup "Validator size is reasonable"
-        [ testCase "Typed validator size" typedValidatorSize
-        , testCase "Untyped validator size" untypedValidatorSize
+        [ testCase "Untyped validator size" untypedValidatorSize
         ]
     , testCase "Mul analysis" mulAnalysisTest
     , testCase "Div analysis" divAnalysisTest
@@ -350,17 +349,12 @@ trustFundTest = checkPredicateOptions defaultCheckOptions "Trust Fund Contract"
 
 uniqueContractHash :: IO ()
 uniqueContractHash = do
-    let hash1 = Scripts.validatorHash $ smallTypedValidator (marloweParams "11")
-    let hash2 = Scripts.validatorHash $ smallTypedValidator (marloweParams "22")
-    let hash3 = Scripts.validatorHash $ smallTypedValidator (marloweParams "22")
+    let hash1 = Scripts.validatorHash $ smallUntypedValidator (marloweParams "11")
+    let hash2 = Scripts.validatorHash $ smallUntypedValidator (marloweParams "22")
+    let hash3 = Scripts.validatorHash $ smallUntypedValidator (marloweParams "22")
     assertBool "Hashes must be different" (hash1 /= hash2)
     assertBool "Hashes must be same" (hash2 == hash3)
 
-typedValidatorSize :: IO ()
-typedValidatorSize = do
-    let validator = Scripts.validatorScript $ smallTypedValidator defaultMarloweParams
-    let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    assertBool ("smallTypedValidator is too large " <> show vsize) (vsize < 17200)
 
 untypedValidatorSize :: IO ()
 untypedValidatorSize = do

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -45,8 +45,8 @@ import Language.Haskell.Interpreter (Extension (OverloadedStrings), MonadInterpr
 import qualified Language.Marlowe as M ((%))
 import Language.Marlowe.Analysis.FSSemantics
 import Language.Marlowe.Client
-import Language.Marlowe.Scripts (MarloweInput, marloweMPS, rolePayoutScript, smallUntypedValidator,
-                                 universalMarloweScript, unwrapped1, wrapper1)
+import Language.Marlowe.Scripts (MarloweInput, marloweMPS, mkRolesCurrency, rolePayoutScript, smallUntypedValidator,
+                                 universalMarloweScript)
 import Language.Marlowe.Semantics
 import Language.Marlowe.SemanticsTypes
 import Language.Marlowe.Util
@@ -261,8 +261,8 @@ trustFundTest = checkPredicateOptions defaultCheckOptions "Trust Fund Contract"
     -- T..&&. emulatorLog (const False) ""
     T..&&. assertNotDone marlowePlutusContract (Trace.walletInstanceTag alice) "contract should not have any errors"
     T..&&. assertNotDone marlowePlutusContract (Trace.walletInstanceTag bob) "contract should not have any errors"
-    T..&&. walletFundsChange alice (lovelaceValueOf (-minAda-25_600_000) <> Val.singleton (rolesCurrency params) "alice" 1)
-    T..&&. walletFundsChange bob (lovelaceValueOf (minAda+25_600_000) <> Val.singleton (rolesCurrency params) "bob" 1)
+    T..&&. walletFundsChange alice (lovelaceValueOf (-minAda-25_600_000) <> Val.singleton (mkRolesCurrency params) "alice" 1)
+    T..&&. walletFundsChange bob (lovelaceValueOf (minAda+25_600_000) <> Val.singleton (mkRolesCurrency params) "bob" 1)
     -- TODO Commented out because the new chain index does not allow to fetch
     -- all transactions that modified an address. Need to find an alternative
     -- way.
@@ -361,17 +361,12 @@ untypedValidatorSize = do
     let validator = Scripts.validatorScript $ smallUntypedValidator defaultMarloweParams
     let validator2 = universalMarloweScript defaultMarloweParams
     let Script plc = marloweMPS defaultMarloweParams
-    let Script wpr = wrapper1
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
     let vsize2 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator2
     let vsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise (marloweMPS defaultMarloweParams)
-    let wsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise wrapper1
-    let wsize4 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise unwrapped1
     -- print $ prettyPlcReadableDebug plc
     -- print $ prettyPlcReadableDebug wpr
     putStrLn $ "smallUntypedValidator " <> show vsize <> ", universalMarloweScript " <> show vsize2 <> ", marloweMPS " <> show vsize3
-    print wsize3
-    print wsize4
     assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 15200)
 
 extractContractRolesTest :: IO ()

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -374,7 +374,7 @@ untypedValidatorSize = do
     let wsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise wrapper1
     let wsize4 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise unwrapped1
     -- print $ prettyPlcReadableDebug plc
-    print $ prettyPlcReadableDebug wpr
+    -- print $ prettyPlcReadableDebug wpr
     putStrLn $ "smallUntypedValidator " <> show vsize <> ", universalMarloweScript " <> show vsize2 <> ", marloweMPS " <> show vsize3
     print wsize3
     print wsize4

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -366,11 +366,11 @@ untypedValidatorSize :: IO ()
 untypedValidatorSize = do
     let validator = Scripts.validatorScript $ smallUntypedValidator defaultMarloweParams
     let validator2 = universalMarloweScript defaultMarloweParams
-    let Script plc = marloweMPS
+    let Script plc = marloweMPS defaultMarloweParams
     let Script wpr = wrapper1
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
     let vsize2 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator2
-    let vsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise marloweMPS
+    let vsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise (marloweMPS defaultMarloweParams)
     let wsize3 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise wrapper1
     let wsize4 = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise unwrapped1
     -- print $ prettyPlcReadableDebug plc


### PR DESCRIPTION
PoC of an idea to combine validator and mintingPolicy in a single script.

It's possible to produce a script that can be run in both Validation and Minting contexts.
In such a case we can mint Marlowe role tokens and ensure we created a Marlowe contract that uses these tokens within the same transaction. Thus, we can guarantee that no one can reuse the same tokens for different Marlowe contracts produced this way.

The thing is that tokens' `CurrencySymbol == ValidatorHash`, and we can check during minting that the Tx contains a script TxOut with `ValidatorHash == CurrencySymbol`.