### PR TITLE
SCP-3963 - Update metadata form to time parameters by their name

### DIFF
--- a/marlowe-playground-client/src/Component/MetadataTab/View.purs
+++ b/marlowe-playground-client/src/Component/MetadataTab/View.purs
@@ -583,8 +583,8 @@ metadataView handlers metadataHints metadata = div_
           _timeParameterDescriptions
           _timeParameters
           render
-          "Slot parameter"
-          "slot parameter"
+          "Time parameter"
+          "time parameter"
   , div [ classes [ ClassName "sortable-metadata-form" ] ] do
       let
         actions =


### PR DESCRIPTION
This just updates the label to match the rest of the playground:

![metadata_slot_params](https://user-images.githubusercontent.com/638102/167733155-bc4d21fa-c143-4b19-9b6d-8262b5e339e3.png)
