### PR TITLE
SCP-4067 - Make static analysis consider unreachable `Close` contracts

### DIFF
--- a/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
+++ b/marlowe-playground-client/src/StaticAnalysis/Reachability.purs
@@ -37,7 +37,7 @@ import StaticAnalysis.Types
   , AnalysisState
   , ContractPath
   , ContractPathStep
-  , ContractZipper(..)
+  , ContractZipper
   , MultiStageAnalysisData(..)
   , MultiStageAnalysisProblemDef
   , PrefixMap
@@ -78,16 +78,7 @@ expandSubproblem z _ = zipperToContractPath z /\ closeZipperContract z
   (Assert FalseObs Close)
 
 isValidSubproblem :: ContractZipper -> Contract -> Boolean
-isValidSubproblem (IfTrueZip _ _ _) c
-  | c /= Close = true
-
-isValidSubproblem (IfFalseZip _ _ _) c
-  | c /= Close = true
-
-isValidSubproblem (WhenCaseZip _ _ _ _ _ _) c
-  | c /= Close = true
-
-isValidSubproblem _ _ = false
+isValidSubproblem _ _ = true
 
 reachabilityAnalysisDef :: MultiStageAnalysisProblemDef
 reachabilityAnalysisDef =


### PR DESCRIPTION
Modify reachability static analysis so that it also flags when a `Close` contract is unreachable (not just non-trivial contracts)
Deployed to: https://marlowe-playground-pablo.plutus.aws.iohkdev.io/