### PR TITLE
SCP-3965 improve output of static analysis

### DIFF
--- a/marlowe-playground-client/src/Marlowe/ViewPartials.purs
+++ b/marlowe-playground-client/src/Marlowe/ViewPartials.purs
@@ -99,7 +99,7 @@ displayWarning index (TransactionPartialPay owner payee tok amount expected) =
           (Party dest) -> ("party " <> (show dest))
       ]
   , text " but there is only "
-  , b_ [ text $ BigInt.toString amount ]
+  , b_ [ text $ humanizeValue tok amount ]
   , text "."
   ]
 


### PR DESCRIPTION
From the Jira issue:

> Static analysis result presumably prints the result of applying the “show” function to POSIX times and choice numbers, and the result is not very readable for users.
> 
> * POSIX time is printed as: (POSIXTime (Instant (Milliseconds __)))
> 
>   * It would be better to print them as a timestamp, something like: YYYY-MM-DD hh:mm:ss (timezone)
> 
> * Choice numbers are printed as: fromString "1"
> 
>   * It would be better to just print the number
![image](https://user-images.githubusercontent.com/2634059/170804027-f7bf53ed-b60a-44cb-96ca-ca127957e9e3.png)

With this PR

<img width="1716" alt="Screen Shot 2022-05-27 at 22 16 18" src="https://user-images.githubusercontent.com/2634059/170804060-66c439f8-b9bc-4459-8203-ed8700f2fac3.png">

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
