### PR TITLE
scp 4141 fix warning crash

### DIFF
--- a/marlowe-playground-client/grammar.ne
+++ b/marlowe-playground-client/grammar.ne
@@ -90,7 +90,7 @@ number
 
 timeout
    -> hole {% ([hole]) => hole %}
-    | number {% ([n]) => opts.mkTerm(opts.mkExtendedTimeValue(n))({startLineNumber: n.line, startColumn: n.col, endLineNumber: n.line, endColumn: n.col + n.toString(10).length}) %}
+    | %number {% ([n]) => opts.mkTerm(opts.mkExtendedTimeValue(n.value))({startLineNumber: n.line, startColumn: n.col, endLineNumber: n.line, endColumn: n.col + n.toString(10).length}) %}
     | lparen "TimeParam" someWS string rparen {% ([start,{line,col},,s,end]) => opts.mkTerm(opts.mkExtendedTimeParam(s))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 string

--- a/marlowe-playground-client/src/Marlowe/Parser.purs
+++ b/marlowe-playground-client/src/Marlowe/Parser.purs
@@ -45,7 +45,7 @@ type HelperFunctions a =
   , getRange :: Term a -> IRange
   , mkBigInteger :: Int -> BigInt
   , mkPOSIXTime :: BigInt -> POSIXTime
-  , mkExtendedTimeValue :: BigInt -> Timeout
+  , mkExtendedTimeValue :: String -> Timeout
   , mkExtendedTimeParam :: String -> Timeout
   , mkClose :: Contract
   , mkPay ::
@@ -116,8 +116,9 @@ helperFunctions =
   , getRange: getLocation >>> locationToRange
   , mkBigInteger: BigInt.fromInt
   , mkPOSIXTime: \bi -> unsafePartial $ fromJust $ POSIXTime.fromBigInt bi
-  , mkExtendedTimeValue:
-      \bi -> H.TimeValue <<< unsafePartial $ fromJust $ POSIXTime.fromBigInt bi
+  , mkExtendedTimeValue: \str ->
+      H.TimeValue <<< unsafePartial $ fromJust $ POSIXTime.fromBigInt =<<
+        BigInt.fromString str
   , mkExtendedTimeParam: TimeParam
   , mkClose: Close
   , mkPay: Pay


### PR DESCRIPTION
This PR fixes an issue in the Blockly editor, where a warning that pointed to a Timeout crashed.
The problem was that we were using the `number` rule that doesn't have Position information instead of using the `%number` token that does.

The fix can be checked in [this deploy](https://marlowe-playground-hernan.plutus.aws.iohkdev.io/)
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
