### PR TITLE
SCP-4066 Always show template parameters

### DIFF
--- a/marlowe-playground-client/src/Component/BottomPanel/View.purs
+++ b/marlowe-playground-client/src/Component/BottomPanel/View.purs
@@ -28,7 +28,6 @@ import Halogen.Classes
   , paddingX
   , smallPaddingRight
   , smallPaddingTop
-  , smallPaddingY
   , spaceX
   , textInactive
   , textSecondary
@@ -96,7 +95,7 @@ render panelTitles panelContent state =
     -- Panel contents
     , div
         [ classes
-            ( [ spaceX, smallPaddingY, accentBorderTop, overflowScroll, minH0 ]
+            ( [ spaceX, accentBorderTop, overflowScroll, minH0 ]
                 <> dontDisplayWhenHidden
             )
         ]

--- a/marlowe-playground-client/src/Page/BlocklyEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/Page/BlocklyEditor/BottomPanel.purs
@@ -6,7 +6,7 @@ import Prologue hiding (div)
 
 import Component.MetadataTab (render) as MetadataTab
 import Data.Array as Array
-import Data.Lens (to, (^.))
+import Data.Lens ((^.))
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
 import Halogen.Classes
@@ -17,10 +17,10 @@ import Halogen.Classes
   , grid
   , gridColsDescriptionLocation
   , justifySelfEnd
-  , paddingRight
   , underline
   )
-import Halogen.HTML (a, div, div_, pre_, section, section_, span_, text)
+import Halogen.Css (classNames)
+import Halogen.HTML (a, div, div_, pre_, section, span_, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
 import MainFrame.Types (ChildSlots)
@@ -33,19 +33,7 @@ import Page.BlocklyEditor.Types
   , _metadataHintInfo
   , _warnings
   )
-import StaticAnalysis.BottomPanel
-  ( analysisResultPane
-  , analyzeButton
-  , clearButton
-  )
-import StaticAnalysis.Types
-  ( _analysisExecutionState
-  , _analysisState
-  , isCloseAnalysisLoading
-  , isNoneAsked
-  , isReachabilityLoading
-  , isStaticLoading
-  )
+import StaticAnalysis.BottomPanel (analysisPane)
 
 panelContents
   :: forall m
@@ -70,47 +58,20 @@ panelContents state metadata StaticAnalysisView =
           ]
       ]
     else
-      [ analysisResultPane
+      [ analysisPane
           metadata
+          { warnings: AnalyseContract
+          , reachability: AnalyseReachabilityContract
+          , refund: AnalyseContractForCloseRefund
+          }
           { valueAction: SetValueTemplateParam
           , timeAction: SetTimeTemplateParam
           }
           state
-      , div [ classes [ paddingRight ] ]
-          [ analyzeButton loadingWarningAnalysis analysisEnabled
-              "Analyse for warnings"
-              AnalyseContract
-          , analyzeButton loadingReachability analysisEnabled
-              "Analyse reachability"
-              AnalyseReachabilityContract
-          , analyzeButton loadingCloseAnalysis analysisEnabled
-              "Analyse for refunds on Close"
-              AnalyseContractForCloseRefund
-          , clearButton clearEnabled "Clear" ClearAnalysisResults
-          ]
       ]
-  where
-  loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState
-    <<< to isStaticLoading
-
-  loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<<
-    to isReachabilityLoading
-
-  loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<<
-    to isCloseAnalysisLoading
-
-  noneAskedAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to
-    isNoneAsked
-
-  nothingLoading = not loadingWarningAnalysis && not loadingReachability && not
-    loadingCloseAnalysis
-
-  clearEnabled = nothingLoading && not noneAskedAnalysis
-
-  analysisEnabled = nothingLoading
 
 panelContents state _ BlocklyWarningsView =
-  section_
+  section [ classNames [ "py-4" ] ]
     if Array.null warnings then
       [ pre_ [ text "No warnings" ] ]
     else

--- a/marlowe-playground-client/src/Page/BlocklyEditor/Types.purs
+++ b/marlowe-playground-client/src/Page/BlocklyEditor/Types.purs
@@ -32,7 +32,6 @@ data Action
   | MetadataAction MetadataAction
   | SetTimeTemplateParam String Instant
   | SetValueTemplateParam String BigInt
-  | ClearAnalysisResults
   | SelectWarning Warning
 
 defaultEvent :: String -> Event
@@ -55,7 +54,6 @@ instance blocklyActionIsEvent :: IsEvent Action where
     { label = Just $ showConstructor action }
   toEvent (SetTimeTemplateParam _ _) = Nothing
   toEvent (SetValueTemplateParam _ _) = Nothing
-  toEvent ClearAnalysisResults = Just $ defaultEvent "ClearAnalysisResults"
   toEvent (SelectWarning _) = Just $ defaultEvent "SelectWarning"
 
 data BottomPanelView

--- a/marlowe-playground-client/src/Page/HaskellEditor/State.purs
+++ b/marlowe-playground-client/src/Page/HaskellEditor/State.purs
@@ -111,6 +111,7 @@ handleAction _ (ChangeKeyBindings bindings) = do
   void $ query _haskellEditorSlot unit (Monaco.SetKeyBindings bindings unit)
 
 handleAction metadata Compile = do
+  clearAnalysisResults
   mContents <- editorGetValue
   case mContents of
     Nothing -> pure unit
@@ -167,12 +168,14 @@ handleAction _ (InitHaskellProject metadataHints contents) = do
   assign _metadataHintInfo metadataHints
   liftEffect $ SessionStorage.setItem haskellBufferLocalStorageKey contents
 
-handleAction _ (SetValueTemplateParam key value) =
+handleAction _ (SetValueTemplateParam key value) = do
+  clearAnalysisResults
   modifying
     (_analysisState <<< _templateContent <<< _valueContent)
     (Map.insert key value)
 
-handleAction _ (SetTimeTemplateParam key value) =
+handleAction _ (SetTimeTemplateParam key value) = do
+  clearAnalysisResults
   modifying
     (_analysisState <<< _templateContent <<< _timeContent)
     (Map.insert key value)
@@ -185,7 +188,8 @@ handleAction _ AnalyseReachabilityContract = analyze analyseReachability
 
 handleAction _ AnalyseContractForCloseRefund = analyze analyseClose
 
-handleAction _ ClearAnalysisResults = assign
+clearAnalysisResults :: forall m. HalogenM State Action ChildSlots Void m Unit
+clearAnalysisResults = assign
   (_analysisState <<< _analysisExecutionState)
   NoneAsked
 

--- a/marlowe-playground-client/src/Page/HaskellEditor/Types.purs
+++ b/marlowe-playground-client/src/Page/HaskellEditor/Types.purs
@@ -42,7 +42,6 @@ data Action
   | AnalyseContract
   | AnalyseReachabilityContract
   | AnalyseContractForCloseRefund
-  | ClearAnalysisResults
   | MetadataAction MetadataAction
   | DoNothing
 
@@ -63,7 +62,6 @@ instance actionIsEvent :: IsEvent Action where
     "AnalyseReachabilityContract"
   toEvent AnalyseContractForCloseRefund = Just $ defaultEvent
     "AnalyseContractForCloseRefund"
-  toEvent ClearAnalysisResults = Just $ defaultEvent "ClearAnalysisResults"
   toEvent (MetadataAction action) = Just $ (defaultEvent "MetadataAction")
     { label = Just $ showConstructor action }
   toEvent DoNothing = Nothing

--- a/marlowe-playground-client/src/Page/HaskellEditor/View.purs
+++ b/marlowe-playground-client/src/Page/HaskellEditor/View.purs
@@ -11,7 +11,7 @@ import Data.Argonaut.Extra (parseDecodeJson)
 import Data.Array as Array
 import Data.Bifunctor (bimap)
 import Data.Enum (toEnum, upFromIncluding)
-import Data.Lens (_Right, has, to, view, (^.))
+import Data.Lens (_Right, has, view, (^.))
 import Data.Maybe (maybe)
 import Data.String (Pattern(..), split)
 import Data.String as String
@@ -69,19 +69,7 @@ import Page.HaskellEditor.Types
   , _haskellEditorKeybindings
   , _metadataHintInfo
   )
-import StaticAnalysis.BottomPanel
-  ( analysisResultPane
-  , analyzeButton
-  , clearButton
-  )
-import StaticAnalysis.Types
-  ( _analysisExecutionState
-  , _analysisState
-  , isCloseAnalysisLoading
-  , isNoneAsked
-  , isReachabilityLoading
-  , isStaticLoading
-  )
+import StaticAnalysis.BottomPanel (analysisPane)
 import Text.Pretty (pretty)
 
 render
@@ -198,7 +186,7 @@ panelContents
   -> BottomPanelView
   -> ComponentHTML Action ChildSlots m
 panelContents state _ GeneratedOutputView =
-  section_ case view _compilationResult state of
+  section [ classNames [ "py-4" ] ] case view _compilationResult state of
     Success (Right (InterpreterResult result)) ->
       [ div [ classes [ bgWhite, spaceBottom, ClassName "code" ] ]
           numberedText
@@ -220,66 +208,41 @@ panelContents state _ GeneratedOutputView =
 
 panelContents state metadata StaticAnalysisView =
   section_
-    ( [ analysisResultPane
+    if isCompiled then
+      [ analysisPane
           metadata
+          { warnings: AnalyseContract
+          , reachability: AnalyseReachabilityContract
+          , refund: AnalyseContractForCloseRefund
+          }
           { valueAction: SetValueTemplateParam
           , timeAction: SetTimeTemplateParam
           }
           state
-      , analyzeButton loadingWarningAnalysis analysisEnabled
-          "Analyse for warnings"
-          AnalyseContract
-      , analyzeButton loadingReachability analysisEnabled "Analyse reachability"
-          AnalyseReachabilityContract
-      , analyzeButton loadingCloseAnalysis analysisEnabled
-          "Analyse for refunds on Close"
-          AnalyseContractForCloseRefund
-      , clearButton clearEnabled "Clear" ClearAnalysisResults
       ]
-        <>
-          ( if isCompiled then []
-            else
-              [ div [ classes [ ClassName "choice-error" ] ]
-                  [ text
-                      "Haskell code needs to be compiled in order to run static analysis"
-                  ]
-              ]
-          )
-    )
+    else
+      [ div [ classNames [ "py-4", "choice-error" ] ]
+          [ text
+              "Haskell code needs to be compiled in order to run static analysis"
+          ]
+      ]
   where
-  loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState
-    <<< to isStaticLoading
-
-  loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<<
-    to isReachabilityLoading
-
-  loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<<
-    to isCloseAnalysisLoading
-
-  noneAskedAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to
-    isNoneAsked
-
-  anyAnalysisLoading = loadingWarningAnalysis || loadingReachability ||
-    loadingCloseAnalysis
-
-  analysisEnabled = not anyAnalysisLoading && isCompiled
-
-  clearEnabled = not (anyAnalysisLoading || noneAskedAnalysis)
-
   isCompiled = has (_compilationResult <<< _Success <<< _Right) state
 
 panelContents state _ ErrorsView =
-  section_ case view _compilationResult state of
+  section [ classNames [ "py-4" ] ] case view _compilationResult state of
     Success (Left (TimeoutError error)) -> [ text error ]
     Success (Left (CompilationErrors errors)) -> map compilationErrorPane errors
     _ -> [ text "No errors" ]
 
 panelContents state metadata MetadataView =
-  MetadataTab.render
-    { metadataHintInfo: state ^. _metadataHintInfo
-    , metadata
-    }
-    MetadataAction
+  section [ classNames [ "py-4" ] ]
+    [ MetadataTab.render
+        { metadataHintInfo: state ^. _metadataHintInfo
+        , metadata
+        }
+        MetadataAction
+    ]
 
 compilationErrorPane :: forall p. CompilationError -> HTML p Action
 compilationErrorPane (RawError error) = div_ [ text error ]

--- a/marlowe-playground-client/src/Page/JavascriptEditor/Types.purs
+++ b/marlowe-playground-client/src/Page/JavascriptEditor/Types.purs
@@ -55,7 +55,6 @@ data Action
   | AnalyseContract
   | AnalyseReachabilityContract
   | AnalyseContractForCloseRefund
-  | ClearAnalysisResults
   | MetadataAction MetadataAction
   | DoNothing
 
@@ -77,7 +76,6 @@ instance actionIsEvent :: IsEvent Action where
     "AnalyseReachabilityContract"
   toEvent AnalyseContractForCloseRefund = Just $ defaultEvent
     "AnalyseContractForCloseRefund"
-  toEvent ClearAnalysisResults = Just $ defaultEvent "ClearAnalysisResults"
   toEvent (MetadataAction action) = Just $ (defaultEvent "MetadataAction")
     { label = Just $ showConstructor action }
   toEvent DoNothing = Nothing

--- a/marlowe-playground-client/src/Page/JavascriptEditor/View.purs
+++ b/marlowe-playground-client/src/Page/JavascriptEditor/View.purs
@@ -8,7 +8,7 @@ import Component.MetadataTab (render) as MetadataTab
 import Data.Array as Array
 import Data.Bifunctor (bimap)
 import Data.Enum (toEnum, upFromIncluding)
-import Data.Lens (to, view, (^.))
+import Data.Lens (view, (^.))
 import Data.Maybe (maybe)
 import Data.String (Pattern(..), split)
 import Data.String as String
@@ -65,17 +65,7 @@ import Page.JavascriptEditor.Types
   )
 import Page.JavascriptEditor.Types as JS
 import StaticAnalysis.BottomPanel
-  ( analysisResultPane
-  , analyzeButton
-  , clearButton
-  )
-import StaticAnalysis.Types
-  ( _analysisExecutionState
-  , _analysisState
-  , isCloseAnalysisLoading
-  , isNoneAsked
-  , isReachabilityLoading
-  , isStaticLoading
+  ( analysisPane
   )
 import Text.Pretty (pretty)
 
@@ -193,7 +183,7 @@ panelContents
   -> BottomPanelView
   -> ComponentHTML Action ChildSlots m
 panelContents state _ GeneratedOutputView =
-  section_ case view _compilationResult state of
+  section [ classNames [ "py-4" ] ] case view _compilationResult state of
     JS.CompiledSuccessfully (InterpreterResult result) ->
       [ div [ HP.classes [ bgWhite, spaceBottom, ClassName "code" ] ]
           numberedText
@@ -206,67 +196,42 @@ panelContents state _ GeneratedOutputView =
 
 panelContents state metadata StaticAnalysisView =
   section_
-    ( [ analysisResultPane
+    if isCompiled then
+      [ analysisPane
           metadata
+          { warnings: AnalyseContract
+          , reachability: AnalyseReachabilityContract
+          , refund: AnalyseContractForCloseRefund
+          }
           { valueAction: SetValueTemplateParam
           , timeAction: SetTimeTemplateParam
           }
           state
-      , analyzeButton loadingWarningAnalysis analysisEnabled
-          "Analyse for warnings"
-          AnalyseContract
-      , analyzeButton loadingReachability analysisEnabled "Analyse reachability"
-          AnalyseReachabilityContract
-      , analyzeButton loadingCloseAnalysis analysisEnabled
-          "Analyse for refunds on Close"
-          AnalyseContractForCloseRefund
-      , clearButton clearEnabled "Clear" ClearAnalysisResults
       ]
-        <>
-          ( if isCompiled then []
-            else
-              [ div [ HP.classes [ ClassName "choice-error" ] ]
-                  [ text
-                      "JavaScript code needs to be compiled in order to run static analysis"
-                  ]
-              ]
-          )
-    )
+    else
+      [ div [ HP.classes [ ClassName "choice-error" ] ]
+          [ text
+              "JavaScript code needs to be compiled in order to run static analysis"
+          ]
+      ]
   where
-  loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState
-    <<< to isStaticLoading
-
-  loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<<
-    to isReachabilityLoading
-
-  loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<<
-    to isCloseAnalysisLoading
-
-  noneAskedAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to
-    isNoneAsked
-
-  anyAnalysisLoading = loadingWarningAnalysis || loadingReachability ||
-    loadingCloseAnalysis
-
-  analysisEnabled = not anyAnalysisLoading && isCompiled
-
-  clearEnabled = not (anyAnalysisLoading || noneAskedAnalysis)
-
   isCompiled = case view _compilationResult state of
     JS.CompiledSuccessfully _ -> true
     _ -> false
 
 panelContents state _ ErrorsView =
-  section_ case view _compilationResult state of
+  section [ classNames [ "py-4" ] ] case view _compilationResult state of
     JS.CompilationError err -> [ compilationErrorPane err ]
     _ -> [ text "No errors" ]
 
 panelContents state metadata MetadataView =
-  MetadataTab.render
-    { metadataHintInfo: state ^. _metadataHintInfo
-    , metadata
-    }
-    MetadataAction
+  section [ classNames [ "py-4" ] ]
+    [ MetadataTab.render
+        { metadataHintInfo: state ^. _metadataHintInfo
+        , metadata
+        }
+        MetadataAction
+    ]
 
 compilationErrorPane :: forall p. CompilationError -> HTML p Action
 compilationErrorPane (RawError error) = div_

--- a/marlowe-playground-client/src/Page/MarloweEditor/BottomPanel.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/BottomPanel.purs
@@ -14,19 +14,17 @@ import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
 import Halogen.Classes
-  ( flex
-  , flexCol
-  , fontBold
+  ( fontBold
   , fullWidth
   , grid
   , gridColsDescriptionLocation
   , justifySelfEnd
   , minW0
   , overflowXScroll
-  , paddingRight
   , underline
   )
-import Halogen.HTML (a, div, div_, pre_, section, section_, span_, text)
+import Halogen.Css (classNames)
+import Halogen.HTML (a, div, pre_, section, span_, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
 import MainFrame.Types (ChildSlots)
@@ -40,21 +38,8 @@ import Page.MarloweEditor.Types
   , _hasHoles
   , _metadataHintInfo
   , _showErrorDetail
-  , contractHasErrors
   )
-import StaticAnalysis.BottomPanel
-  ( analysisResultPane
-  , analyzeButton
-  , clearButton
-  )
-import StaticAnalysis.Types
-  ( _analysisExecutionState
-  , _analysisState
-  , isCloseAnalysisLoading
-  , isNoneAsked
-  , isReachabilityLoading
-  , isStaticLoading
-  )
+import StaticAnalysis.BottomPanel (analysisPane)
 import Text.Extra (lines)
 
 panelContents
@@ -65,62 +50,37 @@ panelContents
   -> BottomPanelView
   -> ComponentHTML Action ChildSlots m
 panelContents state metadata MetadataView =
-  MetadataTab.render
-    { metadata
-    , metadataHintInfo: state ^. _metadataHintInfo
-    }
-    MetadataAction
+  section [ classNames [ "py-4" ] ]
+    [ MetadataTab.render
+        { metadata
+        , metadataHintInfo: state ^. _metadataHintInfo
+        }
+        MetadataAction
+    ]
 
 panelContents state metadata StaticAnalysisView =
-  section [ classes [ flex, flexCol ] ]
+  section [ classNames [ "flex", "flex-col" ] ]
     if (state ^. _hasHoles) then
-      [ div_
+      [ div [ classNames [ "py-4" ] ]
           [ text
               "The contract needs to be complete (no holes) before doing static analysis."
           ]
       ]
     else
-      [ analysisResultPane
+      [ analysisPane
           metadata
+          { warnings: AnalyseContract
+          , reachability: AnalyseReachabilityContract
+          , refund: AnalyseContractForCloseRefund
+          }
           { valueAction: SetValueTemplateParam
           , timeAction: SetTimeTemplateParam
           }
           state
-      , div [ classes [ paddingRight ] ]
-          [ analyzeButton loadingWarningAnalysis analysisEnabled
-              "Analyse for warnings"
-              AnalyseContract
-          , analyzeButton loadingReachability analysisEnabled
-              "Analyse reachability"
-              AnalyseReachabilityContract
-          , analyzeButton loadingCloseAnalysis analysisEnabled
-              "Analyse for refunds on Close"
-              AnalyseContractForCloseRefund
-          , clearButton clearEnabled "Clear" ClearAnalysisResults
-          ]
       ]
-  where
-  loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState
-    <<< to isStaticLoading
-
-  loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<<
-    to isReachabilityLoading
-
-  loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<<
-    to isCloseAnalysisLoading
-
-  noneAskedAnalysis = state ^. _analysisState <<< _analysisExecutionState <<< to
-    isNoneAsked
-
-  nothingLoading = not loadingWarningAnalysis && not loadingReachability && not
-    loadingCloseAnalysis
-
-  clearEnabled = nothingLoading && not noneAskedAnalysis
-
-  analysisEnabled = nothingLoading && not contractHasErrors state
 
 panelContents state _ MarloweWarningsView =
-  section_
+  section [ classNames [ "py-4" ] ]
     if Array.null warnings then
       [ pre_ [ text "No warnings" ] ]
     else
@@ -146,7 +106,7 @@ panelContents state _ MarloweWarningsView =
     ]
 
 panelContents state _ MarloweErrorsView =
-  section_
+  section [ classNames [ "py-4" ] ]
     if Array.null errors then
       [ pre_ [ text "No errors" ] ]
     else

--- a/marlowe-playground-client/src/Page/MarloweEditor/State.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/State.purs
@@ -106,6 +106,7 @@ handleAction metadata (HandleEditorMessage Monaco.EditorReady) = do
   assign _editorReady true
 
 handleAction metadata (HandleEditorMessage (Monaco.TextChanged text)) = do
+  clearAnalysisResults
   -- When the Monaco component start it fires two messages at the same time, an EditorReady
   -- and TextChanged. Because of how Halogen works, it interwines the handleActions calls which
   -- can cause problems while setting and getting the values of the session storage. To avoid
@@ -161,12 +162,14 @@ handleAction _ (InitMarloweProject contents) = do
 
 handleAction _ (SelectHole hole) = assign _selectedHole hole
 
-handleAction _ (SetValueTemplateParam key value) =
+handleAction _ (SetValueTemplateParam key value) = do
+  clearAnalysisResults
   modifying
     (_analysisState <<< _templateContent <<< Template._valueContent)
     (Map.insert key value)
 
-handleAction _ (SetTimeTemplateParam key value) =
+handleAction _ (SetTimeTemplateParam key value) = do
+  clearAnalysisResults
   modifying
     (_analysisState <<< _templateContent <<< Template._timeContent)
     (Map.insert key value)
@@ -181,12 +184,11 @@ handleAction metadata AnalyseReachabilityContract = runAnalysis metadata $
 handleAction metadata AnalyseContractForCloseRefund = runAnalysis metadata $
   analyseClose
 
-handleAction metadata ClearAnalysisResults = do
-  assign (_analysisState <<< _analysisExecutionState) NoneAsked
-  mContents <- editorGetValue
-  for_ mContents $ processMarloweCode metadata
-
 handleAction _ Save = pure unit
+
+clearAnalysisResults :: forall m. HalogenM State Action ChildSlots Void m Unit
+clearAnalysisResults = assign (_analysisState <<< _analysisExecutionState)
+  NoneAsked
 
 runAnalysis
   :: forall m

--- a/marlowe-playground-client/src/Page/MarloweEditor/Types.purs
+++ b/marlowe-playground-client/src/Page/MarloweEditor/Types.purs
@@ -44,7 +44,6 @@ data Action
   | AnalyseContract
   | AnalyseReachabilityContract
   | AnalyseContractForCloseRefund
-  | ClearAnalysisResults
   | Save
   | DoNothing
 
@@ -75,7 +74,6 @@ instance actionIsEvent :: IsEvent Action where
     "AnalyseReachabilityContract"
   toEvent AnalyseContractForCloseRefund = Just $ defaultEvent
     "AnalyseContractForCloseRefund"
-  toEvent ClearAnalysisResults = Just $ defaultEvent "ClearAnalysisResults"
   toEvent Save = Just $ defaultEvent "Save"
   toEvent DoNothing = Nothing
 

--- a/marlowe-playground-client/src/Page/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Page/Simulation/BottomPanel.purs
@@ -11,10 +11,10 @@ import Data.Map as Map
 import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Halogen (ComponentHTML)
-import Halogen.Classes (first, rTable, rTable4cols, rTableCell, rTableEmptyRow)
+import Halogen.Classes (first, rTableCell, rTableEmptyRow)
 import Halogen.Classes as Classes
 import Halogen.Css (classNames)
-import Halogen.HTML (HTML, br_, div, div_, h4, text)
+import Halogen.HTML (HTML, br_, div, div_, h4, section, text)
 import Halogen.HTML.Properties (class_, classes)
 import Humanize (humanizeValue)
 import MainFrame.Types (ChildSlots)
@@ -65,11 +65,12 @@ panelContents _ state WarningsAndErrorsView =
       )
       state
   in
-    warningsAndErrorsView runtimeWarnings mRuntimeError
+    section [ classNames [ "py-4" ] ] $
+      [ warningsAndErrorsView runtimeWarnings mRuntimeError ]
 
 currentStateView :: forall p action. MetaData -> State -> HTML p action
 currentStateView metadata state =
-  div [ classes [ rTable, rTable4cols ] ]
+  div [ classNames [ "Rtable", "Rtable--4cols", "py-4" ] ]
     ( tableRow
         { title: "Accounts"
         , emptyMessage: "No accounts have been used"

--- a/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/BottomPanel.purs
@@ -1,15 +1,12 @@
 module StaticAnalysis.BottomPanel
-  ( analysisResultPane
-  , analyzeButton
-  , clearButton
+  ( analysisPane
   ) where
 
 import Prologue hiding (div)
 
 import Data.Array as Array
 import Data.BigInt.Argonaut as BigInt
-import Data.Lens ((^.))
-import Data.Lens.Iso.Newtype (_Newtype)
+import Data.Lens (to, (^.))
 import Data.List (List(..), null, toUnfoldable, (:))
 import Data.List as List
 import Data.List.NonEmpty (toList)
@@ -40,8 +37,8 @@ import Icons (Icon(..), icon)
 import MainFrame.Types (ChildSlots)
 import Marlowe.Extended.Metadata (MetaData)
 import Marlowe.Semantics (ChoiceId(..), Input(..), TransactionInput(..))
+import Marlowe.Symbolic.Types.Response (Result)
 import Marlowe.Symbolic.Types.Response as R
-import Marlowe.Template (TemplateContent(..))
 import Marlowe.ViewPartials (displayWarningList)
 import Network.RemoteData (RemoteData(..))
 import Page.Simulation.View (TemplateParameterActionsGen, templateParameters)
@@ -55,8 +52,11 @@ import StaticAnalysis.Types
   , _analysisExecutionState
   , _analysisState
   , _templateContent
+  , isCloseAnalysisLoading
+  , isReachabilityLoading
+  , isStaticLoading
   )
-import Types (WarningAnalysisError(..))
+import Types (WarningAnalysisData, WarningAnalysisError(..))
 
 analyzeButton
   :: forall p action. Boolean -> Boolean -> String -> action -> HTML p action
@@ -68,273 +68,330 @@ analyzeButton isLoading isEnabled name action =
     ]
     [ text (if isLoading then "Analysing..." else name) ]
 
-clearButton
-  :: forall p action. Boolean -> String -> action -> HTML p action
-clearButton isEnabled name action =
-  button
-    [ onClick $ const action
-    , enabled isEnabled
-    , classes [ spaceTop, spaceBottom, spaceRight, btn ]
+type AnalyseActionGen action =
+  { warnings :: action
+  , reachability :: action
+  , refund :: action
+  }
+
+analysisPane
+  :: forall action m state
+   . MonadAff m
+  => MetaData
+  -> AnalyseActionGen action
+  -> TemplateParameterActionsGen action
+  -> { analysisState :: AnalysisState, tzOffset :: Minutes | state }
+  -> ComponentHTML action ChildSlots m
+analysisPane metadata analysisAction templateAction state =
+  div
+    [ classNames [ "flex" ]
     ]
-    [ text name ]
+    [ div [ classNames [ "flex-grow" ] ]
+        [ analysisResultPane state
+        , analysisButtons
+        ]
+    , div
+        [ classNames
+            [ "pl-4"
+            , "border-0"
+            , "border-l"
+            , "border-solid"
+            , "border-layout-accent"
+            ]
+        ]
+        [ h3 [ classNames [ "analysis-result-title" ] ]
+            [ text "Template parameters" ]
+
+        , templateParameters
+            "static-analisys"
+            metadata
+            templateContent
+            templateAction
+            tzOffset
+        ]
+    ]
+  where
+  analysisButtons = div [ classNames [ "pr-4" ] ]
+    [ analyzeButton loadingWarningAnalysis analysisEnabled
+        "Analyse for warnings"
+        analysisAction.warnings
+    , analyzeButton loadingReachability analysisEnabled
+        "Analyse reachability"
+        analysisAction.reachability
+    , analyzeButton loadingCloseAnalysis analysisEnabled
+        "Analyse for refunds on Close"
+        analysisAction.refund
+    ]
+
+  templateContent =
+    state ^. (_analysisState <<< _templateContent)
+  tzOffset = state.tzOffset
+
+  loadingWarningAnalysis = state ^. _analysisState <<< _analysisExecutionState
+    <<< to isStaticLoading
+
+  loadingReachability = state ^. _analysisState <<< _analysisExecutionState <<<
+    to isReachabilityLoading
+
+  loadingCloseAnalysis = state ^. _analysisState <<< _analysisExecutionState <<<
+    to isCloseAnalysisLoading
+
+  nothingLoading = not loadingWarningAnalysis && not loadingReachability && not
+    loadingCloseAnalysis
+
+  analysisEnabled = nothingLoading
 
 analysisResultPane
   :: forall action m state
    . MonadAff m
-  => MetaData
-  -> TemplateParameterActionsGen action
-  -> { analysisState :: AnalysisState, tzOffset :: Minutes | state }
+  => { analysisState :: AnalysisState, tzOffset :: Minutes | state }
   -> ComponentHTML action ChildSlots m
-analysisResultPane metadata actionGen state =
+analysisResultPane state =
   let
-    { timeContent, valueContent } =
-      state ^. (_analysisState <<< _templateContent <<< _Newtype)
-
-    templateContent = TemplateContent { timeContent, valueContent }
     result = state ^. (_analysisState <<< _analysisExecutionState)
     tzOffset = state.tzOffset
-    explanation = div [ classes [ ClassName "padded-explanation" ] ]
   in
     case result of
-      NoneAsked ->
-        explanation
-          [ text ""
-          , templateParameters
-              "static-analisys"
-              metadata
-              templateContent
-              actionGen
-              tzOffset
+      NoneAsked -> h3 [ classNames [ "analysis-result-title" ] ]
+        [ text "Static Analysis: None Asked" ]
+      WarningAnalysis staticSubResult -> warningAnalysisResult tzOffset
+        staticSubResult
+      ReachabilityAnalysis reachabilitySubResult -> reachabilityAnalysisResult
+        reachabilitySubResult
+      CloseAnalysis closeAnalysisSubResult -> closeAnalysisResult
+        closeAnalysisSubResult
+
+warningAnalysisResult
+  :: forall action m
+   . MonadAff m
+  => Minutes
+  -> WarningAnalysisData Result
+  -> ComponentHTML action ChildSlots m
+warningAnalysisResult tzOffset staticSubResult = div
+  [ classNames [ "padded-explanation" ] ]
+
+  case staticSubResult of
+    NotAsked -> [ text "" ]
+    Success (R.Valid) ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Warning Analysis Result: Pass" ]
+      , text
+          "Static analysis could not find any execution that results in any warning."
+      ]
+    Success
+      ( R.CounterExample
+          { initialSlot, transactionList, transactionWarning }
+      ) ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Warning Analysis Result: Warnings Found" ]
+      , text "Static analysis found the following counterexample:"
+      , ul [ classes [ ClassName "indented-enum-initial" ] ]
+          [ li_
+              [ spanText "Warnings issued: "
+              , displayWarningList transactionWarning
+              ]
+          , li_
+              [ spanText "Initial slot: "
+              , b_ [ spanText (BigInt.toString initialSlot) ]
+              ]
+          , li_
+              [ spanText "Offending sequence: "
+              , displayTransactionList tzOffset transactionList
+              ]
           ]
-      WarningAnalysis staticSubResult -> case staticSubResult of
-        NotAsked ->
-          explanation
-            [ text ""
-            ]
-        Success (R.Valid) ->
-          explanation
-            [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                [ text "Warning Analysis Result: Pass" ]
-            , text
-                "Static analysis could not find any execution that results in any warning."
-            ]
-        Success
-          ( R.CounterExample
-              { initialSlot, transactionList, transactionWarning }
-          ) ->
-          explanation
-            [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                [ text "Warning Analysis Result: Warnings Found" ]
-            , text "Static analysis found the following counterexample:"
-            , ul [ classes [ ClassName "indented-enum-initial" ] ]
-                [ li_
-                    [ spanText "Warnings issued: "
-                    , displayWarningList transactionWarning
-                    ]
-                , li_
-                    [ spanText "Initial slot: "
-                    , b_ [ spanText (BigInt.toString initialSlot) ]
-                    ]
-                , li_
-                    [ spanText "Offending sequence: "
-                    , displayTransactionList tzOffset transactionList
-                    ]
-                ]
-            ]
-        Success (R.Error str) ->
-          explanation
-            [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                [ text "Error during warning analysis" ]
-            , text "Analysis failed for the following reason:"
-            , ul [ classes [ ClassName "indented-enum-initial" ] ]
-                [ li_
-                    [ b_ [ spanText str ]
-                    ]
-                ]
-            ]
-        Failure (WarningAnalysisAjaxError error) ->
-          explanation
-            [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                [ text "Error during warning analysis" ]
-            , text "Analysis failed for the following reason:"
-            , ul [ classes [ ClassName "indented-enum-initial" ] ]
-                [ li_
-                    [ b_
-                        [ spanText $ printAjaxError error
-                        ]
-                    ]
-                ]
-            ]
-        Failure WarningAnalysisIsExtendedMarloweError ->
-          explanation
-            [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                [ text "Error during warning analysis" ]
-            , text "Analysis failed for the following reason:"
-            , ul [ classes [ ClassName "indented-enum-initial" ] ]
-                [ li_
-                    [ b_
-                        [ spanText
-                            "The code has templates. Static analysis can only be run in core Marlowe code."
-                        ]
-                    ]
-                ]
-            ]
-        Loading -> text ""
-      ReachabilityAnalysis reachabilitySubResult ->
-        case reachabilitySubResult of
-          AnalysisNotStarted ->
-            explanation
-              [ text ""
+      ]
+    Success (R.Error str) ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Error during warning analysis" ]
+      , text "Analysis failed for the following reason:"
+      , ul [ classes [ ClassName "indented-enum-initial" ] ]
+          [ li_
+              [ b_ [ spanText str ]
               ]
-          AnalysisInProgress
-            { numSubproblems: totalSteps
-            , numSolvedSubproblems: doneSteps
-            , counterExampleSubcontracts: foundcounterExampleSubcontracts
-            } ->
-            explanation
-              ( [ text
-                    ( "Reachability analysis in progress, " <> show doneSteps
-                        <> " subcontracts out of "
-                        <> show totalSteps
-                        <> " analysed..."
-                    )
-                ]
-                  <>
-                    if null foundcounterExampleSubcontracts then
-                      [ br_, text "No unreachable subcontracts found so far." ]
-                    else
-                      ( [ br_
-                        , text
-                            "Found the following unreachable subcontracts so far:"
-                        ]
-                          <>
-                            [ ul
-                                [ classes [ ClassName "indented-enum-initial" ]
-                                ]
-                                do
-                                  contractPath <- toUnfoldable
-                                    foundcounterExampleSubcontracts
-                                  pure
-                                    ( li_ $ displayContractPath
-                                        (text "Unreachable code")
-                                        contractPath
-                                    )
-                            ]
-                      )
-              )
-          AnalysisFailure err ->
-            explanation
-              [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                  [ text "Error during reachability analysis" ]
-              , text "Reachability analysis failed for the following reason:"
-              , ul [ classes [ ClassName "indented-enum-initial" ] ]
-                  [ li_
-                      [ b_ [ spanText err ]
-                      ]
+          ]
+      ]
+    Failure (WarningAnalysisAjaxError error) ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Error during warning analysis" ]
+      , text "Analysis failed for the following reason:"
+      , ul [ classes [ ClassName "indented-enum-initial" ] ]
+          [ li_
+              [ b_
+                  [ spanText $ printAjaxError error
                   ]
               ]
-          AnalysisFoundCounterExamples { counterExampleSubcontracts } ->
-            explanation
-              ( [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                    [ text
-                        "Reachability Analysis Result: Unreachable Subcontract Found"
-                    ]
+          ]
+      ]
+    Failure WarningAnalysisIsExtendedMarloweError ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Error during warning analysis" ]
+      , text "Analysis failed for the following reason:"
+      , ul [ classes [ ClassName "indented-enum-initial" ] ]
+          [ li_
+              [ b_
+                  [ spanText
+                      "The code has templates. Static analysis can only be run in core Marlowe code."
+                  ]
+              ]
+          ]
+      ]
+    Loading -> [ text "" ]
+
+reachabilityAnalysisResult
+  :: forall action m
+   . MonadAff m
+  => MultiStageAnalysisData
+  -> ComponentHTML action ChildSlots m
+reachabilityAnalysisResult reachabilitySubResult = div
+  [ classNames [ "padded-explanation" ] ]
+  case reachabilitySubResult of
+    AnalysisNotStarted -> [ text "" ]
+    AnalysisInProgress
+      { numSubproblems: totalSteps
+      , numSolvedSubproblems: doneSteps
+      , counterExampleSubcontracts: foundcounterExampleSubcontracts
+      } ->
+      ( [ text
+            ( "Reachability analysis in progress, " <> show doneSteps
+                <> " subcontracts out of "
+                <> show totalSteps
+                <> " analysed..."
+            )
+        ]
+          <>
+            if null foundcounterExampleSubcontracts then
+              [ br_, text "No unreachable subcontracts found so far." ]
+            else
+              ( [ br_
                 , text
-                    "Static analysis found the following subcontracts that are unreachable:"
+                    "Found the following unreachable subcontracts so far:"
                 ]
                   <>
-                    [ ul [ classes [ ClassName "indented-enum-initial" ] ] do
-                        contractPath <- toUnfoldable
-                          (toList counterExampleSubcontracts)
-                        pure
-                          ( li_ $ displayContractPath (text "Unreachable code")
-                              contractPath
-                          )
+                    [ ul
+                        [ classes [ ClassName "indented-enum-initial" ]
+                        ]
+                        do
+                          contractPath <- toUnfoldable
+                            foundcounterExampleSubcontracts
+                          pure
+                            ( li_ $ displayContractPath
+                                (text "Unreachable code")
+                                contractPath
+                            )
                     ]
               )
-          AnalysisFinishedAndPassed ->
-            explanation
-              [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                  [ text "Reachability Analysis Result: Pass" ]
-              , text
-                  "Reachability analysis could not find any subcontract that is not reachable."
+      )
+    AnalysisFailure err ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Error during reachability analysis" ]
+      , text "Reachability analysis failed for the following reason:"
+      , ul [ classes [ ClassName "indented-enum-initial" ] ]
+          [ li_
+              [ b_ [ spanText err ]
               ]
-      CloseAnalysis closeAnalysisSubResult -> case closeAnalysisSubResult of
-        AnalysisNotStarted ->
-          explanation
-            [ text ""
+          ]
+      ]
+    AnalysisFoundCounterExamples { counterExampleSubcontracts } ->
+      ( [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+            [ text
+                "Reachability Analysis Result: Unreachable Subcontract Found"
             ]
-        AnalysisInProgress
-          { numSubproblems: totalSteps
-          , numSolvedSubproblems: doneSteps
-          , counterExampleSubcontracts: foundcounterExampleSubcontracts
-          } ->
-          explanation
-            ( [ text
-                  ( "Close analysis in progress, " <> show doneSteps
-                      <> " subcontracts out of "
-                      <> show totalSteps
-                      <> " analysed..."
+        , text
+            "Static analysis found the following subcontracts that are unreachable:"
+        ]
+          <>
+            [ ul [ classes [ ClassName "indented-enum-initial" ] ] do
+                contractPath <- toUnfoldable
+                  (toList counterExampleSubcontracts)
+                pure
+                  ( li_ $ displayContractPath (text "Unreachable code")
+                      contractPath
                   )
-              ]
-                <>
-                  if null foundcounterExampleSubcontracts then
-                    [ br_, text "No refunds on Close found so far." ]
-                  else
-                    ( [ br_
-                      , text "Found the following refunds on Close so far:"
-                      ]
-                        <>
-                          [ ul [ classes [ ClassName "indented-enum-initial" ] ]
-                              do
-                                contractPath <- toUnfoldable
-                                  foundcounterExampleSubcontracts
-                                pure
-                                  ( li_ $ displayContractPath (text "Close")
-                                      contractPath
-                                  )
-                          ]
-                    )
+            ]
+      )
+    AnalysisFinishedAndPassed ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Reachability Analysis Result: Pass" ]
+      , text
+          "Reachability analysis could not find any subcontract that is not reachable."
+      ]
+
+closeAnalysisResult
+  :: forall action m
+   . MonadAff m
+  => MultiStageAnalysisData
+  -> ComponentHTML action ChildSlots m
+closeAnalysisResult closeAnalysisSubResult = div
+  [ classNames [ "padded-explanation" ] ]
+  case closeAnalysisSubResult of
+    AnalysisNotStarted -> [ text "" ]
+    AnalysisInProgress
+      { numSubproblems: totalSteps
+      , numSolvedSubproblems: doneSteps
+      , counterExampleSubcontracts: foundcounterExampleSubcontracts
+      } ->
+      ( [ text
+            ( "Close analysis in progress, " <> show doneSteps
+                <> " subcontracts out of "
+                <> show totalSteps
+                <> " analysed..."
             )
-        AnalysisFailure err ->
-          explanation
-            [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                [ text "Error during Close refund analysis" ]
-            , text "Close refund analysis failed for the following reason:"
-            , ul [ classes [ ClassName "indented-enum-initial" ] ]
-                [ li_
-                    [ b_ [ spanText err ]
-                    ]
+        ]
+          <>
+            if null foundcounterExampleSubcontracts then
+              [ br_, text "No refunds on Close found so far." ]
+            else
+              ( [ br_
+                , text "Found the following refunds on Close so far:"
                 ]
-            ]
-        AnalysisFoundCounterExamples { counterExampleSubcontracts } ->
-          explanation
-            ( [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                  [ text
-                      "Close Refund Analysis Result: Some of the Close constructs may refund assets"
-                  ]
-              , text
-                  "The following Close constructs may implicitly refund money:"
+                  <>
+                    [ ul [ classes [ ClassName "indented-enum-initial" ] ]
+                        do
+                          contractPath <- toUnfoldable
+                            foundcounterExampleSubcontracts
+                          pure
+                            ( li_ $ displayContractPath (text "Close")
+                                contractPath
+                            )
+                    ]
+              )
+      )
+    AnalysisFailure err ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Error during Close refund analysis" ]
+      , text "Close refund analysis failed for the following reason:"
+      , ul [ classes [ ClassName "indented-enum-initial" ] ]
+          [ li_
+              [ b_ [ spanText err ]
               ]
-                <>
-                  [ ul [ classes [ ClassName "indented-enum-initial" ] ] do
-                      contractPath <- toUnfoldable
-                        (toList counterExampleSubcontracts)
-                      pure
-                        (li_ $ displayContractPath (text "Close") contractPath)
-                  ]
-                <>
-                  [ text
-                      "This does not necessarily mean there is anything wrong with the contract."
-                  ]
-            )
-        AnalysisFinishedAndPassed ->
-          explanation
-            [ h3 [ classes [ ClassName "analysis-result-title" ] ]
-                [ text "Close Refund Analysis Result: No implicit refunds" ]
-            , text
-                "None of the Close constructs refunds any money, all refunds are explicit."
+          ]
+      ]
+    AnalysisFoundCounterExamples { counterExampleSubcontracts } ->
+      ( [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+            [ text
+                "Close Refund Analysis Result: Some of the Close constructs may refund assets"
             ]
+        , text
+            "The following Close constructs may implicitly refund money:"
+        ]
+          <>
+            [ ul [ classes [ ClassName "indented-enum-initial" ] ] do
+                contractPath <- toUnfoldable
+                  (toList counterExampleSubcontracts)
+                pure
+                  (li_ $ displayContractPath (text "Close") contractPath)
+            ]
+          <>
+            [ text
+                "This does not necessarily mean there is anything wrong with the contract."
+            ]
+      )
+    AnalysisFinishedAndPassed ->
+      [ h3 [ classes [ ClassName "analysis-result-title" ] ]
+          [ text "Close Refund Analysis Result: No implicit refunds" ]
+      , text
+          "None of the Close constructs refunds any money, all refunds are explicit."
+      ]
 
 displayTransactionList
   :: forall p action. Minutes -> Array TransactionInput -> HTML p action

--- a/marlowe-playground-client/tailwind.config.js
+++ b/marlowe-playground-client/tailwind.config.js
@@ -25,7 +25,7 @@ module.exports = {
       darkgray: "#b7b7b7",
       purple: "#4700c3",
       lightpurple: "#8701fc",
-
+      "layout-accent": "rgba(51, 51, 51, 0.2)",
       gray: {
         light: "#f8f8f8",
         dark: "#e7e7e9",


### PR DESCRIPTION
This PR removes the need of the `Clear` button in the Static Analysis tool by always showing the template parameters on the  right of the panel, and by clearing the static analysis when the code or a template parameter changes.

This can be previewed in [this deploy](https://marlowe-playground-hernan.plutus.aws.iohkdev.io/#/).

Before
<img width="1791" alt="Screen Shot 2022-06-03 at 14 15 23" src="https://user-images.githubusercontent.com/2634059/171913993-41be4a3e-c4ad-4a82-abe1-115c08d8f9d9.png">

After
<img width="1790" alt="Screen Shot 2022-06-03 at 14 13 41" src="https://user-images.githubusercontent.com/2634059/171914025-985db117-4812-4d1b-a96c-cd739e5f257d.png">


Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
