### PR TITLE
SCP-3585 transaction log improvements

### DIFF
--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -734,6 +734,7 @@ lintValue env t@(Term (DivValue a b) pos) = do
     (ConstantSimp _ _ v1 /\ ConstantSimp _ _ v2) ->
       let
         evaluated = evalValue
+          -- TODO: SCP-3887 unify time construct
           (makeEnvironment (POSIXTime unixEpoch) (POSIXTime unixEpoch))
           emptyState
           (S.DivValue (S.Constant v1) (S.Constant v2))

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -33,6 +33,7 @@ import Data.Set (Set)
 import Data.Set as Set
 import Data.Set.Ordered.OSet as OSet
 import Data.Tuple.Nested (type (/\), (/\))
+import Humanize (humanizeValue)
 import Marlowe.Extended as EM
 import Marlowe.Extended.Metadata
   ( MetadataHintInfo
@@ -67,7 +68,7 @@ import Marlowe.Semantics as S
 import Marlowe.Time (unixEpoch)
 import Monaco (TextEdit)
 import Plutus.V1.Ledger.Time (POSIXTime(..))
-import Pretty (showPrettyMoney, showPrettyParty, showPrettyToken)
+import Pretty (showPrettyParty)
 import StaticAnalysis.Reachability (initializePrefixMap, stepPrefixMap)
 import StaticAnalysis.Types (ContractPath, ContractPathStep(..), PrefixMap)
 import Text.Pretty (hasArgs, pretty)
@@ -146,13 +147,12 @@ instance showWarningDetail :: Show WarningDetail where
   show (PayBeforeDeposit account) = "The contract makes a payment from account "
     <> showPrettyParty account
     <> " before a deposit has been made"
-  show (PartialPayment accountId tokenId availableAmount demandedAmount) =
-    "The contract makes a payment of " <> showPrettyMoney demandedAmount <> " "
-      <> showPrettyToken tokenId
+  show (PartialPayment accountId token availableAmount demandedAmount) =
+    "The contract makes a payment of " <> humanizeValue token demandedAmount
       <> " from account "
       <> showPrettyParty accountId
       <> " but the account only has "
-      <> showPrettyMoney availableAmount
+      <> humanizeValue token availableAmount
 
 derive instance genericWarningDetail :: Generic WarningDetail _
 

--- a/marlowe-playground-client/src/Marlowe/ViewPartials.purs
+++ b/marlowe-playground-client/src/Marlowe/ViewPartials.purs
@@ -11,9 +11,9 @@ import Halogen (ComponentHTML)
 import Halogen.Css (classNames)
 import Halogen.HTML (ClassName(..), b_, div_, h4, li_, ol, text)
 import Halogen.HTML.Properties (classes)
+import Humanize (humanizeValue)
 import MainFrame.Types (ChildSlots)
 import Marlowe.Semantics (Payee(..), TransactionWarning(..))
-import Pretty (showPrettyToken)
 
 displayWarningList
   :: forall m action
@@ -61,9 +61,7 @@ displayWarning index (TransactionNonPositiveDeposit party owner tok amount) =
   , text " - Party "
   , b_ [ text $ show party ]
   , text " is asked to deposit "
-  , b_ [ text $ BigInt.toString amount ]
-  , text " units of "
-  , b_ [ text $ showPrettyToken tok ]
+  , b_ [ text $ humanizeValue tok amount ]
   , text " into account of "
   , b_ [ text (show owner) ]
   , text "."
@@ -74,9 +72,7 @@ displayWarning index (TransactionNonPositivePay owner payee tok amount) =
   , warningHint index
       "A non-positive pay is when the contract needs to pay a participant a value which is 0 or lower."
   , text " - The contract is supposed to make a payment of "
-  , b_ [ text $ BigInt.toString amount ]
-  , text " units of "
-  , b_ [ text $ showPrettyToken tok ]
+  , b_ [ text $ humanizeValue tok amount ]
   , text " from account of "
   , b_ [ text (show owner) ]
   , text " to "
@@ -93,9 +89,7 @@ displayWarning index (TransactionPartialPay owner payee tok amount expected) =
   , warningHint index
       "A partial pay is when the contract needs to pay a participant a value grater than the funds available in the origin account."
   , text " - The contract is supposed to make a payment of "
-  , b_ [ text $ BigInt.toString expected ]
-  , text " units of "
-  , b_ [ text $ showPrettyToken tok ]
+  , b_ [ text $ humanizeValue tok expected ]
   , text " from account of "
   , b_ [ text (show owner) ]
   , text " to "

--- a/marlowe-playground-client/src/Page/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Page/Simulation/BottomPanel.purs
@@ -3,6 +3,7 @@ module Page.Simulation.BottomPanel (panelContents) where
 import Prologue hiding (div)
 
 import Data.BigInt.Argonaut (BigInt)
+import Data.BigInt.Argonaut as BigInt
 import Data.Foldable (foldMap)
 import Data.Lens (preview, to, view, (^.))
 import Data.Lens.NonEmptyList (_Head)
@@ -15,6 +16,7 @@ import Halogen.Classes as Classes
 import Halogen.Css (classNames)
 import Halogen.HTML (HTML, br_, div, div_, h4, text)
 import Halogen.HTML.Properties (class_, classes)
+import Humanize (humanizeValue)
 import MainFrame.Types (ChildSlots)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Semantics
@@ -30,7 +32,7 @@ import Marlowe.Semantics
   )
 import Marlowe.ViewPartials (displayWarningList)
 import Page.Simulation.Types (BottomPanelView(..), State)
-import Pretty (renderPrettyParty, renderPrettyToken, showPrettyMoney)
+import Pretty (renderPrettyParty)
 import Simulator.Lenses
   ( _SimulationRunning
   , _executionState
@@ -71,7 +73,7 @@ currentStateView metadata state =
     ( tableRow
         { title: "Accounts"
         , emptyMessage: "No accounts have been used"
-        , columns: ("Participant" /\ "Token" /\ "Money")
+        , columns: ("Participant" /\ "Value" /\ mempty)
         , rowData: accountsData
         }
         <> tableRow
@@ -98,8 +100,9 @@ currentStateView metadata state =
         )
 
       asTuple (Tuple (Tuple accountOwner tok) value) =
-        renderPrettyParty metadata accountOwner /\ renderPrettyToken tok /\ text
-          (showPrettyMoney value)
+        renderPrettyParty metadata accountOwner
+          /\ text (humanizeValue tok value)
+          /\ text mempty
     in
       map asTuple accounts
 
@@ -114,7 +117,7 @@ currentStateView metadata state =
 
       asTuple (Tuple (ChoiceId choiceName choiceOwner) value) =
         text (show choiceName) /\ renderPrettyParty metadata choiceOwner /\ text
-          (showPrettyMoney value)
+          (BigInt.toString value)
     in
       map asTuple choices
 
@@ -128,7 +131,7 @@ currentStateView metadata state =
         )
 
       asTuple (Tuple (ValueId valueId) value) = text (show valueId)
-        /\ text (showPrettyMoney value)
+        /\ text (BigInt.toString value)
         /\ text ""
     in
       map asTuple bindings

--- a/marlowe-playground-client/src/Page/Simulation/Types.purs
+++ b/marlowe-playground-client/src/Page/Simulation/Types.purs
@@ -41,7 +41,6 @@ data Action
   | StartSimulation
   | DownloadAsJson
   | MoveTime Instant
-  | SetTime Instant
   | AddInput Input (Array Bound)
   | SetChoice ChoiceId ChosenNum
   | ResetSimulator
@@ -67,7 +66,6 @@ instance isEventAction :: IsEvent Action where
   toEvent StartSimulation = Just $ defaultEvent "StartSimulation"
   toEvent DownloadAsJson = Just $ defaultEvent "DownloadAsJson"
   toEvent (MoveTime _) = Just $ defaultEvent "MoveTime"
-  toEvent (SetTime _) = Just $ defaultEvent "SetTime"
   toEvent (AddInput _ _) = Just $ defaultEvent "AddInput"
   toEvent (SetChoice _ _) = Just $ defaultEvent "SetChoice"
   toEvent ResetSimulator = Just $ defaultEvent "ResetSimulator"

--- a/marlowe-playground-client/src/Page/Simulation/View.purs
+++ b/marlowe-playground-client/src/Page/Simulation/View.purs
@@ -12,14 +12,7 @@ import Component.Icons as Icon
 import Component.Popper (Placement(..))
 import Component.Tooltip.State (tooltip)
 import Component.Tooltip.Types (ReferenceId(..))
-import Data.Array
-  ( concatMap
-  , intercalate
-  , length
-  , mapWithIndex
-  , reverse
-  , sortWith
-  )
+import Data.Array (concatMap, intercalate, length, mapWithIndex, sortWith)
 import Data.Array as Array
 import Data.Bifunctor (bimap)
 import Data.BigInt.Argonaut (BigInt)
@@ -47,7 +40,6 @@ import Halogen.Classes
   , flex
   , flexCol
   , flexGrow
-  , flexShrink0
   , fontBold
   , fullHeight
   , fullWidth
@@ -61,19 +53,16 @@ import Halogen.Classes
   , minH0
   , noMargins
   , overflowHidden
-  , overflowScroll
   , paddingX
   , plusBtn
   , smallBtn
   , smallSpaceBottom
   , spaceBottom
-  , spaceLeft
   , spaceRight
   , spanText
   , textSecondaryColor
   , textXs
   , uppercase
-  , w30p
   )
 import Halogen.Css (classNames)
 import Halogen.Extra (renderSubmodule)
@@ -110,6 +99,7 @@ import Humanize
   ( formatPOSIXTime
   , humanizeInterval
   , humanizeOffset
+  , humanizeValue
   , localToUtc
   , utcToLocal
   )
@@ -146,13 +136,7 @@ import Page.Simulation.BottomPanel (panelContents)
 import Page.Simulation.Lenses (_bottomPanelState)
 import Page.Simulation.Types (Action(..), BottomPanelView(..), State)
 import Plutus.V1.Ledger.Time (POSIXTime(..))
-import Pretty
-  ( renderPrettyParty
-  , renderPrettyPayee
-  , renderPrettyToken
-  , showPrettyChoice
-  , showPrettyMoney
-  )
+import Pretty (renderPrettyParty, renderPrettyPayee, showPrettyChoice)
 import Simulator.Lenses
   ( _SimulationRunning
   , _currentContract
@@ -196,7 +180,15 @@ render metadata state =
                 state
             ]
         ]
-    , aside [ classes [ flexShrink0, spaceLeft, overflowScroll, w30p ] ]
+    , aside
+        [ classNames
+            [ "flex-shrink-0"
+            , "ml-medium"
+            , "w-30p"
+            , "flex"
+            , "flex-col"
+            ]
+        ]
         (sidebar metadata state)
     ]
   where
@@ -946,13 +938,12 @@ renderDeposit
 renderDeposit metadata accountOwner party tok money =
   span [ classes [ ClassName "break-word-span" ] ]
     [ text "Deposit "
-    , strong_ [ text (showPrettyMoney money) ]
-    , text " units of "
-    , strong_ [ renderPrettyToken tok ]
-    , text " into account of "
-    , strong_ [ renderPrettyParty metadata accountOwner ]
-    , text " as "
+    , strong_ [ text (humanizeValue tok money) ]
+    , text " from "
     , strong_ [ renderPrettyParty metadata party ]
+    , text " wallet, into "
+    , strong_ [ renderPrettyParty metadata accountOwner ]
+    , text " account"
     ]
 
 ------------------------------------------------------------
@@ -972,9 +963,11 @@ logWidget metadata state =
         )
   where
   logEntries = state ^.
-    ( _marloweState <<< _Head <<< _executionState <<< _SimulationRunning
+    ( _marloweState
+        <<< _Head
+        <<< _executionState
+        <<< _SimulationRunning
         <<< _log
-        <<< to reverse
     )
   inputLines = join $ logToLines state.tzOffset metadata `mapWithIndex`
     logEntries
@@ -1060,14 +1053,12 @@ inputToLine
   stepNumber
   (IDeposit accountOwner party token money) =
   [ span_
-      [ text "Deposit "
-      , strong_ [ text (showPrettyMoney money) ]
-      , text " units of "
-      , strong_ [ renderPrettyToken token ]
-      , text " into account of "
+      [ strong_ [ renderPrettyParty metadata party ]
+      , text " deposited "
+      , strong_ [ text (humanizeValue token money) ]
+      , text " from his/her wallet into "
       , strong_ [ renderPrettyParty metadata accountOwner ]
-      , text " as "
-      , strong_ [ renderPrettyParty metadata party ]
+      , text " account "
       ]
   , logTime stepNumber tzOffset timeInterval
   ]
@@ -1079,9 +1070,8 @@ inputToLine
   stepNumber
   (IChoice (ChoiceId choiceName choiceOwner) chosenNum) =
   [ span_
-      [ text "Participant "
-      , strong_ [ renderPrettyParty metadata choiceOwner ]
-      , text " chooses the value "
+      [ strong_ [ renderPrettyParty metadata choiceOwner ]
+      , text " choosed the value "
       , strong_
           [ text
               (showPrettyChoice (getChoiceFormat metadata choiceName) chosenNum)
@@ -1160,13 +1150,11 @@ paymentToLine
   money =
   [ span_
       [ text "The contract pays "
-      , strong_ [ text (showPrettyMoney money) ]
-      , text " units of "
-      , strong_ [ renderPrettyToken token ]
-      , text " to "
-      , strong_ $ renderPrettyPayee metadata payee
+      , strong_ [ text (humanizeValue token money) ]
       , text " from "
       , strong_ $ renderPrettyPayee metadata (Account accountId)
+      , text " to "
+      , strong_ $ renderPrettyPayee metadata payee
       ]
   , logTime stepNumber tzOffset timeInterval
   ]
@@ -1192,9 +1180,14 @@ cardWidget name body =
       [ classes [ noMargins, textSecondaryColor, bold, uppercase, textXs ] ]
       [ text name ]
   in
-    div [ classes [ ClassName "simulation-card-widget" ] ]
-      [ div [ class_ (ClassName "simulation-card-widget-header") ] [ title' ]
-      , div [ class_ (ClassName "simulation-card-widget-body") ] [ body ]
+    div
+      [ classNames
+          [ "simulation-card-widget", "overflow-hidden", "flex", "flex-col" ]
+      ]
+      [ div [ classNames [ "simulation-card-widget-header" ] ]
+          [ title' ]
+      , div [ classNames [ "simulation-card-widget-body", "overflow-scroll" ] ]
+          [ body ]
       ]
 
 markdownHintWithTitle :: String -> String -> PlainHTML

--- a/marlowe-playground-client/src/Pretty.purs
+++ b/marlowe-playground-client/src/Pretty.purs
@@ -12,17 +12,7 @@ import Data.String.CodeUnits (fromCharArray, toCharArray)
 import Halogen.HTML (HTML, abbr, text)
 import Halogen.HTML.Properties (title)
 import Marlowe.Extended.Metadata (MetaData, NumberFormat(..))
-import Marlowe.Semantics (Party(..), Payee(..), Token(..))
-
-renderPrettyToken :: forall p i. Token -> HTML p i
-renderPrettyToken (Token "" "") = text "ADA"
-
-renderPrettyToken (Token cur tok) = abbr [ title cur ] [ text tok ]
-
-showPrettyToken :: Token -> String
-showPrettyToken (Token "" "") = "ADA"
-
-showPrettyToken (Token cur tok) = "\"" <> cur <> " " <> tok <> "\""
+import Marlowe.Semantics (Party(..), Payee(..))
 
 renderPrettyParty :: forall p i. MetaData -> Party -> HTML p i
 renderPrettyParty _ (PK pkh) =
@@ -43,17 +33,12 @@ showPrettyParty (PK pkh) = "PubKey " <> pkh
 
 showPrettyParty (Role role) = show role
 
--- TODO I think this used to add commas? confirm this and add this back if
--- needed.
-showPrettyMoney :: BigInt -> String
-showPrettyMoney = BigInt.toString
-
 renderPrettyPayee :: forall p i. MetaData -> Payee -> Array (HTML p i)
 renderPrettyPayee metadata (Account owner2) =
   [ text "account of ", renderPrettyParty metadata owner2 ]
 
 renderPrettyPayee metadata (Party dest) =
-  [ text "party ", renderPrettyParty metadata dest ]
+  [ renderPrettyParty metadata dest, text " wallet" ]
 
 showBigIntAsCurrency :: BigInt -> Int -> String
 showBigIntAsCurrency number numDecimals = fromCharArray numberStr

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -32,6 +32,7 @@ import Halogen.HTML
   )
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (classes, enabled)
+import Humanize (humanizeValue)
 import MainFrame.Types (ChildSlots)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Semantics
@@ -45,7 +46,6 @@ import Marlowe.Template (TemplateContent(..))
 import Marlowe.ViewPartials (displayWarningList)
 import Network.RemoteData (RemoteData(..))
 import Page.Simulation.View (TemplateParameterActionsGen, templateParameters)
-import Pretty (showPrettyToken)
 import Servant.PureScript (printAjaxError)
 import StaticAnalysis.Types
   ( AnalysisExecutionState(..)
@@ -368,9 +368,7 @@ displayInput (IDeposit owner party tok money) =
   , text " - Party "
   , b_ [ text $ show party ]
   , text " deposits "
-  , b_ [ text $ show money ]
-  , text " units of "
-  , b_ [ text $ showPrettyToken tok ]
+  , b_ [ text $ humanizeValue tok money ]
   , text " into account of "
   , b_ [ text (show owner) ]
   , text "."

--- a/marlowe-playground-client/static/css/utilities.css
+++ b/marlowe-playground-client/static/css/utilities.css
@@ -41,3 +41,7 @@
 .box-shadow-inverted {
   box-shadow: var(--box-shadow-inverted);
 }
+
+.underline-dotted {
+  text-decoration: underline dotted;
+}

--- a/marlowe-playground-client/test/Marlowe/ContractTests.purs
+++ b/marlowe-playground-client/test/Marlowe/ContractTests.purs
@@ -378,7 +378,7 @@ contractHasNoErrors contractName contract =
       Just possibleActions -> do
         action <- lift $ elements possibleActions
         mRunActionResult <- case action of
-          MoveToTime newTime -> runMaybeT $ advanceTime newTime
+          MoveToTime _ newTime -> runMaybeT $ advanceTime newTime
           DepositInput accountId party token value -> pure
             <$> applyInput (IDeposit accountId party token value)
           ChoiceInput choiceId bounds value -> pure <$> do

--- a/marlowe-playground-client/test/Marlowe/LintTests.purs
+++ b/marlowe-playground-client/test/Marlowe/LintTests.purs
@@ -490,7 +490,7 @@ payDepositDifferentCurrency = testWarningSimple
 payInsufficientDeposit :: forall m. MonadThrow Error m => m Unit
 payInsufficientDeposit = testWarningSimple
   (depositAndThenDo "(Constant 9)" continuation)
-  "The contract makes a payment of 10 ADA from account \"role\" but the account only has 9"
+  "The contract makes a payment of ₳ 0.000010 from account \"role\" but the account only has ₳ 0.000009"
   where
   continuation =
     "(Pay (Role \"role\") (Party (Role \"role\")) (Token \"\" \"\") (Constant 10) Close)"
@@ -498,7 +498,7 @@ payInsufficientDeposit = testWarningSimple
 payTwiceInsufficientDeposit :: forall m. MonadThrow Error m => m Unit
 payTwiceInsufficientDeposit = testWarningSimple
   (depositAndThenDo "(Constant 9)" continuation)
-  "The contract makes a payment of 5 ADA from account \"role\" but the account only has 4"
+  "The contract makes a payment of ₳ 0.000005 from account \"role\" but the account only has ₳ 0.000004"
   where
   continuation =
     "(Pay (Role \"role\") (Party (Role \"role\")) (Token \"\" \"\") (Constant 5) "

--- a/web-common-marlowe/src/Examples/PureScript/CouponBondGuaranteed.purs
+++ b/web-common-marlowe/src/Examples/PureScript/CouponBondGuaranteed.purs
@@ -74,6 +74,7 @@ transfer amount from to timeout timeoutContinuation continuation =
 extendedContract :: Contract
 extendedContract =
   deposit (guaranteedAmount (fromInt 3)) guarantor investor
+    -- TODO: SCP-3887 unify time construct
     (TimeValue $ POSIXTime $ unsafeInstantFromInt 300)
     Close
     $ transfer principal investor issuer


### PR DESCRIPTION
This PR adds some improvements to the simulator in general:

* ff4fd307c3ea4a57ea4db5fe38ba8540c6daee95 (individual commit already merged into sprint-54): Fixes the time entries in the transaction log that were using the Show instance.
* 22f8960f04d67d86c6a3ee043f67dbecb30336bb: Changes the MoveTo input to three different actions (move to next minute, next timeout, expiration time) and also fixes issue when simulating a Close contract directly should trigger the contract Start and End action at the same time.
![Screen Shot 2022-05-02 at 14 30 57](https://user-images.githubusercontent.com/2634059/166295844-f83da164-0beb-4bfd-97be-b5a60bc6d319.png)
* 6257f432f36830e9bc5979187279a738eaf16cf1 
  * Removed basic Pretty.showPrettyMoney for humanizeValue (used in Run)
  * Fixed reverse order in payments
  * Fixed log scrolling

![Untitled_Artwork](https://user-images.githubusercontent.com/2634059/166474981-2f21949a-446d-4611-864f-c1f32b8b7dea.jpg)

![Untitled_Artwork 2](https://user-images.githubusercontent.com/2634059/166475012-1a1d5baa-e5d9-4426-a7e5-e5bcab73dfd6.jpg)



Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
