### PR TITLE
Try -j1 for darwin builds

### DIFF
--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -76,6 +76,7 @@ let
           marlowe-cli.components.library.ghcOptions = [ "-j1" ];
           marlowe-dashboard-server.components.library.ghcOptions = [ "-j1" ];
           marlowe-playground-server.components.library.ghcOptions = [ "-j1" ];
+          threepenny-gui.components.library.ghcOptions = [ "-j1" ];
         };
       })
       ({ pkgs, ... }: lib.mkIf (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform) {

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -74,6 +74,8 @@ let
           cardano-wallet-core.components.library.ghcOptions = [ "-j2" ]; # Using `-j1` here caused a timeout error on hydra mac mini builder
           plutus-pab.components.library.ghcOptions = [ "-j1" ];
           marlowe-cli.components.library.ghcOptions = [ "-j1" ];
+          marlowe-dashboard-server.components.library.ghcOptions = [ "-j1" ];
+          marlowe-playground-server.components.library.ghcOptions = [ "-j1" ];
         };
       })
       ({ pkgs, ... }: lib.mkIf (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform) {

--- a/nix/pkgs/haskell/haskell.nix
+++ b/nix/pkgs/haskell/haskell.nix
@@ -61,6 +61,21 @@ let
         tests: False
     '';
     modules = [
+      ({ pkgs, ... }: lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin) {
+        packages = {
+          # This workaround is for an error that started showing up when building with macOS 12:
+          #   `cannot dlopen until fork() handlers have completed`
+          # This error often goes away if the build is restarted on hydra, but some
+          # packages consistently fail.
+          # Using `-fexternal-interpreter` may also be an option, but using it
+          # for all packages brought up some other issues.
+          blockfrost-api.components.library.ghcOptions = [ "-j1" ];
+          plutus-contract.components.library.ghcOptions = [ "-j1" ];
+          cardano-wallet-core.components.library.ghcOptions = [ "-j2" ]; # Using `-j1` here caused a timeout error on hydra mac mini builder
+          plutus-pab.components.library.ghcOptions = [ "-j1" ];
+          marlowe-cli.components.library.ghcOptions = [ "-j1" ];
+        };
+      })
       ({ pkgs, ... }: lib.mkIf (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform) {
         packages = {
           # Things that need plutus-tx-plugin

--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,5 @@
 # TODO re-enable Darwin after Hydra Darwin build issues are resolved.
-{ supportedSystems ? [ "x86_64-linux" /* "x86_64-darwin" */ ]
+{ supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
 , rootsOnly ? false
   # We explicitly pass true here in the GitHub action but don't want to slow down hydra
 , checkMaterialization ? false


### PR DESCRIPTION
This workaround is for an error that started showing up when building with macOS 12:
   `cannot dlopen until fork() handlers have completed`
