### PR TITLE
Make Marlowe chain agnostic

### DIFF
--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/BusinessEvents.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/BusinessEvents.hs
@@ -6,7 +6,7 @@ module Language.Marlowe.ACTUS.Domain.BusinessEvents where
 
 import Data.Aeson.Types (FromJSON, ToJSON)
 import GHC.Generics (Generic)
-import Language.Marlowe (Token, Value)
+import Language.Marlowe (PubKeyHash, Token, Value)
 
 {-| ACTUS event types
     https://github.com/actusfrf/actus-dictionary/blob/master/actus-dictionary-event.json
@@ -54,4 +54,4 @@ data RiskFactorsPoly a = RiskFactorsPoly
     deriving anyclass (FromJSON, ToJSON)
 
 type RiskFactors = RiskFactorsPoly Double
-type RiskFactorsMarlowe = RiskFactorsPoly (Value Token)
+type RiskFactorsMarlowe = RiskFactorsPoly (Value PubKeyHash Token)

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/BusinessEvents.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/BusinessEvents.hs
@@ -6,7 +6,7 @@ module Language.Marlowe.ACTUS.Domain.BusinessEvents where
 
 import Data.Aeson.Types (FromJSON, ToJSON)
 import GHC.Generics (Generic)
-import Language.Marlowe (Observation, Value)
+import Language.Marlowe (Observation, Token, Value)
 
 {-| ACTUS event types
     https://github.com/actusfrf/actus-dictionary/blob/master/actus-dictionary-event.json
@@ -54,4 +54,4 @@ data RiskFactorsPoly a = RiskFactorsPoly
     deriving anyclass (FromJSON, ToJSON)
 
 type RiskFactors = RiskFactorsPoly Double
-type RiskFactorsMarlowe = RiskFactorsPoly (Value Observation)
+type RiskFactorsMarlowe = RiskFactorsPoly (Value (Observation Token) Token)

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/BusinessEvents.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/BusinessEvents.hs
@@ -6,7 +6,7 @@ module Language.Marlowe.ACTUS.Domain.BusinessEvents where
 
 import Data.Aeson.Types (FromJSON, ToJSON)
 import GHC.Generics (Generic)
-import Language.Marlowe (Observation, Token, Value)
+import Language.Marlowe (Token, Value)
 
 {-| ACTUS event types
     https://github.com/actusfrf/actus-dictionary/blob/master/actus-dictionary-event.json
@@ -54,4 +54,4 @@ data RiskFactorsPoly a = RiskFactorsPoly
     deriving anyclass (FromJSON, ToJSON)
 
 type RiskFactors = RiskFactorsPoly Double
-type RiskFactorsMarlowe = RiskFactorsPoly (Value (Observation Token) Token)
+type RiskFactorsMarlowe = RiskFactorsPoly (Value Token)

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractState.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractState.hs
@@ -9,7 +9,7 @@ module Language.Marlowe.ACTUS.Domain.ContractState where
 import Data.Aeson.Types (ToJSON)
 import Data.Time (LocalTime)
 import GHC.Generics (Generic)
-import Language.Marlowe (Observation, Value)
+import Language.Marlowe (Observation, Token, Value)
 import Language.Marlowe.ACTUS.Domain.ContractTerms (PRF)
 
 {-| ACTUS contract states are defined in
@@ -37,7 +37,7 @@ data ContractStatePoly a = ContractStatePoly
   deriving stock (Show, Eq)
 
 type ContractState = ContractStatePoly Double
-type ContractStateMarlowe = ContractStatePoly (Value Observation)
+type ContractStateMarlowe = ContractStatePoly (Value (Observation Token) Token)
 
 deriving instance Generic ContractState
 deriving instance ToJSON ContractState

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractState.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractState.hs
@@ -9,7 +9,7 @@ module Language.Marlowe.ACTUS.Domain.ContractState where
 import Data.Aeson.Types (ToJSON)
 import Data.Time (LocalTime)
 import GHC.Generics (Generic)
-import Language.Marlowe (Observation, Token, Value)
+import Language.Marlowe (Token, Value)
 import Language.Marlowe.ACTUS.Domain.ContractTerms (PRF)
 
 {-| ACTUS contract states are defined in
@@ -37,7 +37,7 @@ data ContractStatePoly a = ContractStatePoly
   deriving stock (Show, Eq)
 
 type ContractState = ContractStatePoly Double
-type ContractStateMarlowe = ContractStatePoly (Value (Observation Token) Token)
+type ContractStateMarlowe = ContractStatePoly (Value Token)
 
 deriving instance Generic ContractState
 deriving instance ToJSON ContractState

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractState.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractState.hs
@@ -9,7 +9,7 @@ module Language.Marlowe.ACTUS.Domain.ContractState where
 import Data.Aeson.Types (ToJSON)
 import Data.Time (LocalTime)
 import GHC.Generics (Generic)
-import Language.Marlowe (Token, Value)
+import Language.Marlowe (PubKeyHash, Token, Value)
 import Language.Marlowe.ACTUS.Domain.ContractTerms (PRF)
 
 {-| ACTUS contract states are defined in
@@ -37,7 +37,7 @@ data ContractStatePoly a = ContractStatePoly
   deriving stock (Show, Eq)
 
 type ContractState = ContractStatePoly Double
-type ContractStateMarlowe = ContractStatePoly (Value Token)
+type ContractStateMarlowe = ContractStatePoly (Value PubKeyHash Token)
 
 deriving instance Generic ContractState
 deriving instance ToJSON ContractState

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractTerms.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractTerms.hs
@@ -18,7 +18,7 @@ import Data.Text as T hiding (reverse, takeWhile)
 import Data.Text.Read as T
 import Data.Time (Day, LocalTime)
 import GHC.Generics (Generic)
-import qualified Language.Marlowe as Marlowe (Observation, Value)
+import qualified Language.Marlowe as Marlowe (Observation, Token, Value)
 
 -- |ContractType
 data CT = PAM   -- ^ Principal at maturity
@@ -585,7 +585,7 @@ instance FromJSON ContractTerms where
   parseJSON _ = mzero
 
 type ContractTerms = ContractTermsPoly Double
-type ContractTermsMarlowe = ContractTermsPoly (Marlowe.Value Marlowe.Observation)
+type ContractTermsMarlowe = ContractTermsPoly (Marlowe.Value (Marlowe.Observation Marlowe.Token) Marlowe.Token)
 
 setDefaultContractTermValues :: ContractTerms -> ContractTerms
 setDefaultContractTermValues ct@ContractTermsPoly {..} =

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractTerms.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractTerms.hs
@@ -18,7 +18,7 @@ import Data.Text as T hiding (reverse, takeWhile)
 import Data.Text.Read as T
 import Data.Time (Day, LocalTime)
 import GHC.Generics (Generic)
-import qualified Language.Marlowe as Marlowe (Observation, Token, Value)
+import qualified Language.Marlowe as Marlowe (Token, Value)
 
 -- |ContractType
 data CT = PAM   -- ^ Principal at maturity
@@ -585,7 +585,7 @@ instance FromJSON ContractTerms where
   parseJSON _ = mzero
 
 type ContractTerms = ContractTermsPoly Double
-type ContractTermsMarlowe = ContractTermsPoly (Marlowe.Value (Marlowe.Observation Marlowe.Token) Marlowe.Token)
+type ContractTermsMarlowe = ContractTermsPoly (Marlowe.Value Marlowe.Token)
 
 setDefaultContractTermValues :: ContractTerms -> ContractTerms
 setDefaultContractTermValues ct@ContractTermsPoly {..} =

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractTerms.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/ContractTerms.hs
@@ -18,7 +18,7 @@ import Data.Text as T hiding (reverse, takeWhile)
 import Data.Text.Read as T
 import Data.Time (Day, LocalTime)
 import GHC.Generics (Generic)
-import qualified Language.Marlowe as Marlowe (Token, Value)
+import qualified Language.Marlowe as Marlowe (PubKeyHash, Token, Value)
 
 -- |ContractType
 data CT = PAM   -- ^ Principal at maturity
@@ -585,7 +585,7 @@ instance FromJSON ContractTerms where
   parseJSON _ = mzero
 
 type ContractTerms = ContractTermsPoly Double
-type ContractTermsMarlowe = ContractTermsPoly (Marlowe.Value Marlowe.Token)
+type ContractTermsMarlowe = ContractTermsPoly (Marlowe.Value Marlowe.PubKeyHash Marlowe.Token)
 
 setDefaultContractTermValues :: ContractTerms -> ContractTerms
 setDefaultContractTermValues ct@ContractTermsPoly {..} =

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/Ops.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/Ops.hs
@@ -4,7 +4,7 @@
 module Language.Marlowe.ACTUS.Domain.Ops where
 
 import Data.Time (LocalTime)
-import Language.Marlowe (Observation (..), Value (..))
+import Language.Marlowe (Observation (..), Token, Value (..))
 import Language.Marlowe.ACTUS.Domain.ContractTerms (CR (..), DCC (..))
 import Language.Marlowe.ACTUS.Utility.YearFraction (yearFraction)
 
@@ -49,7 +49,7 @@ class (ActusNum a, ActusOps a) => RoleSignOps a where
     _r CR_PF  = _negate _one
 
 instance RoleSignOps Double
-instance RoleSignOps (Value Observation)
+instance RoleSignOps (Value (Observation Token) Token)
 
 instance ActusOps Double where
     _min  = min
@@ -72,12 +72,12 @@ instance YearFractionOps Double where
 instance ScheduleOps Double where
     _ceiling = ceiling
 
-instance YearFractionOps (Value Observation) where
+instance YearFractionOps (Value (Observation Token) Token) where
     _y a b c d = Constant . toMarloweFixedPoint $ yearFraction a b c d
       where
         toMarloweFixedPoint = round <$> (fromIntegral marloweFixedPoint Prelude.*)
 
-instance ScheduleOps (Value Observation) where
+instance ScheduleOps (Value (Observation Token) Token) where
     _ceiling (Constant a) = a `div` marloweFixedPoint
     -- ACTUS is implemented only for Fixed Schedules
     -- that means schedules are known before the contract
@@ -85,7 +85,7 @@ instance ScheduleOps (Value Observation) where
     -- riskfactors
     _ceiling _            = error "Precondition: Fixed schedules"
 
-instance ActusOps (Value Observation) where
+instance ActusOps (Value (Observation Token) Token) where
     _min a b = Cond (ValueLT a b) a b
     _max a b = Cond (ValueGT a b) a b
     _abs a = _max a (SubValue _zero a)
@@ -97,7 +97,7 @@ instance ActusOps (Value Observation) where
 infixl 7  *, /
 infixl 6  +, -
 
-instance ActusNum (Value Observation) where
+instance ActusNum (Value (Observation Token) Token) where
   -- add
   x + (Constant 0)            = x
   (Constant 0) + y            = y

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/Ops.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/Ops.hs
@@ -4,7 +4,7 @@
 module Language.Marlowe.ACTUS.Domain.Ops where
 
 import Data.Time (LocalTime)
-import Language.Marlowe (Observation (..), Token, Value, Value_ (..))
+import Language.Marlowe (Observation (..), PubKeyHash, Token, Value, Value_ (..))
 import Language.Marlowe.ACTUS.Domain.ContractTerms (CR (..), DCC (..))
 import Language.Marlowe.ACTUS.Utility.YearFraction (yearFraction)
 
@@ -49,7 +49,7 @@ class (ActusNum a, ActusOps a) => RoleSignOps a where
     _r CR_PF  = _negate _one
 
 instance RoleSignOps Double
-instance RoleSignOps (Value Token)
+instance RoleSignOps (Value PubKeyHash Token)
 
 instance ActusOps Double where
     _min  = min
@@ -72,12 +72,12 @@ instance YearFractionOps Double where
 instance ScheduleOps Double where
     _ceiling = ceiling
 
-instance YearFractionOps (Value Token) where
+instance YearFractionOps (Value PubKeyHash Token) where
     _y a b c d = Constant . toMarloweFixedPoint $ yearFraction a b c d
       where
         toMarloweFixedPoint = round <$> (fromIntegral marloweFixedPoint Prelude.*)
 
-instance ScheduleOps (Value Token) where
+instance ScheduleOps (Value PubKeyHash Token) where
     _ceiling (Constant a) = a `div` marloweFixedPoint
     -- ACTUS is implemented only for Fixed Schedules
     -- that means schedules are known before the contract
@@ -85,7 +85,7 @@ instance ScheduleOps (Value Token) where
     -- riskfactors
     _ceiling _            = error "Precondition: Fixed schedules"
 
-instance ActusOps (Value Token) where
+instance ActusOps (Value PubKeyHash Token) where
     _min a b = Cond (ValueLT a b) a b
     _max a b = Cond (ValueGT a b) a b
     _abs a = _max a (SubValue _zero a)
@@ -97,7 +97,7 @@ instance ActusOps (Value Token) where
 infixl 7  *, /
 infixl 6  +, -
 
-instance ActusNum (Value Token) where
+instance ActusNum (Value PubKeyHash Token) where
   -- add
   x + (Constant 0)            = x
   (Constant 0) + y            = y

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/Ops.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Domain/Ops.hs
@@ -4,7 +4,7 @@
 module Language.Marlowe.ACTUS.Domain.Ops where
 
 import Data.Time (LocalTime)
-import Language.Marlowe (Observation (..), Token, Value (..))
+import Language.Marlowe (Observation (..), Token, Value, Value_ (..))
 import Language.Marlowe.ACTUS.Domain.ContractTerms (CR (..), DCC (..))
 import Language.Marlowe.ACTUS.Utility.YearFraction (yearFraction)
 
@@ -49,7 +49,7 @@ class (ActusNum a, ActusOps a) => RoleSignOps a where
     _r CR_PF  = _negate _one
 
 instance RoleSignOps Double
-instance RoleSignOps (Value (Observation Token) Token)
+instance RoleSignOps (Value Token)
 
 instance ActusOps Double where
     _min  = min
@@ -72,12 +72,12 @@ instance YearFractionOps Double where
 instance ScheduleOps Double where
     _ceiling = ceiling
 
-instance YearFractionOps (Value (Observation Token) Token) where
+instance YearFractionOps (Value Token) where
     _y a b c d = Constant . toMarloweFixedPoint $ yearFraction a b c d
       where
         toMarloweFixedPoint = round <$> (fromIntegral marloweFixedPoint Prelude.*)
 
-instance ScheduleOps (Value (Observation Token) Token) where
+instance ScheduleOps (Value Token) where
     _ceiling (Constant a) = a `div` marloweFixedPoint
     -- ACTUS is implemented only for Fixed Schedules
     -- that means schedules are known before the contract
@@ -85,7 +85,7 @@ instance ScheduleOps (Value (Observation Token) Token) where
     -- riskfactors
     _ceiling _            = error "Precondition: Fixed schedules"
 
-instance ActusOps (Value (Observation Token) Token) where
+instance ActusOps (Value Token) where
     _min a b = Cond (ValueLT a b) a b
     _max a b = Cond (ValueGT a b) a b
     _abs a = _max a (SubValue _zero a)
@@ -97,7 +97,7 @@ instance ActusOps (Value (Observation Token) Token) where
 infixl 7  *, /
 infixl 6  +, -
 
-instance ActusNum (Value (Observation Token) Token) where
+instance ActusNum (Value Token) where
   -- add
   x + (Constant 0)            = x
   (Constant 0) + y            = y

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/Generator.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/Generator.hs
@@ -11,10 +11,10 @@ where
 
 import Data.String (IsString (fromString))
 import Language.Marlowe (Action (..), Case (..), Contract (..), Observation (..), POSIXTime (..), Party (..),
-                         Payee (..), Value (..), ada)
+                         Payee (..), Token, Value (..), ada)
 import Ledger.Value (TokenName (TokenName))
 
-invoice :: String -> String -> Value Observation -> POSIXTime -> Contract -> Contract
+invoice :: String -> String -> Value (Observation Token) Token -> POSIXTime -> Contract Token -> Contract Token
 invoice from to amount timeout continue =
   let party = Role $ TokenName $ fromString from
       counterparty = Role $ TokenName $ fromString to

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/Generator.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/Generator.hs
@@ -10,11 +10,11 @@ module Language.Marlowe.ACTUS.Generator.Generator
 where
 
 import Data.String (IsString (fromString))
-import Language.Marlowe (Action (..), Case_ (..), Contract (..), POSIXTime (..), Party (..), Payee (..), Token, Value,
-                         ada)
+import Language.Marlowe (Action (..), Case_ (..), Contract (..), POSIXTime (..), Party (..), Payee (..), PubKeyHash,
+                         Token, Value, ada)
 import Ledger.Value (TokenName (TokenName))
 
-invoice :: String -> String -> Value Token -> POSIXTime -> Contract Token -> Contract Token
+invoice :: String -> String -> Value PubKeyHash Token -> POSIXTime -> Contract PubKeyHash Token -> Contract PubKeyHash Token
 invoice from to amount timeout continue =
   let party = Role $ TokenName $ fromString from
       counterparty = Role $ TokenName $ fromString to

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/Generator.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/Generator.hs
@@ -10,11 +10,11 @@ module Language.Marlowe.ACTUS.Generator.Generator
 where
 
 import Data.String (IsString (fromString))
-import Language.Marlowe (Action (..), Case (..), Contract (..), Observation (..), POSIXTime (..), Party (..),
-                         Payee (..), Token, Value (..), ada)
+import Language.Marlowe (Action (..), Case_ (..), Contract (..), POSIXTime (..), Party (..), Payee (..), Token, Value,
+                         ada)
 import Ledger.Value (TokenName (TokenName))
 
-invoice :: String -> String -> Value (Observation Token) Token -> POSIXTime -> Contract Token -> Contract Token
+invoice :: String -> String -> Value Token -> POSIXTime -> Contract Token -> Contract Token
 invoice from to amount timeout continue =
   let party = Role $ TokenName $ fromString from
       counterparty = Role $ TokenName $ fromString to

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorFs.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorFs.hs
@@ -44,7 +44,7 @@ genFsContract' ::
 genFsContract' rf ct =
   let cfs = genProjectedCashflows rf ct
 
-      gen :: CashFlowPoly (Value (Observation Token) Token) -> Contract Token -> Contract Token
+      gen :: CashFlowPoly (Value Token) -> Contract Token -> Contract Token
       gen CashFlowPoly {..} cont =
         let t = POSIXTime $ timeToSlotNumber cashPaymentDay
             a = reduce $ DivValue amount (Constant marloweFixedPoint)
@@ -99,7 +99,7 @@ reduceObservation (ValueLT a b) = ValueLT (reduce a) (reduce b)
 reduceObservation (ValueEQ a b) = ValueEQ (reduce a) (reduce b)
 reduceObservation x             = x
 
-reduce :: Value (Observation t) t -> Value (Observation t) t
+reduce :: Value t -> Value t
 reduce (ChoiceValue i) = ChoiceValue i
 reduce (UseValue i) = UseValue i
 reduce (Constant i) = Constant i

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorFs.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorFs.hs
@@ -32,19 +32,19 @@ import Language.Marlowe.ACTUS.Model.Applicability (validateTerms)
 -- to genereate a Marlowe contract with risk factors observed at a given point
 -- in time
 genFsContract ::
-     (EventType -> LocalTime -> RiskFactorsMarlowe)     -- ^ Risk factors per event and time
-  -> ContractTermsMarlowe                               -- ^ ACTUS contract terms
-  -> Validation [TermValidationError] (Contract Token)  -- ^ Marlowe contract or applicabilty errors
+     (EventType -> LocalTime -> RiskFactorsMarlowe)                -- ^ Risk factors per event and time
+  -> ContractTermsMarlowe                                          -- ^ ACTUS contract terms
+  -> Validation [TermValidationError] (Contract PubKeyHash Token)  -- ^ Marlowe contract or applicabilty errors
 genFsContract rf = fmap (genFsContract' rf) . validateTerms
 
 genFsContract' ::
   (EventType -> LocalTime -> RiskFactorsMarlowe) ->
   ContractTermsMarlowe ->
-  Contract Token
+  Contract PubKeyHash Token
 genFsContract' rf ct =
   let cfs = genProjectedCashflows rf ct
 
-      gen :: CashFlowPoly (Value Token) -> Contract Token -> Contract Token
+      gen :: CashFlowPoly (Value PubKeyHash Token) -> Contract PubKeyHash Token -> Contract PubKeyHash Token
       gen CashFlowPoly {..} cont =
         let t = POSIXTime $ timeToSlotNumber cashPaymentDay
             a = reduce $ DivValue amount (Constant marloweFixedPoint)
@@ -88,7 +88,7 @@ genFsContract' rf ct =
                   )
    in foldl' (flip gen) Close $ reverse cfs
 
-reduceObservation :: Observation t -> Observation t
+reduceObservation :: Observation i t -> Observation i t
 reduceObservation (AndObs a b)  = AndObs (reduceObservation a) (reduceObservation b)
 reduceObservation (OrObs a b)   = OrObs (reduceObservation a) (reduceObservation b)
 reduceObservation (NotObs a)    = NotObs (reduceObservation a)
@@ -99,7 +99,7 @@ reduceObservation (ValueLT a b) = ValueLT (reduce a) (reduce b)
 reduceObservation (ValueEQ a b) = ValueEQ (reduce a) (reduce b)
 reduceObservation x             = x
 
-reduce :: Value t -> Value t
+reduce :: Value i t -> Value i t
 reduce (ChoiceValue i) = ChoiceValue i
 reduce (UseValue i) = UseValue i
 reduce (Constant i) = Constant i

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorStatic.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorStatic.hs
@@ -14,7 +14,7 @@ where
 import Data.List as L (foldl')
 import Data.Time (LocalTime)
 import Data.Validation (Validation (..))
-import Language.Marlowe (Contract (..), POSIXTime (..), Value (..))
+import Language.Marlowe (Contract (..), POSIXTime (..), Token, Value (..))
 import Language.Marlowe.ACTUS.Domain.BusinessEvents (EventType (..), RiskFactors)
 import Language.Marlowe.ACTUS.Domain.ContractTerms (ContractTerms, TermValidationError (..))
 import Language.Marlowe.ACTUS.Domain.Schedule (CashFlowPoly (..))
@@ -27,16 +27,16 @@ import Language.Marlowe.ACTUS.Model.Applicability (validateTerms)
 -- Marlowe contract with risk factors known in advance. The contract therefore
 -- only consists of transactions, i.e. 'Deposit' and 'Pay'
 genStaticContract ::
-     (EventType -> LocalTime -> RiskFactors)   -- ^ Risk factors per event and time
-  -> ContractTerms                             -- ^ ACTUS contract terms
-  -> Validation [TermValidationError] Contract -- ^ Marlowe contract or applicability errors
+     (EventType -> LocalTime -> RiskFactors)           -- ^ Risk factors per event and time
+  -> ContractTerms                                     -- ^ ACTUS contract terms
+  -> Validation [TermValidationError] (Contract Token) -- ^ Marlowe contract or applicability errors
 genStaticContract rf = fmap (genStaticContract' rf) . validateTerms
 
 -- |Same as 'genStaticContract' without validation
 genStaticContract' ::
      (EventType -> LocalTime -> RiskFactors)
   -> ContractTerms
-  -> Contract
+  -> Contract Token
 genStaticContract' rf ct =
   let cfs = genProjectedCashflows rf ct
       gen CashFlowPoly {..}

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorStatic.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorStatic.hs
@@ -14,7 +14,7 @@ where
 import Data.List as L (foldl')
 import Data.Time (LocalTime)
 import Data.Validation (Validation (..))
-import Language.Marlowe (Contract (..), POSIXTime (..), Token, Value (..))
+import Language.Marlowe (Contract (..), POSIXTime (..), Token, Value_ (..))
 import Language.Marlowe.ACTUS.Domain.BusinessEvents (EventType (..), RiskFactors)
 import Language.Marlowe.ACTUS.Domain.ContractTerms (ContractTerms, TermValidationError (..))
 import Language.Marlowe.ACTUS.Domain.Schedule (CashFlowPoly (..))

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorStatic.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/GeneratorStatic.hs
@@ -14,7 +14,7 @@ where
 import Data.List as L (foldl')
 import Data.Time (LocalTime)
 import Data.Validation (Validation (..))
-import Language.Marlowe (Contract (..), POSIXTime (..), Token, Value_ (..))
+import Language.Marlowe (Contract (..), POSIXTime (..), PubKeyHash, Token, Value_ (..))
 import Language.Marlowe.ACTUS.Domain.BusinessEvents (EventType (..), RiskFactors)
 import Language.Marlowe.ACTUS.Domain.ContractTerms (ContractTerms, TermValidationError (..))
 import Language.Marlowe.ACTUS.Domain.Schedule (CashFlowPoly (..))
@@ -27,16 +27,16 @@ import Language.Marlowe.ACTUS.Model.Applicability (validateTerms)
 -- Marlowe contract with risk factors known in advance. The contract therefore
 -- only consists of transactions, i.e. 'Deposit' and 'Pay'
 genStaticContract ::
-     (EventType -> LocalTime -> RiskFactors)           -- ^ Risk factors per event and time
-  -> ContractTerms                                     -- ^ ACTUS contract terms
-  -> Validation [TermValidationError] (Contract Token) -- ^ Marlowe contract or applicability errors
+     (EventType -> LocalTime -> RiskFactors)                      -- ^ Risk factors per event and time
+  -> ContractTerms                                                -- ^ ACTUS contract terms
+  -> Validation [TermValidationError] (Contract PubKeyHash Token) -- ^ Marlowe contract or applicability errors
 genStaticContract rf = fmap (genStaticContract' rf) . validateTerms
 
 -- |Same as 'genStaticContract' without validation
 genStaticContract' ::
      (EventType -> LocalTime -> RiskFactors)
   -> ContractTerms
-  -> Contract Token
+  -> Contract PubKeyHash Token
 genStaticContract' rf ct =
   let cfs = genProjectedCashflows rf ct
       gen CashFlowPoly {..}

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/MarloweCompat.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/MarloweCompat.hs
@@ -7,24 +7,24 @@ module Language.Marlowe.ACTUS.Generator.MarloweCompat where
 import Data.String (IsString (fromString))
 import Data.Time (Day, LocalTime (..), UTCTime (UTCTime), timeOfDayToTime)
 import Data.Time.Clock.System (SystemTime (MkSystemTime), utcToSystemTime)
-import Language.Marlowe (Contract (Let), Observation, Token, Value (Constant, UseValue), ValueId (ValueId))
+import Language.Marlowe (Contract (Let), Token, Value, ValueId (ValueId), Value_ (Constant, UseValue))
 import Language.Marlowe.ACTUS.Domain.ContractTerms
 import Language.Marlowe.ACTUS.Domain.Ops (marloweFixedPoint)
 
-useval :: String -> Integer -> Value (Observation t) t
+useval :: String -> Integer -> Value t
 useval name t = UseValue $ ValueId $ fromString $ name ++ "_" ++ show t
 
-letval :: String -> Integer -> Value (Observation t) t -> Contract t -> Contract t
+letval :: String -> Integer -> Value t -> Contract t -> Contract t
 letval name t = Let $ ValueId $ fromString $ name ++ "_" ++ show t
 
-letval' :: String -> Integer -> Maybe (Value (Observation t) t) -> Contract t -> Contract t
+letval' :: String -> Integer -> Maybe (Value t) -> Contract t -> Contract t
 letval' name t (Just o) c = letval name t o c
 letval' _ _ Nothing c     = c
 
 toMarloweFixedPoint :: Double -> Integer
 toMarloweFixedPoint = round <$> (fromIntegral marloweFixedPoint *)
 
-constnt :: Double -> Value (Observation t) t
+constnt :: Double -> Value t
 constnt = Constant . toMarloweFixedPoint
 
 enum :: a -> a
@@ -43,10 +43,10 @@ timeToSlotNumber LocalTime {..} =
   let (MkSystemTime secs _) = utcToSystemTime (UTCTime localDay (timeOfDayToTime localTimeOfDay))
    in fromIntegral secs - cardanoEpochStart
 
-marloweDate :: Day -> Value (Observation t) t
+marloweDate :: Day -> Value t
 marloweDate = Constant . fromInteger . dayToSlotNumber
 
-marloweTime :: LocalTime -> Value (Observation t) t
+marloweTime :: LocalTime -> Value t
 marloweTime = Constant . fromInteger . timeToSlotNumber
 
 toMarlowe :: ContractTerms -> ContractTermsMarlowe
@@ -130,7 +130,7 @@ toMarlowe ct =
       constraints = constraints ct
     }
   where
-    trans :: ContractStructure Double -> ContractStructure (Value (Observation Token) Token)
+    trans :: ContractStructure Double -> ContractStructure (Value Token)
     trans cs = cs { reference = case reference cs of
                                   ReferenceId r    -> ReferenceId r
                                   ReferenceTerms t -> ReferenceTerms $ toMarlowe t }

--- a/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/MarloweCompat.hs
+++ b/marlowe-actus/src/Language/Marlowe/ACTUS/Generator/MarloweCompat.hs
@@ -7,24 +7,24 @@ module Language.Marlowe.ACTUS.Generator.MarloweCompat where
 import Data.String (IsString (fromString))
 import Data.Time (Day, LocalTime (..), UTCTime (UTCTime), timeOfDayToTime)
 import Data.Time.Clock.System (SystemTime (MkSystemTime), utcToSystemTime)
-import Language.Marlowe (Contract (Let), Token, Value, ValueId (ValueId), Value_ (Constant, UseValue))
+import Language.Marlowe (Contract (Let), PubKeyHash, Token, Value, ValueId (ValueId), Value_ (Constant, UseValue))
 import Language.Marlowe.ACTUS.Domain.ContractTerms
 import Language.Marlowe.ACTUS.Domain.Ops (marloweFixedPoint)
 
-useval :: String -> Integer -> Value t
+useval :: String -> Integer -> Value i t
 useval name t = UseValue $ ValueId $ fromString $ name ++ "_" ++ show t
 
-letval :: String -> Integer -> Value t -> Contract t -> Contract t
+letval :: String -> Integer -> Value i t -> Contract i t -> Contract i t
 letval name t = Let $ ValueId $ fromString $ name ++ "_" ++ show t
 
-letval' :: String -> Integer -> Maybe (Value t) -> Contract t -> Contract t
+letval' :: String -> Integer -> Maybe (Value i t) -> Contract i t -> Contract i t
 letval' name t (Just o) c = letval name t o c
 letval' _ _ Nothing c     = c
 
 toMarloweFixedPoint :: Double -> Integer
 toMarloweFixedPoint = round <$> (fromIntegral marloweFixedPoint *)
 
-constnt :: Double -> Value t
+constnt :: Double -> Value i t
 constnt = Constant . toMarloweFixedPoint
 
 enum :: a -> a
@@ -43,10 +43,10 @@ timeToSlotNumber LocalTime {..} =
   let (MkSystemTime secs _) = utcToSystemTime (UTCTime localDay (timeOfDayToTime localTimeOfDay))
    in fromIntegral secs - cardanoEpochStart
 
-marloweDate :: Day -> Value t
+marloweDate :: Day -> Value i t
 marloweDate = Constant . fromInteger . dayToSlotNumber
 
-marloweTime :: LocalTime -> Value t
+marloweTime :: LocalTime -> Value i t
 marloweTime = Constant . fromInteger . timeToSlotNumber
 
 toMarlowe :: ContractTerms -> ContractTermsMarlowe
@@ -130,7 +130,7 @@ toMarlowe ct =
       constraints = constraints ct
     }
   where
-    trans :: ContractStructure Double -> ContractStructure (Value Token)
+    trans :: ContractStructure Double -> ContractStructure (Value PubKeyHash Token)
     trans cs = cs { reference = case reference cs of
                                   ReferenceId r    -> ReferenceId r
                                   ReferenceTerms t -> ReferenceTerms $ toMarlowe t }

--- a/marlowe-actus/test/Spec/Marlowe/ACTUS/Examples.hs
+++ b/marlowe-actus/test/Spec/Marlowe/ACTUS/Examples.hs
@@ -375,7 +375,7 @@ defaultRiskFactors _ _ =
     }
 
 -- |totalPayments calculates the sum of the payments provided as argument
-totalPayments :: Payee -> [Payment Token] -> Integer
+totalPayments :: Payee PubKeyHash -> [Payment PubKeyHash Token] -> Integer
 totalPayments payee = sum . map m . filter f
   where
     m (Payment _ _ mon) = Val.valueOf (moneyToValue mon) "" ""

--- a/marlowe-actus/test/Spec/Marlowe/ACTUS/Examples.hs
+++ b/marlowe-actus/test/Spec/Marlowe/ACTUS/Examples.hs
@@ -375,8 +375,8 @@ defaultRiskFactors _ _ =
     }
 
 -- |totalPayments calculates the sum of the payments provided as argument
-totalPayments :: Payee -> [Payment] -> Integer
+totalPayments :: Payee -> [Payment Token] -> Integer
 totalPayments payee = sum . map m . filter f
   where
-    m (Payment _ _ mon) = Val.valueOf mon "" ""
+    m (Payment _ _ mon) = Val.valueOf (moneyToValue mon) "" ""
     f (Payment _ pay _) = pay == payee

--- a/marlowe-cli/src/Language/Marlowe/CLI/ChainIndex.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/ChainIndex.hs
@@ -45,6 +45,7 @@ import Language.Marlowe.Core.V1.Semantics (MarloweData (..), MarloweParams (..))
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Scripts (smallUntypedValidator)
 import Ledger (ciTxOutDatum, ciTxOutValue, toTxOut)
+import Ledger.Crypto (PubKeyHash)
 import Ledger.Scripts (validatorHash)
 import Ledger.TimeSlot (SlotConfig)
 import Ledger.Tx.CardanoAPI (fromCardanoAddress, fromCardanoTxId, fromCardanoValue)
@@ -149,7 +150,7 @@ queryApp runApi params spent outputFile =
     let
       credential = ScriptCredential . validatorHash . validatorScript $ smallUntypedValidator params
     result <- runApi $ queryScript spent credential
-    maybeWriteJson outputFile (result :: [TxOutMarlowe (MarloweData Token)])
+    maybeWriteJson outputFile (result :: [TxOutMarlowe (MarloweData PubKeyHash Token)])
 
 
 -- | Query state of the Marlowe payout script.

--- a/marlowe-cli/src/Language/Marlowe/CLI/ChainIndex.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/ChainIndex.hs
@@ -42,6 +42,7 @@ import Language.Marlowe.CLI.IO (liftCli, maybeWriteJson)
 import Language.Marlowe.CLI.Types (CliError (..), OutputQuery (..))
 import Language.Marlowe.Client.History (histories)
 import Language.Marlowe.Core.V1.Semantics (MarloweData (..), MarloweParams (..))
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Scripts (smallUntypedValidator)
 import Ledger (ciTxOutDatum, ciTxOutValue, toTxOut)
 import Ledger.Scripts (validatorHash)
@@ -148,7 +149,7 @@ queryApp runApi params spent outputFile =
     let
       credential = ScriptCredential . validatorHash . validatorScript $ smallUntypedValidator params
     result <- runApi $ queryScript spent credential
-    maybeWriteJson outputFile (result :: [TxOutMarlowe MarloweData])
+    maybeWriteJson outputFile (result :: [TxOutMarlowe (MarloweData Token)])
 
 
 -- | Query state of the Marlowe payout script.

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Input.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Input.hs
@@ -25,7 +25,8 @@ module Language.Marlowe.CLI.Command.Input (
 import Control.Monad.Except (MonadIO)
 import Language.Marlowe.CLI.Command.Parse (parseParty, parseToken)
 import Language.Marlowe.CLI.Run (makeChoice, makeDeposit, makeNotification)
-import Language.Marlowe.Core.V1.Semantics.Types (AccountId, ChoiceName, ChosenNum, Party, Token)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
+import Language.Marlowe.Core.V1.Semantics.Types (AccountId, ChoiceName, ChosenNum, Party)
 
 import qualified Options.Applicative as O
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Input.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Input.hs
@@ -27,6 +27,7 @@ import Language.Marlowe.CLI.Command.Parse (parseParty, parseToken)
 import Language.Marlowe.CLI.Run (makeChoice, makeDeposit, makeNotification)
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (AccountId, ChoiceName, ChosenNum, Party)
+import Ledger.Crypto (PubKeyHash)
 
 import qualified Options.Applicative as O
 
@@ -36,19 +37,19 @@ data InputCommand =
     -- | Input a deposit to a contract.
     InputDeposit
     {
-      account    :: AccountId       -- ^ The account for the deposit.
-    , party      :: Party           -- ^ The party making the deposit.
-    , token      :: Maybe Token     -- ^ The token being deposited, if not Ada.
-    , amount     :: Integer         -- ^ The amount of the token deposited.
-    , outputFile :: Maybe FilePath  -- ^ The output JSON file representing the input.
+      account    :: AccountId PubKeyHash  -- ^ The account for the deposit.
+    , party      :: Party PubKeyHash      -- ^ The party making the deposit.
+    , token      :: Maybe Token           -- ^ The token being deposited, if not Ada.
+    , amount     :: Integer               -- ^ The amount of the token deposited.
+    , outputFile :: Maybe FilePath        -- ^ The output JSON file representing the input.
     }
     -- | Input a choice to a contract.
   | InputChoice
     {
-      choiceName  :: ChoiceName      -- ^ The name of the choice made.
-    , choiceParty :: Party           -- ^ The party making the choice.
-    , chosen      :: ChosenNum       -- ^ The number chosen.
-    , outputFile  :: Maybe FilePath  -- ^ The output JSON file representing the input.
+      choiceName  :: ChoiceName        -- ^ The name of the choice made.
+    , choiceParty :: Party PubKeyHash  -- ^ The party making the choice.
+    , chosen      :: ChosenNum         -- ^ The number chosen.
+    , outputFile  :: Maybe FilePath    -- ^ The output JSON file representing the input.
     }
     -- | Input a notification to a contract.
   | InputNotify

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Parse.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Parse.hs
@@ -228,7 +228,7 @@ readAddressAnyEither s =
 
 
 -- | Parser for `Party`.
-parseParty :: O.ReadM Party
+parseParty :: O.ReadM (Party PubKeyHash)
 parseParty =
         O.eitherReader readPartyPkEither
     <|> O.eitherReader readPartyRoleEither
@@ -236,8 +236,8 @@ parseParty =
 
 
 -- | Reader for `Party` `PK`.
-readPartyPkEither :: String               -- ^ The string to be read.
-                  -> Either String Party  -- ^ Either the public key hash role or an error message.
+readPartyPkEither :: String                            -- ^ The string to be read.
+                  -> Either String (Party PubKeyHash)  -- ^ Either the public key hash role or an error message.
 readPartyPkEither s =
   case s =~ "^PK=([[:xdigit:]]{56})$" of
     [[_, pubKeyHash]] -> PK <$> readPubKeyHashEither pubKeyHash
@@ -245,8 +245,8 @@ readPartyPkEither s =
 
 
 -- | Reader for `Party` `Role`.
-readPartyRoleEither :: String               -- ^ The string to be read.
-                    -> Either String Party  -- ^ Either the party role or an error message.
+readPartyRoleEither :: String                            -- ^ The string to be read.
+                    -> Either String (Party PubKeyHash)  -- ^ Either the party role or an error message.
 readPartyRoleEither s =
   case s =~ "^Role=(.+)$" of
     [[_, role]] -> Right . Role . TokenName . toBuiltin . BS8.pack $ role
@@ -300,12 +300,12 @@ parseMarloweClientInput = ClientInput <$> parseInputContent
 
 
 -- | Parse input to a contract.
-parseInput :: O.Parser (Input Token)
+parseInput :: O.Parser (Input PubKeyHash Token)
 parseInput = NormalInput <$> parseInputContent
 
 
 -- | Parse input to a contract.
-parseInputContent :: O.Parser (InputContent Token)
+parseInputContent :: O.Parser (InputContent PubKeyHash Token)
 parseInputContent =
   parseDeposit <|> parseChoice <|> parseNotify
     where

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Parse.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Parse.hs
@@ -52,7 +52,8 @@ import Control.Applicative ((<|>))
 import Data.List.Split (splitOn)
 import Language.Marlowe.CLI.Types (OutputQuery (..))
 import Language.Marlowe.Client (MarloweClientInput (..))
-import Language.Marlowe.Core.V1.Semantics.Types (ChoiceId (..), Input (..), InputContent (..), Party (..), Token (..))
+import Language.Marlowe.Core.V1.Semantics.Token (Token (..))
+import Language.Marlowe.Core.V1.Semantics.Types (ChoiceId (..), Input (..), InputContent (..), Party (..))
 import Ledger (POSIXTime (..))
 import Plutus.V1.Ledger.Ada (adaSymbol, adaToken)
 import Plutus.V1.Ledger.Api (BuiltinByteString, CurrencySymbol (..), PubKeyHash (..), TokenName (..), toBuiltin)
@@ -299,12 +300,12 @@ parseMarloweClientInput = ClientInput <$> parseInputContent
 
 
 -- | Parse input to a contract.
-parseInput :: O.Parser Input
+parseInput :: O.Parser (Input Token)
 parseInput = NormalInput <$> parseInputContent
 
 
 -- | Parse input to a contract.
-parseInputContent :: O.Parser InputContent
+parseInputContent :: O.Parser (InputContent Token)
 parseInputContent =
   parseDeposit <|> parseChoice <|> parseNotify
     where

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Run.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Run.hs
@@ -36,6 +36,7 @@ import Language.Marlowe.CLI.Run (initializeTransaction, prepareTransaction, runT
 import Language.Marlowe.CLI.Transaction (querySlotConfig)
 import Language.Marlowe.CLI.Types (CliError)
 import Language.Marlowe.Client (defaultMarloweParams, marloweParams)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Input)
 import Plutus.V1.Ledger.Api (CurrencySymbol, POSIXTime (..), TokenName, defaultCostModelParams)
 
@@ -62,7 +63,7 @@ data RunCommand =
   | Prepare
     {
       marloweInFile :: FilePath        -- ^ The JSON file with Marlowe initial state and initial contract.
-    , inputs'       :: [Input]         -- ^ The contract's inputs.
+    , inputs'       :: [Input Token]   -- ^ The contract's inputs.
     , minimumTime   :: POSIXTime       -- ^ The first valid time for the transaction.
     , maximumTime   :: POSIXTime       -- ^ The last valid time for the transaction.
     , outputFile    :: Maybe FilePath  -- ^ The output JSON file with the results of the computation.

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Run.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Run.hs
@@ -38,6 +38,7 @@ import Language.Marlowe.CLI.Types (CliError)
 import Language.Marlowe.Client (defaultMarloweParams, marloweParams)
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Input)
+import Ledger.Crypto (PubKeyHash)
 import Plutus.V1.Ledger.Api (CurrencySymbol, POSIXTime (..), TokenName, defaultCostModelParams)
 
 import qualified Cardano.Api as Api (Value)
@@ -62,12 +63,12 @@ data RunCommand =
     -- | Prepare a Marlowe transaction for execution.
   | Prepare
     {
-      marloweInFile :: FilePath        -- ^ The JSON file with Marlowe initial state and initial contract.
-    , inputs'       :: [Input Token]   -- ^ The contract's inputs.
-    , minimumTime   :: POSIXTime       -- ^ The first valid time for the transaction.
-    , maximumTime   :: POSIXTime       -- ^ The last valid time for the transaction.
-    , outputFile    :: Maybe FilePath  -- ^ The output JSON file with the results of the computation.
-    , printStats    :: Bool            -- ^ Whether to print statistics about the redeemer.
+      marloweInFile :: FilePath                  -- ^ The JSON file with Marlowe initial state and initial contract.
+    , inputs'       :: [Input PubKeyHash Token]  -- ^ The contract's inputs.
+    , minimumTime   :: POSIXTime                 -- ^ The first valid time for the transaction.
+    , maximumTime   :: POSIXTime                 -- ^ The last valid time for the transaction.
+    , outputFile    :: Maybe FilePath            -- ^ The output JSON file with the results of the computation.
+    , printStats    :: Bool                      -- ^ Whether to print statistics about the redeemer.
     }
     -- | Run a Marlowe transaction.
   | Run

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Template.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Template.hs
@@ -33,6 +33,7 @@ import qualified Language.Marlowe.Core.V1.Semantics.Types as C
 import Language.Marlowe.Extended.V1 as E (AccountId, Contract (..), Party (..), Timeout, Token, Value (..), toCore,
                                           toCore')
 import Language.Marlowe.Util (ada)
+import Ledger.Crypto (PubKeyHash)
 import Marlowe.Contracts (coveredCall, escrow, swap, trivial, zeroCouponBond)
 
 import qualified Options.Applicative as O
@@ -180,7 +181,7 @@ runTemplateCommand TemplateCoveredCall{..}    = let marloweContract = makeContra
 
 
 -- | Conversion from Extended to Core Marlowe.
-makeContract :: E.Contract -> C.Contract Token
+makeContract :: E.Contract -> C.Contract PubKeyHash Token
 makeContract = errorHandling . toCore
   where
     errorHandling (Just contract) = contract
@@ -188,7 +189,7 @@ makeContract = errorHandling . toCore
 
 
 -- | Build the initial Marlowe state.
-initialMarloweState :: AccountId -> Integer -> State Token
+initialMarloweState :: AccountId -> Integer -> State PubKeyHash Token
 initialMarloweState party minAda =
   State
   {
@@ -334,6 +335,6 @@ templateCoveredCallOptions =
 parseParty :: O.ReadM Party
 parseParty = aux <$> P.parseParty
   where
-    aux :: C.Party -> Party
+    aux :: C.Party PubKeyHash -> Party
     aux (C.PK pk)     = PK pk
     aux (C.Role name) = Role name

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Template.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Template.hs
@@ -177,7 +177,7 @@ runTemplateCommand TemplateCoveredCall{..}    = let marloweContract = makeContra
 
 
 -- | Conversion from Extended to Core Marlowe.
-makeContract :: E.Contract -> C.Contract
+makeContract :: E.Contract -> C.Contract Token
 makeContract = errorHandling . toCore
   where
     errorHandling (Just contract) = contract
@@ -185,7 +185,7 @@ makeContract = errorHandling . toCore
 
 
 -- | Build the initial Marlowe state.
-initialMarloweState :: AccountId -> Integer -> State
+initialMarloweState :: AccountId -> Integer -> State Token
 initialMarloweState party minAda =
   State
   {

--- a/marlowe-cli/src/Language/Marlowe/CLI/Examples.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Examples.hs
@@ -23,16 +23,17 @@ module Language.Marlowe.CLI.Examples (
 import Control.Monad.Except (MonadIO, liftIO)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Language.Marlowe.Core.V1.Semantics (MarloweData (..))
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 
 import qualified Data.ByteString.Lazy as LBS (writeFile)
 
 
 -- | Serialise an example contract to JSON.
 makeExample :: MonadIO m
-            => FilePath        -- ^ The output JSON file for the Marlowe contract.
-            -> FilePath        -- ^ The output JSON file for the Marlowe contract's state.
-            -> MarloweData     -- ^ The contract and state data.
-            -> m ()            -- ^ Action to serialise the Marlowe data.
+            => FilePath           -- ^ The output JSON file for the Marlowe contract.
+            -> FilePath           -- ^ The output JSON file for the Marlowe contract's state.
+            -> MarloweData Token  -- ^ The contract and state data.
+            -> m ()               -- ^ Action to serialise the Marlowe data.
 makeExample contractFile stateFile MarloweData{..} =
   liftIO
     $ do

--- a/marlowe-cli/src/Language/Marlowe/CLI/Examples.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Examples.hs
@@ -24,16 +24,17 @@ import Control.Monad.Except (MonadIO, liftIO)
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Language.Marlowe.Core.V1.Semantics (MarloweData (..))
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
+import Ledger.Crypto (PubKeyHash)
 
 import qualified Data.ByteString.Lazy as LBS (writeFile)
 
 
 -- | Serialise an example contract to JSON.
 makeExample :: MonadIO m
-            => FilePath           -- ^ The output JSON file for the Marlowe contract.
-            -> FilePath           -- ^ The output JSON file for the Marlowe contract's state.
-            -> MarloweData Token  -- ^ The contract and state data.
-            -> m ()               -- ^ Action to serialise the Marlowe data.
+            => FilePath                      -- ^ The output JSON file for the Marlowe contract.
+            -> FilePath                      -- ^ The output JSON file for the Marlowe contract's state.
+            -> MarloweData PubKeyHash Token  -- ^ The contract and state data.
+            -> m ()                          -- ^ Action to serialise the Marlowe data.
 makeExample contractFile stateFile MarloweData{..} =
   liftIO
     $ do

--- a/marlowe-cli/src/Language/Marlowe/CLI/Export.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Export.hs
@@ -60,6 +60,7 @@ import Language.Marlowe.CLI.IO (decodeFileStrict, maybeWriteJson, maybeWriteText
 import Language.Marlowe.CLI.Types (CliError (..), DatumInfo (..), MarloweInfo (..), RedeemerInfo (..),
                                    ValidatorInfo (..))
 import Language.Marlowe.Core.V1.Semantics (MarloweData (..), MarloweParams)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Contract (..), Input, State (..))
 import Language.Marlowe.Scripts (marloweTxInputsFromInputs, rolePayoutScript, smallUntypedValidator)
 import Ledger.Scripts (datumHash, toCardanoApiScript, validatorHash)
@@ -81,9 +82,9 @@ buildMarlowe :: IsShelleyBasedEra era
              -> CostModelParams                    -- ^ The cost model parameters.
              -> NetworkId                          -- ^ The network ID.
              -> StakeAddressReference              -- ^ The stake address.
-             -> Contract                           -- ^ The contract.
-             -> State                              -- ^ The contract's state.
-             -> [Input]                            -- ^ The contract's input,
+             -> Contract Token                     -- ^ The contract.
+             -> State Token                        -- ^ The contract's state.
+             -> [Input Token]                      -- ^ The contract's input,
              -> Either CliError (MarloweInfo era)  -- ^ The contract and transaction information, or an error message.
 buildMarlowe marloweParams costModel network stake contract state inputs =
   do
@@ -141,9 +142,9 @@ printMarlowe :: MonadError CliError m
               -> CostModelParams        -- ^ The cost model parameters.
               -> NetworkId              -- ^ The network ID.
               -> StakeAddressReference  -- ^ The stake address.
-              -> Contract               -- ^ The contract.
-              -> State                  -- ^ The contract's state.
-              -> [Input]                -- ^ The contract's input,
+              -> Contract Token         -- ^ The contract.
+              -> State Token            -- ^ The contract's state.
+              -> [Input Token]          -- ^ The contract's input,
               -> m ()                   -- ^ Action to print the contract and transaction information.
 printMarlowe marloweParams costModel network stake contract state inputs =
   do
@@ -338,9 +339,9 @@ buildDatumImpl datum =
 
 
 -- | Build the datum information about a Marlowe transaction.
-buildDatum :: Contract   -- ^ The contract.
-           -> State      -- ^ The contract's state.
-           -> DatumInfo  -- ^ Information about the transaction datum.
+buildDatum :: Contract Token  -- ^ The contract.
+           -> State Token     -- ^ The contract's state.
+           -> DatumInfo       -- ^ Information about the transaction datum.
 buildDatum marloweContract marloweState =
   let
     marloweData = MarloweData{..}
@@ -383,6 +384,7 @@ exportDatum contractFile stateFile outputFile printStats =
     marloweContract <- decodeFileStrict contractFile
     marloweState    <- decodeFileStrict stateFile
     let
+      marloweData :: MarloweData Token
       marloweData = MarloweData{..}
       marloweDatum = PlutusTx.toBuiltinData marloweData
     exportDatumImpl marloweDatum outputFile printStats
@@ -405,8 +407,8 @@ buildRedeemerImpl redeemer =
 
 
 -- | Build the redeemer information about a Marlowe transaction.
-buildRedeemer :: [Input]       -- ^ The contract's input,
-              -> RedeemerInfo  -- ^ Information about the transaction redeemer.
+buildRedeemer :: [Input Token]  -- ^ The contract's input,
+              -> RedeemerInfo   -- ^ Information about the transaction redeemer.
 buildRedeemer = buildRedeemerImpl . PlutusTx.toBuiltinData . marloweTxInputsFromInputs
 
 
@@ -439,7 +441,7 @@ exportRedeemer :: MonadError CliError m
 exportRedeemer inputFiles outputFile printStats =
   do
     inputs <- mapM decodeFileStrict inputFiles
-    exportRedeemerImpl (PlutusTx.toBuiltinData (inputs :: [Input])) outputFile printStats
+    exportRedeemerImpl (PlutusTx.toBuiltinData (inputs :: [Input Token])) outputFile printStats
 
 
 -- | Compute the role address of a Marlowe contract.

--- a/marlowe-cli/src/Language/Marlowe/CLI/Merkle.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Merkle.hs
@@ -44,7 +44,7 @@ import Language.Marlowe.Core.V1.Semantics (ApplyResult (..), ReduceResult (..), 
                                            TransactionOutput (..), applyInput, computeTransaction, fixInterval,
                                            reduceContractUntilQuiescent)
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
-import Language.Marlowe.Core.V1.Semantics.Types (Case (..), Contract (..), Input (..), IntervalResult (..), State,
+import Language.Marlowe.Core.V1.Semantics.Types (Case_ (..), Contract (..), Input (..), IntervalResult (..), State,
                                                  TimeInterval)
 import Ledger.Scripts (dataHash)
 import Plutus.V1.Ledger.Api (DatumHash (..), toBuiltinData)

--- a/marlowe-cli/src/Language/Marlowe/CLI/Orphans.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Orphans.hs
@@ -27,6 +27,8 @@ import Cardano.Api (AddressAny (..), AsType (AsAddressAny), BlockHeader (..), Bl
 import Data.Aeson (FromJSON (..), ToJSON (..), Value (Null, String), object, withObject, withText, (.:), (.=))
 import Data.ByteString.Short (ShortByteString, fromShort, toShort)
 import Language.Marlowe.Core.V1.Semantics (Payment (..), TransactionOutput (..))
+import Language.Marlowe.Core.V1.Semantics.Money (Money)
+import Language.Marlowe.Core.V1.Semantics.Token (Token, moneyFromValue, moneyToValue)
 
 import qualified Data.ByteString.Base16 as Base16 (decode, encode)
 import qualified Data.ByteString.Char8 as BS8 (pack, unpack)
@@ -45,7 +47,7 @@ instance FromJSON ShortByteString where
           Left  message -> fail message
 
 
-instance ToJSON TransactionOutput where
+instance ToJSON (TransactionOutput Token) where
   toJSON TransactionOutput{..} =
     object
       [
@@ -61,7 +63,7 @@ instance ToJSON TransactionOutput where
       ]
 
 
-instance ToJSON Payment where
+instance ToJSON (Payment Token) where
   toJSON (Payment accountId payee money) =
     object
       [
@@ -71,7 +73,7 @@ instance ToJSON Payment where
       ]
 
 
-instance FromJSON Payment where
+instance FromJSON (Payment Token) where
   parseJSON =
     withObject "Payment"
       $ \o ->
@@ -80,6 +82,11 @@ instance FromJSON Payment where
           <*> (o .: "payee"    )
           <*> (o .: "money"    )
 
+instance ToJSON (Money Token) where
+  toJSON = toJSON . moneyToValue
+
+instance FromJSON (Money Token) where
+  parseJSON = fmap moneyFromValue . parseJSON
 
 instance ToJSON AddressAny where
   toJSON = String . serialiseAddress

--- a/marlowe-cli/src/Language/Marlowe/CLI/Orphans.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Orphans.hs
@@ -29,6 +29,7 @@ import Data.ByteString.Short (ShortByteString, fromShort, toShort)
 import Language.Marlowe.Core.V1.Semantics (Payment (..), TransactionOutput (..))
 import Language.Marlowe.Core.V1.Semantics.Money (Money)
 import Language.Marlowe.Core.V1.Semantics.Token (Token, moneyFromValue, moneyToValue)
+import Ledger.Crypto (PubKeyHash)
 
 import qualified Data.ByteString.Base16 as Base16 (decode, encode)
 import qualified Data.ByteString.Char8 as BS8 (pack, unpack)
@@ -47,7 +48,7 @@ instance FromJSON ShortByteString where
           Left  message -> fail message
 
 
-instance ToJSON (TransactionOutput Token) where
+instance ToJSON (TransactionOutput PubKeyHash Token) where
   toJSON TransactionOutput{..} =
     object
       [
@@ -63,7 +64,7 @@ instance ToJSON (TransactionOutput Token) where
       ]
 
 
-instance ToJSON (Payment Token) where
+instance ToJSON (Payment PubKeyHash Token) where
   toJSON (Payment accountId payee money) =
     object
       [
@@ -73,7 +74,7 @@ instance ToJSON (Payment Token) where
       ]
 
 
-instance FromJSON (Payment Token) where
+instance FromJSON (Payment PubKeyHash Token) where
   parseJSON =
     withObject "Payment"
       $ \o ->

--- a/marlowe-cli/src/Language/Marlowe/CLI/PAB.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/PAB.hs
@@ -57,6 +57,7 @@ import Language.Marlowe.Contract (MarloweContract (..))
 import Language.Marlowe.Core.V1.Semantics (MarloweParams)
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Contract)
+import Ledger.Crypto (PubKeyHash)
 import Network.WebSockets (Connection, receiveData)
 import Plutus.PAB.Events.Contract (ContractInstanceId (..))
 import Plutus.PAB.Webserver.Client (InstanceClient (..), PabClient (..))
@@ -257,7 +258,7 @@ callCreate pabClient runApi instanceFile contractFile owners =
     call pabClient runApi instanceFile "create"
       ((
       , AM.fromList $ second anyAddressInShelleyBasedEra <$> owners :: AM.Map TokenName (AddressInEra ShelleyEra)
-      , contract :: Contract Token
+      , contract :: Contract PubKeyHash Token
       ) :: UUID -> CreateEndpointSchema)
 
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/PAB.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/PAB.hs
@@ -55,6 +55,7 @@ import Language.Marlowe.Client (ApplyInputsEndpointSchema, CompanionState, Creat
                                 MarloweEndpointResult (CreateResponse), MarloweError, RedeemEndpointSchema)
 import Language.Marlowe.Contract (MarloweContract (..))
 import Language.Marlowe.Core.V1.Semantics (MarloweParams)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Contract)
 import Network.WebSockets (Connection, receiveData)
 import Plutus.PAB.Events.Contract (ContractInstanceId (..))
@@ -256,7 +257,7 @@ callCreate pabClient runApi instanceFile contractFile owners =
     call pabClient runApi instanceFile "create"
       ((
       , AM.fromList $ second anyAddressInShelleyBasedEra <$> owners :: AM.Map TokenName (AddressInEra ShelleyEra)
-      , contract :: Contract
+      , contract :: Contract Token
       ) :: UUID -> CreateEndpointSchema)
 
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Sync.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Sync.hs
@@ -462,17 +462,17 @@ classifyInputs txBody@(TxBody TxBodyContent{..}) =
 
 
 -- | Classify a transaction input's Marlowe content.
-classifyInput :: [(BuiltinByteString, Contract t)]  -- ^ Contract continuations and their hashes.
-              -> MarloweInput t                     -- ^ The transaction input.
-              -> Maybe [Input t]                    -- ^ The the Marlowe input, if any.
+classifyInput :: [(BuiltinByteString, Contract i t)]  -- ^ Contract continuations and their hashes.
+              -> MarloweInput i t                     -- ^ The transaction input.
+              -> Maybe [Input i t]                    -- ^ The the Marlowe input, if any.
 classifyInput continuations =
   mapM $ unmerkleize continuations
 
 
 -- | Restore a contract from its merkleization.
-unmerkleize :: [(BuiltinByteString, Contract t)]  -- ^ Contract continuations and their hashes.
-            -> MarloweTxInput t                   -- ^ The Marlowe transaction input.
-            -> Maybe (Input t)                    -- ^ Marlowe input, if any.
+unmerkleize :: [(BuiltinByteString, Contract i t)]  -- ^ Contract continuations and their hashes.
+            -> MarloweTxInput i t                   -- ^ The Marlowe transaction input.
+            -> Maybe (Input i t)                    -- ^ Marlowe input, if any.
 unmerkleize _ (Input content) =
   pure $ NormalInput content
 unmerkleize continuations (MerkleizedTxInput content continuationHash) =

--- a/marlowe-cli/src/Language/Marlowe/CLI/Sync.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Sync.hs
@@ -462,17 +462,17 @@ classifyInputs txBody@(TxBody TxBodyContent{..}) =
 
 
 -- | Classify a transaction input's Marlowe content.
-classifyInput :: [(BuiltinByteString, Contract)]  -- ^ Contract continuations and their hashes.
-              -> MarloweInput                     -- ^ The transaction input.
-              -> Maybe [Input]                    -- ^ The the Marlowe input, if any.
+classifyInput :: [(BuiltinByteString, Contract t)]  -- ^ Contract continuations and their hashes.
+              -> MarloweInput t                     -- ^ The transaction input.
+              -> Maybe [Input t]                    -- ^ The the Marlowe input, if any.
 classifyInput continuations =
   mapM $ unmerkleize continuations
 
 
 -- | Restore a contract from its merkleization.
-unmerkleize :: [(BuiltinByteString, Contract)]  -- ^ Contract continuations and their hashes.
-            -> MarloweTxInput                   -- ^ The Marlowe transaction input.
-            -> Maybe Input                      -- ^ Marlowe input, if any.
+unmerkleize :: [(BuiltinByteString, Contract t)]  -- ^ Contract continuations and their hashes.
+            -> MarloweTxInput t                   -- ^ The Marlowe transaction input.
+            -> Maybe (Input t)                    -- ^ Marlowe input, if any.
 unmerkleize _ (Input content) =
   pure $ NormalInput content
 unmerkleize continuations (MerkleizedTxInput content continuationHash) =

--- a/marlowe-cli/src/Language/Marlowe/CLI/Sync/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Sync/Types.hs
@@ -38,6 +38,7 @@ import Language.Marlowe.Core.V1.Semantics (MarloweData (..), MarloweParams (..))
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Input, TimeInterval)
 import Ledger.Address (Address)
+import Ledger.Crypto (PubKeyHash)
 import Plutus.V1.Ledger.Api (TokenName)
 
 import qualified Data.Aeson as A (Value)
@@ -76,8 +77,8 @@ data MarloweIn =
     -- | Input to the Marlowe application script.
   | ApplicationIn
     {
-      miTxIn   :: TxIn           -- ^ The transaction input.
-    , miInputs :: [Input Token]  -- ^ The Marlowe inputs.
+      miTxIn   :: TxIn                      -- ^ The transaction input.
+    , miInputs :: [Input PubKeyHash Token]  -- ^ The Marlowe inputs.
     }
   | PayoutIn
     {
@@ -99,10 +100,10 @@ data MarloweOut =
     -- | Output to the Marlowe application script.
   | ApplicationOut
     {
-      moTxIn    :: TxIn               -- ^ The transaction input being produced.
-    , moAddress :: Address            -- ^ The address receiving the output.
-    , moValue   :: Value              -- ^ The value output.
-    , moOutput  :: MarloweData Token  -- ^ The Marlowe data in the output.
+      moTxIn    :: TxIn                          -- ^ The transaction input being produced.
+    , moAddress :: Address                       -- ^ The address receiving the output.
+    , moValue   :: Value                         -- ^ The value output.
+    , moOutput  :: MarloweData PubKeyHash Token  -- ^ The Marlowe data in the output.
     }
     -- | Output to the Marlowe payout script.
   | PayoutOut

--- a/marlowe-cli/src/Language/Marlowe/CLI/Sync/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Sync/Types.hs
@@ -35,6 +35,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
 import Language.Marlowe.CLI.Orphans ()
 import Language.Marlowe.Core.V1.Semantics (MarloweData (..), MarloweParams (..))
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Input, TimeInterval)
 import Ledger.Address (Address)
 import Plutus.V1.Ledger.Api (TokenName)
@@ -75,8 +76,8 @@ data MarloweIn =
     -- | Input to the Marlowe application script.
   | ApplicationIn
     {
-      miTxIn   :: TxIn     -- ^ The transaction input.
-    , miInputs :: [Input]  -- ^ The Marlowe inputs.
+      miTxIn   :: TxIn           -- ^ The transaction input.
+    , miInputs :: [Input Token]  -- ^ The Marlowe inputs.
     }
   | PayoutIn
     {
@@ -98,10 +99,10 @@ data MarloweOut =
     -- | Output to the Marlowe application script.
   | ApplicationOut
     {
-      moTxIn    :: TxIn         -- ^ The transaction input being produced.
-    , moAddress :: Address      -- ^ The address receiving the output.
-    , moValue   :: Value        -- ^ The value output.
-    , moOutput  :: MarloweData  -- ^ The Marlowe data in the output.
+      moTxIn    :: TxIn               -- ^ The transaction input being produced.
+    , moAddress :: Address            -- ^ The address receiving the output.
+    , moValue   :: Value              -- ^ The value output.
+    , moOutput  :: MarloweData Token  -- ^ The Marlowe data in the output.
     }
     -- | Output to the Marlowe payout script.
   | PayoutOut

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -125,12 +125,12 @@ type InstanceNickname = String
 data ScriptTest =
   ScriptTest
   {
-    stTestName         :: String             -- ^ The name of the test.
-  , stSlotLength       :: Integer            -- ^ The slot length, in milliseconds.
-  , stSlotZeroOffset   :: Integer            -- ^ The effective POSIX time of slot zero, in milliseconds.
-  , stInitialContract  :: Contract Token     -- ^ The contract.
-  , stInitialState     :: State Token        -- ^ The the contract's initial state.
-  , stScriptOperations :: [ScriptOperation]  -- ^ The sequence of test operations.
+    stTestName         :: String                     -- ^ The name of the test.
+  , stSlotLength       :: Integer                    -- ^ The slot length, in milliseconds.
+  , stSlotZeroOffset   :: Integer                    -- ^ The effective POSIX time of slot zero, in milliseconds.
+  , stInitialContract  :: Contract PubKeyHash Token  -- ^ The contract.
+  , stInitialState     :: State PubKeyHash Token     -- ^ The the contract's initial state.
+  , stScriptOperations :: [ScriptOperation]          -- ^ The sequence of test operations.
   }
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
@@ -239,9 +239,9 @@ data PabOperation =
     -- | Call the "create" endpoint of `WalletApp`.
   | CallCreate
     {
-      poInstance :: InstanceNickname  -- ^ The nickname of the PAB contract instance.
-    , poOwners   :: [RoleName]        -- ^ The names of roles in the contract.
-    , poContract :: Contract Token    -- ^ The Marlowe contract to be created.
+      poInstance :: InstanceNickname           -- ^ The nickname of the PAB contract instance.
+    , poOwners   :: [RoleName]                 -- ^ The names of roles in the contract.
+    , poContract :: Contract PubKeyHash Token  -- ^ The Marlowe contract to be created.
     }
     -- | Wait for confirmation of a call to the "create" endpoint.
   | AwaitCreate

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -67,6 +67,7 @@ import Language.Marlowe.CLI.Types (CliError, SomePaymentSigningKey)
 import Language.Marlowe.Client (MarloweClientInput, MarloweContractState)
 import Language.Marlowe.Contract (MarloweContract)
 import Language.Marlowe.Core.V1.Semantics (MarloweParams)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Contract, State, TimeInterval)
 import Plutus.Contract (ContractInstanceId)
 import Plutus.PAB.Webserver.Client (PabClient)
@@ -127,8 +128,8 @@ data ScriptTest =
     stTestName         :: String             -- ^ The name of the test.
   , stSlotLength       :: Integer            -- ^ The slot length, in milliseconds.
   , stSlotZeroOffset   :: Integer            -- ^ The effective POSIX time of slot zero, in milliseconds.
-  , stInitialContract  :: Contract           -- ^ The contract.
-  , stInitialState     :: State              -- ^ The the contract's initial state.
+  , stInitialContract  :: Contract Token     -- ^ The contract.
+  , stInitialState     :: State Token        -- ^ The the contract's initial state.
   , stScriptOperations :: [ScriptOperation]  -- ^ The sequence of test operations.
   }
     deriving stock (Eq, Generic, Show)
@@ -240,7 +241,7 @@ data PabOperation =
     {
       poInstance :: InstanceNickname  -- ^ The nickname of the PAB contract instance.
     , poOwners   :: [RoleName]        -- ^ The names of roles in the contract.
-    , poContract :: Contract          -- ^ The Marlowe contract to be created.
+    , poContract :: Contract Token    -- ^ The Marlowe contract to be created.
     }
     -- | Wait for confirmation of a call to the "create" endpoint.
   | AwaitCreate

--- a/marlowe-cli/src/Language/Marlowe/CLI/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Types.hs
@@ -55,6 +55,7 @@ import Language.Marlowe.CLI.Orphans ()
 import Language.Marlowe.Core.V1.Semantics (Payment)
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Contract, Input, State)
+import Ledger.Crypto (PubKeyHash)
 import Ledger.TimeSlot (SlotConfig)
 import Plutus.V1.Ledger.Api (CurrencySymbol, Datum, DatumHash, ExBudget, Redeemer, ValidatorHash)
 
@@ -78,23 +79,23 @@ type SomePaymentSigningKey = Either (SigningKey PaymentKey) (SigningKey PaymentE
 
 
 -- | Continuations for contracts.
-type Continuations t = M.Map DatumHash (Contract t)
+type Continuations i t = M.Map DatumHash (Contract i t)
 
 
 -- | Complete description of a Marlowe transaction.
 data MarloweTransaction era =
   MarloweTransaction
   {
-    mtValidator     :: ValidatorInfo era       -- ^ The Marlowe validator.
-  , mtRoleValidator :: ValidatorInfo era       -- ^ The roles validator.
-  , mtRoles         :: CurrencySymbol          -- ^ The roles currency.
-  , mtState         :: State Token             -- ^ The Marlowe state after the transaction.
-  , mtContract      :: Contract Token          -- ^ The Marlowe contract after the transaction.
-  , mtContinuations :: Continuations Token     -- ^ The merkleized continuations for the contract.
-  , mtRange         :: Maybe (SlotNo, SlotNo)  -- ^ The slot range for the transaction, if any.
-  , mtInputs        :: [Input Token]           -- ^ The inputs to the transaction.
-  , mtPayments      :: [Payment Token]         -- ^ The payments from the transaction.
-  , mtSlotConfig    :: SlotConfig              -- ^ The POSIXTime-to-Slot configuration.
+    mtValidator     :: ValidatorInfo era               -- ^ The Marlowe validator.
+  , mtRoleValidator :: ValidatorInfo era               -- ^ The roles validator.
+  , mtRoles         :: CurrencySymbol                  -- ^ The roles currency.
+  , mtState         :: State PubKeyHash Token          -- ^ The Marlowe state after the transaction.
+  , mtContract      :: Contract PubKeyHash Token       -- ^ The Marlowe contract after the transaction.
+  , mtContinuations :: Continuations PubKeyHash Token  -- ^ The merkleized continuations for the contract.
+  , mtRange         :: Maybe (SlotNo, SlotNo)          -- ^ The slot range for the transaction, if any.
+  , mtInputs        :: [Input PubKeyHash Token]        -- ^ The inputs to the transaction.
+  , mtPayments      :: [Payment PubKeyHash Token]      -- ^ The payments from the transaction.
+  , mtSlotConfig    :: SlotConfig                      -- ^ The POSIXTime-to-Slot configuration.
   }
     deriving (Generic, Show)
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Types.hs
@@ -53,6 +53,7 @@ import Data.String (IsString)
 import GHC.Generics (Generic)
 import Language.Marlowe.CLI.Orphans ()
 import Language.Marlowe.Core.V1.Semantics (Payment)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Contract, Input, State)
 import Ledger.TimeSlot (SlotConfig)
 import Plutus.V1.Ledger.Api (CurrencySymbol, Datum, DatumHash, ExBudget, Redeemer, ValidatorHash)
@@ -77,7 +78,7 @@ type SomePaymentSigningKey = Either (SigningKey PaymentKey) (SigningKey PaymentE
 
 
 -- | Continuations for contracts.
-type Continuations = M.Map DatumHash Contract
+type Continuations t = M.Map DatumHash (Contract t)
 
 
 -- | Complete description of a Marlowe transaction.
@@ -87,12 +88,12 @@ data MarloweTransaction era =
     mtValidator     :: ValidatorInfo era       -- ^ The Marlowe validator.
   , mtRoleValidator :: ValidatorInfo era       -- ^ The roles validator.
   , mtRoles         :: CurrencySymbol          -- ^ The roles currency.
-  , mtState         :: State                   -- ^ The Marlowe state after the transaction.
-  , mtContract      :: Contract                -- ^ The Marlowe contract after the transaction.
-  , mtContinuations :: Continuations           -- ^ The merkleized continuations for the contract.
+  , mtState         :: State Token             -- ^ The Marlowe state after the transaction.
+  , mtContract      :: Contract Token          -- ^ The Marlowe contract after the transaction.
+  , mtContinuations :: Continuations Token     -- ^ The merkleized continuations for the contract.
   , mtRange         :: Maybe (SlotNo, SlotNo)  -- ^ The slot range for the transaction, if any.
-  , mtInputs        :: [Input]                 -- ^ The inputs to the transaction.
-  , mtPayments      :: [Payment]               -- ^ The payments from the transaction.
+  , mtInputs        :: [Input Token]           -- ^ The inputs to the transaction.
+  , mtPayments      :: [Payment Token]         -- ^ The payments from the transaction.
   , mtSlotConfig    :: SlotConfig              -- ^ The POSIXTime-to-Slot configuration.
   }
     deriving (Generic, Show)

--- a/marlowe-contracts/test/Spec/Marlowe/Analysis.hs
+++ b/marlowe-contracts/test/Spec/Marlowe/Analysis.hs
@@ -29,7 +29,7 @@ tests = testGroup "Marlowe Contract"
     , testCase "Option test" optionTest
     ]
 
-hasWarnings :: Maybe (C.Contract Token) -> IO Bool
+hasWarnings :: Maybe (C.Contract C.PubKeyHash Token) -> IO Bool
 hasWarnings (Just contract) = do
   result <- warningsTrace contract
   case result of

--- a/marlowe-contracts/test/Spec/Marlowe/Analysis.hs
+++ b/marlowe-contracts/test/Spec/Marlowe/Analysis.hs
@@ -29,7 +29,7 @@ tests = testGroup "Marlowe Contract"
     , testCase "Option test" optionTest
     ]
 
-hasWarnings :: Maybe C.Contract -> IO Bool
+hasWarnings :: Maybe (C.Contract Token) -> IO Bool
 hasWarnings (Just contract) = do
   result <- warningsTrace contract
   case result of

--- a/marlowe-contracts/test/Spec/Marlowe/Contracts.hs
+++ b/marlowe-contracts/test/Spec/Marlowe/Contracts.hs
@@ -53,10 +53,10 @@ tokSymbol = ""
 tok :: Token
 tok = Token tokSymbol tokName
 
-tokValueOf :: Integer -> C.Money
-tokValueOf = singleton tokSymbol tokName
+tokValueOf :: Integer -> C.Money Token
+tokValueOf = C.moneyFromValue . singleton tokSymbol tokName
 
-assertTotalPayments :: Party -> [C.Payment] -> C.Money -> Assertion
+assertTotalPayments :: Party -> [C.Payment Token] -> C.Money Token -> Assertion
 assertTotalPayments p t x = assertBool "total payments to party" (totalPayments t == x)
   where
     totalPayments = mconcat . map (\(C.Payment _ _ a) -> a) . filter (\(C.Payment _ a _) -> a == C.Party p)
@@ -65,7 +65,7 @@ assertNoWarnings :: [a] -> Assertion
 assertNoWarnings [] = pure ()
 assertNoWarnings t  = assertBool "Assert no warnings" $ null t
 
-assertClose :: C.Contract -> Assertion
+assertClose :: C.Contract Token -> Assertion
 assertClose = assertBool "Contract is in Close" . (C.Close==)
 
 assertNoFailedTransactions :: C.TransactionError -> Assertion
@@ -95,7 +95,7 @@ zeroCouponBondTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (lovelaceValueOf 90_000_000)
+          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 90_000_000)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -124,7 +124,7 @@ couponBondTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (lovelaceValueOf 92_000_000)
+          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 92_000_000)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -148,8 +148,8 @@ swapContractTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (lovelaceValueOf 10_000_000 <> tokValueOf 30)
-          assertTotalPayments w2Pk txOutPayments (lovelaceValueOf 10_000_000 <> tokValueOf 30)
+          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue (lovelaceValueOf 10_000_000) <> tokValueOf 30)
+          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue (lovelaceValueOf 10_000_000) <> tokValueOf 30)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -215,7 +215,7 @@ americanCallOptionExercisedTest =
           assertClose txOutContract
           assertNoWarnings txOutWarnings
           assertTotalPayments w1Pk txOutPayments (tokValueOf 30)
-          assertTotalPayments w2Pk txOutPayments (lovelaceValueOf 10_000_000)
+          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -281,7 +281,7 @@ europeanCallOptionExercisedTest =
           assertClose txOutContract
           assertNoWarnings txOutWarnings
           assertTotalPayments w1Pk txOutPayments (tokValueOf 30)
-          assertTotalPayments w2Pk txOutPayments (lovelaceValueOf 10_000_000)
+          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -319,8 +319,8 @@ futureNoChange =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings $ filter nonZeroPay txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (lovelaceValueOf 8_000_000)
-          assertTotalPayments w2Pk txOutPayments (lovelaceValueOf 8_000_000)
+          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 8_000_000)
+          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 8_000_000)
         C.Error err ->
           assertNoFailedTransactions err
   where
@@ -355,8 +355,8 @@ futureNoMarginCall =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (lovelaceValueOf 1_333_333)
-          assertTotalPayments w2Pk txOutPayments (lovelaceValueOf 14_666_667)
+          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 1_333_333)
+          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 14_666_667)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -395,8 +395,8 @@ futureWithMarginCall =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (lovelaceValueOf 61_333_333)
-          assertTotalPayments w2Pk txOutPayments (lovelaceValueOf 14_666_667)
+          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 61_333_333)
+          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 14_666_667)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -458,6 +458,6 @@ reverseConvertibleTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (lovelaceValueOf 10_000_000)
+          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
         C.Error err ->
           assertNoFailedTransactions err

--- a/marlowe-contracts/test/Spec/Marlowe/Contracts.hs
+++ b/marlowe-contracts/test/Spec/Marlowe/Contracts.hs
@@ -59,7 +59,7 @@ tokValueOf = C.moneyFromValue . singleton tokSymbol tokName
 assertTotalPayments :: Party -> [C.Payment Token] -> C.Money Token -> Assertion
 assertTotalPayments p t x = assertBool "total payments to party" (totalPayments t == x)
   where
-    totalPayments = mconcat . map (\(C.Payment _ _ a) -> a) . filter (\(C.Payment _ a _) -> a == C.Party p)
+    totalPayments = mconcat . map (\(C.Payment _ _ a) -> a) . filter (\(C.Payment _ a _) -> a == C.Party (toCore' p))
 
 assertNoWarnings :: [a] -> Assertion
 assertNoWarnings [] = pure ()
@@ -88,8 +88,8 @@ zeroCouponBondTest =
           ada
           Close
       txIn =
-        [ C.TransactionInput (toPOSIX "2021-12-31 00:00:00.000000 UTC", toPOSIX "2021-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit w1Pk w1Pk ada 75_000_000]
-        , C.TransactionInput (toPOSIX "2022-12-31 00:00:00.000000 UTC", toPOSIX "2022-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit w2Pk w2Pk ada 90_000_000]
+        [ C.TransactionInput (toPOSIX "2021-12-31 00:00:00.000000 UTC", toPOSIX "2021-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 75_000_000]
+        , C.TransactionInput (toPOSIX "2022-12-31 00:00:00.000000 UTC", toPOSIX "2022-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) ada 90_000_000]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
@@ -115,10 +115,10 @@ couponBondTest =
           ada
           Close
       txIn =
-        [ C.TransactionInput (toPOSIX "2021-12-31 00:00:00.000000 UTC", toPOSIX "2021-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit w1Pk w1Pk ada 75_000_000]
-        , C.TransactionInput (toPOSIX "2022-06-30 00:00:00.000000 UTC", toPOSIX "2022-06-30 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit w2Pk w2Pk ada 1_000_000]
-        , C.TransactionInput (toPOSIX "2022-12-31 00:00:00.000000 UTC", toPOSIX "2022-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit w2Pk w2Pk ada 1_000_000]
-        , C.TransactionInput (toPOSIX "2022-12-31 00:00:00.000000 UTC", toPOSIX "2022-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit w2Pk w2Pk ada 90_000_000]
+        [ C.TransactionInput (toPOSIX "2021-12-31 00:00:00.000000 UTC", toPOSIX "2021-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 75_000_000]
+        , C.TransactionInput (toPOSIX "2022-06-30 00:00:00.000000 UTC", toPOSIX "2022-06-30 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) ada 1_000_000]
+        , C.TransactionInput (toPOSIX "2022-12-31 00:00:00.000000 UTC", toPOSIX "2022-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) ada 1_000_000]
+        , C.TransactionInput (toPOSIX "2022-12-31 00:00:00.000000 UTC", toPOSIX "2022-12-31 23:59:59.999999 UTC") [C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) ada 90_000_000]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
@@ -138,10 +138,10 @@ swapContractTest =
       timestamp = read "2022-01-01 00:00:00.000000 UTC"
       txIn =
         [ C.TransactionInput (0, 0)
-            [ C.NormalInput $ C.IDeposit w1Pk w1Pk ada 10_000_000
-            , C.NormalInput $ C.IDeposit w2Pk w2Pk tok 30
-            , C.NormalInput $ C.IDeposit w2Pk w2Pk ada 10_000_000
-            , C.NormalInput $ C.IDeposit w1Pk w1Pk tok 30
+            [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 10_000_000
+            , C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) tok 30
+            , C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) ada 10_000_000
+            , C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) tok 30
             ]
         ]
    in case C.playTrace 0 contract txIn of
@@ -168,7 +168,7 @@ americanCallOptionTest =
           (read "2022-03-01 09:00:00.000000 UTC")
           (read "2022-03-31 17:30:00.000000 UTC")
       txIn =
-        [ C.TransactionInput (0, 0) [C.NormalInput $ C.IChoice (ChoiceId "Exercise Call" w1Pk) 0] ]
+        [ C.TransactionInput (0, 0) [C.NormalInput $ C.IChoice (C.ChoiceId "Exercise Call" (toCore' w1Pk)) 0] ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
           assertClose txOutContract
@@ -206,9 +206,9 @@ americanCallOptionExercisedTest =
       t2 = toPOSIX "2022-03-15 08:00:00.000000 UTC"
 
       txIn =
-        [ C.TransactionInput (t0, t0) [C.NormalInput $ C.IDeposit w2Pk w2Pk tok 30]
-        , C.TransactionInput (t1, t1) [C.NormalInput $ C.IChoice (ChoiceId "Exercise Call" w1Pk) 1]
-        , C.TransactionInput (t2, t2) [C.NormalInput $ C.IDeposit w1Pk w1Pk ada 10_000_000]
+        [ C.TransactionInput (t0, t0) [C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) tok 30]
+        , C.TransactionInput (t1, t1) [C.NormalInput $ C.IChoice (C.ChoiceId "Exercise Call" (toCore' w1Pk)) 1]
+        , C.TransactionInput (t2, t2) [C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 10_000_000]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
@@ -235,7 +235,7 @@ europeanCallOptionTest =
           (read "2022-03-20 17:30:00.000000 UTC")
       exerciseTime = toPOSIX "2022-03-19 17:31:00.000000 UTC"
       txIn =
-        [ C.TransactionInput (exerciseTime, exerciseTime) [C.NormalInput $ C.IChoice (ChoiceId "Exercise Call" w1Pk) 0] ]
+        [ C.TransactionInput (exerciseTime, exerciseTime) [C.NormalInput $ C.IChoice (C.ChoiceId "Exercise Call" (toCore' w1Pk)) 0] ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
           assertClose txOutContract
@@ -272,9 +272,9 @@ europeanCallOptionExercisedTest =
       exerciseTime = toPOSIX "2022-03-19 17:31:00.000000 UTC"
       depositTime = toPOSIX "2022-03-19 17:32:00.000000 UTC"
       txIn =
-        [ C.TransactionInput (0, 0)                       [C.NormalInput $ C.IDeposit w2Pk w2Pk tok 30]
-        , C.TransactionInput (exerciseTime, exerciseTime) [C.NormalInput $ C.IChoice (ChoiceId "Exercise Call" w1Pk) 1]
-        , C.TransactionInput (depositTime, depositTime)   [C.NormalInput $ C.IDeposit w1Pk w1Pk ada 10_000_000]
+        [ C.TransactionInput (0, 0)                       [C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) tok 30]
+        , C.TransactionInput (exerciseTime, exerciseTime) [C.NormalInput $ C.IChoice (C.ChoiceId "Exercise Call" (toCore' w1Pk)) 1]
+        , C.TransactionInput (depositTime, depositTime)   [C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 10_000_000]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
@@ -309,11 +309,11 @@ futureNoChange =
 
       txIn =
         [ C.TransactionInput (t0, t0)
-            [ C.NormalInput $ C.IDeposit w1Pk w1Pk ada 8_000_000
-            , C.NormalInput $ C.IDeposit w2Pk w2Pk ada 8_000_000 ]
+            [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 8_000_000
+            , C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) ada 8_000_000 ]
         , C.TransactionInput (t1, t1)
-            [ C.NormalInput $ C.IChoice dirRate 125_000_000
-            , C.NormalInput $ C.IChoice invRate 80_000_000 ]
+            [ C.NormalInput $ C.IChoice (toCore' dirRate) 125_000_000
+            , C.NormalInput $ C.IChoice (toCore' invRate) 80_000_000 ]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
@@ -345,11 +345,11 @@ futureNoMarginCall =
 
       txIn =
         [ C.TransactionInput (t0, t0)
-            [ C.NormalInput $ C.IDeposit w1Pk w1Pk ada 8_000_000
-            , C.NormalInput $ C.IDeposit w2Pk w2Pk ada 8_000_000 ]
+            [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 8_000_000
+            , C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) ada 8_000_000 ]
         , C.TransactionInput (t1, t1)
-            [ C.NormalInput $ C.IChoice dirRate 133_333_333
-            , C.NormalInput $ C.IChoice invRate 75_000_000 ]
+            [ C.NormalInput $ C.IChoice (toCore' dirRate) 133_333_333
+            , C.NormalInput $ C.IChoice (toCore' invRate) 75_000_000 ]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
@@ -380,16 +380,16 @@ futureWithMarginCall =
 
       txIn =
         [ C.TransactionInput (t0, t0)
-            [ C.NormalInput $ C.IDeposit w1Pk w1Pk ada 8_000_000
-            , C.NormalInput $ C.IDeposit w2Pk w2Pk ada 8_000_000 ]
+            [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 8_000_000
+            , C.NormalInput $ C.IDeposit (toCore' w2Pk) (toCore' w2Pk) ada 8_000_000 ]
         , C.TransactionInput (t1, t1)
-            [ C.NormalInput $ C.IChoice dirRate 200_000_000
-            , C.NormalInput $ C.IChoice invRate 50_000_000 ]
+            [ C.NormalInput $ C.IChoice (toCore' dirRate) 200_000_000
+            , C.NormalInput $ C.IChoice (toCore' invRate) 50_000_000 ]
         , C.TransactionInput (t2, t2)
-            [ C.NormalInput $ C.IDeposit w1Pk w1Pk ada 60_000_000 ]
+            [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 60_000_000 ]
         , C.TransactionInput (t3, t3)
-            [ C.NormalInput $ C.IChoice dirRate 133_333_333
-            , C.NormalInput $ C.IChoice invRate 75_000_000 ]
+            [ C.NormalInput $ C.IChoice (toCore' dirRate) 133_333_333
+            , C.NormalInput $ C.IChoice (toCore' invRate) 75_000_000 ]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
@@ -418,11 +418,11 @@ reverseConvertibleExercisedTest =
       repaymentTime = toPOSIX "2022-03-19 17:29:59.000000 UTC"
       exerciseTime = toPOSIX "2022-03-19 17:30:00.000000 UTC"
       txIn =
-        [ C.TransactionInput (0, 0)   [ C.NormalInput $ C.IDeposit w1Pk w1Pk ada 9_000_000 ]
-        , C.TransactionInput (repaymentTime, repaymentTime) [ C.NormalInput $ C.IDeposit w1Pk (Role "BondProvider") ada 10_000_000 ]
+        [ C.TransactionInput (0, 0)   [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 9_000_000 ]
+        , C.TransactionInput (repaymentTime, repaymentTime) [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (C.Role "BondProvider") ada 10_000_000 ]
         , C.TransactionInput (exerciseTime, exerciseTime)
-            [ C.NormalInput $ C.IChoice (ChoiceId "Exercise Put" (Role "OptionCounterparty")) 1
-            , C.NormalInput $ C.IDeposit (Role "OptionCounterparty") (Role "OptionCounterparty") tok 30 ]
+            [ C.NormalInput $ C.IChoice (C.ChoiceId "Exercise Put" (C.Role "OptionCounterparty")) 1
+            , C.NormalInput $ C.IDeposit (C.Role "OptionCounterparty") (C.Role "OptionCounterparty") tok 30 ]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do
@@ -450,9 +450,9 @@ reverseConvertibleTest =
       repaymentTime = toPOSIX "2022-03-19 17:29:59.000000 UTC"
       exerciseTime = toPOSIX "2022-03-19 17:30:00.000000 UTC"
       txIn =
-        [ C.TransactionInput (0, 0)                         [ C.NormalInput $ C.IDeposit w1Pk w1Pk ada 9_000_000 ]
-        , C.TransactionInput (repaymentTime, repaymentTime) [ C.NormalInput $ C.IDeposit w1Pk (Role "BondProvider") ada 10_000_000 ]
-        , C.TransactionInput (exerciseTime, exerciseTime)   [ C.NormalInput $ C.IChoice (ChoiceId "Exercise Put" (Role "OptionCounterparty")) 0 ]
+        [ C.TransactionInput (0, 0)                         [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (toCore' w1Pk) ada 9_000_000 ]
+        , C.TransactionInput (repaymentTime, repaymentTime) [ C.NormalInput $ C.IDeposit (toCore' w1Pk) (C.Role "BondProvider") ada 10_000_000 ]
+        , C.TransactionInput (exerciseTime, exerciseTime)   [ C.NormalInput $ C.IChoice (C.ChoiceId "Exercise Put" (C.Role "OptionCounterparty")) 0 ]
         ]
    in case C.playTrace 0 contract txIn of
         C.TransactionOutput {..} -> do

--- a/marlowe-contracts/test/Spec/Marlowe/Contracts.hs
+++ b/marlowe-contracts/test/Spec/Marlowe/Contracts.hs
@@ -56,16 +56,16 @@ tok = Token tokSymbol tokName
 tokValueOf :: Integer -> C.Money Token
 tokValueOf = C.moneyFromValue . singleton tokSymbol tokName
 
-assertTotalPayments :: Party -> [C.Payment Token] -> C.Money Token -> Assertion
+assertTotalPayments :: C.Party C.PubKeyHash -> [C.Payment C.PubKeyHash Token] -> C.Money Token -> Assertion
 assertTotalPayments p t x = assertBool "total payments to party" (totalPayments t == x)
   where
-    totalPayments = mconcat . map (\(C.Payment _ _ a) -> a) . filter (\(C.Payment _ a _) -> a == C.Party (toCore' p))
+    totalPayments = mconcat . map (\(C.Payment _ _ a) -> a) . filter (\(C.Payment _ a _) -> a == C.Party p)
 
 assertNoWarnings :: [a] -> Assertion
 assertNoWarnings [] = pure ()
 assertNoWarnings t  = assertBool "Assert no warnings" $ null t
 
-assertClose :: C.Contract Token -> Assertion
+assertClose :: C.Contract C.PubKeyHash Token -> Assertion
 assertClose = assertBool "Contract is in Close" . (C.Close==)
 
 assertNoFailedTransactions :: C.TransactionError -> Assertion
@@ -95,7 +95,7 @@ zeroCouponBondTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 90_000_000)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 90_000_000)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -124,7 +124,7 @@ couponBondTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 92_000_000)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 92_000_000)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -148,8 +148,8 @@ swapContractTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue (lovelaceValueOf 10_000_000) <> tokValueOf 30)
-          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue (lovelaceValueOf 10_000_000) <> tokValueOf 30)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (C.moneyFromValue (lovelaceValueOf 10_000_000) <> tokValueOf 30)
+          assertTotalPayments (toCore' w2Pk) txOutPayments (C.moneyFromValue (lovelaceValueOf 10_000_000) <> tokValueOf 30)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -173,8 +173,8 @@ americanCallOptionTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments mempty
-          assertTotalPayments w2Pk txOutPayments mempty
+          assertTotalPayments (toCore' w1Pk) txOutPayments mempty
+          assertTotalPayments (toCore' w2Pk) txOutPayments mempty
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -214,8 +214,8 @@ americanCallOptionExercisedTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (tokValueOf 30)
-          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (tokValueOf 30)
+          assertTotalPayments (toCore' w2Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -240,8 +240,8 @@ europeanCallOptionTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments mempty
-          assertTotalPayments w2Pk txOutPayments mempty
+          assertTotalPayments (toCore' w1Pk) txOutPayments mempty
+          assertTotalPayments (toCore' w2Pk) txOutPayments mempty
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -280,8 +280,8 @@ europeanCallOptionExercisedTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (tokValueOf 30)
-          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (tokValueOf 30)
+          assertTotalPayments (toCore' w2Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -319,8 +319,8 @@ futureNoChange =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings $ filter nonZeroPay txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 8_000_000)
-          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 8_000_000)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 8_000_000)
+          assertTotalPayments (toCore' w2Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 8_000_000)
         C.Error err ->
           assertNoFailedTransactions err
   where
@@ -355,8 +355,8 @@ futureNoMarginCall =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 1_333_333)
-          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 14_666_667)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 1_333_333)
+          assertTotalPayments (toCore' w2Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 14_666_667)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -395,8 +395,8 @@ futureWithMarginCall =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 61_333_333)
-          assertTotalPayments w2Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 14_666_667)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 61_333_333)
+          assertTotalPayments (toCore' w2Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 14_666_667)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -428,7 +428,7 @@ reverseConvertibleExercisedTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (tokValueOf 30)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (tokValueOf 30)
         C.Error err ->
           assertNoFailedTransactions err
 
@@ -458,6 +458,6 @@ reverseConvertibleTest =
         C.TransactionOutput {..} -> do
           assertClose txOutContract
           assertNoWarnings txOutWarnings
-          assertTotalPayments w1Pk txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
+          assertTotalPayments (toCore' w1Pk) txOutPayments (C.moneyFromValue $ lovelaceValueOf 10_000_000)
         C.Error err ->
           assertNoFailedTransactions err

--- a/marlowe-playground-server/app/PSGenerator.hs
+++ b/marlowe-playground-server/app/PSGenerator.hs
@@ -307,6 +307,8 @@ writePangramJson outputDir = do
                     S.Close
                 )
         encodedPangram = BS8.pack . Char8.unpack $ encode pangram
+
+        state :: State S.PubKeyHash Token
         state =
             State
             { accounts = Map.singleton (alicePk, token) 12

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
@@ -20,7 +20,7 @@ import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (Proxy))
 import Formatting (fprint, (%))
 import Formatting.Clock (timeSpecs)
-import Language.Marlowe (Contract, POSIXTime (..), State, TransactionInput, TransactionWarning)
+import Language.Marlowe (Contract, POSIXTime (..), State, Token, TransactionInput, TransactionWarning)
 import Language.Marlowe.Analysis.FSSemantics (warningsTraceCustom)
 import Marlowe.Symbolic.Types.Request (Request (..))
 import Marlowe.Symbolic.Types.Response (Response (..), Result (..))
@@ -33,7 +33,7 @@ import Text.PrettyPrint.Leijen (displayS, renderCompact)
 type API = "api" :> "marlowe-analysis" :> ReqBody '[JSON] Request :> Post '[JSON] Response
 
 makeResult ::
-  Either String (Maybe (POSIXTime, [TransactionInput], [TransactionWarning])) ->
+  Either String (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning Token])) ->
   Result
 makeResult (Left err) = Error (show err)
 makeResult (Right res) =

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Server.hs
@@ -20,7 +20,7 @@ import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (Proxy))
 import Formatting (fprint, (%))
 import Formatting.Clock (timeSpecs)
-import Language.Marlowe (Contract, POSIXTime (..), State, Token, TransactionInput, TransactionWarning)
+import Language.Marlowe (Contract, POSIXTime (..), PubKeyHash, State, Token, TransactionInput, TransactionWarning)
 import Language.Marlowe.Analysis.FSSemantics (warningsTraceCustom)
 import Marlowe.Symbolic.Types.Request (Request (..))
 import Marlowe.Symbolic.Types.Response (Response (..), Result (..))
@@ -33,7 +33,7 @@ import Text.PrettyPrint.Leijen (displayS, renderCompact)
 type API = "api" :> "marlowe-analysis" :> ReqBody '[JSON] Request :> Post '[JSON] Response
 
 makeResult ::
-  Either String (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning Token])) ->
+  Either String (Maybe (POSIXTime, [TransactionInput PubKeyHash Token], [TransactionWarning PubKeyHash Token])) ->
   Result
 makeResult (Left err) = Error (show err)
 makeResult (Right res) =

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Types/Request.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Types/Request.hs
@@ -3,12 +3,12 @@ module Marlowe.Symbolic.Types.Request where
 
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
-import Language.Marlowe (Contract, State, Token)
+import Language.Marlowe (Contract, PubKeyHash, State, Token)
 
 data Request = Request
   { onlyAssertions :: Bool
-  , contract       :: Contract Token
-  , state          :: State Token
+  , contract       :: Contract PubKeyHash Token
+  , state          :: State PubKeyHash Token
   } deriving (Generic)
 instance FromJSON Request
 instance ToJSON Request

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Types/Request.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Types/Request.hs
@@ -3,12 +3,12 @@ module Marlowe.Symbolic.Types.Request where
 
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
-import Language.Marlowe (Contract, State)
+import Language.Marlowe (Contract, State, Token)
 
 data Request = Request
   { onlyAssertions :: Bool
-  , contract       :: Contract
-  , state          :: State
+  , contract       :: Contract Token
+  , state          :: State Token
   } deriving (Generic)
 instance FromJSON Request
 instance ToJSON Request

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Types/Response.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Types/Response.hs
@@ -5,12 +5,13 @@ import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics
 import Language.Marlowe.Core.V1.Semantics (TransactionInput, TransactionWarning)
 import Language.Marlowe.Core.V1.Semantics.Token (Token)
+import Ledger (PubKeyHash)
 
 data Result = Valid
             | CounterExample
                 { initialSlot        :: Integer
-                , transactionList    :: [TransactionInput Token]
-                , transactionWarning :: [TransactionWarning Token]
+                , transactionList    :: [TransactionInput PubKeyHash Token]
+                , transactionWarning :: [TransactionWarning PubKeyHash Token]
                 }
             | Error String
   deriving (Generic)

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Types/Response.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Types/Response.hs
@@ -4,12 +4,13 @@ module Marlowe.Symbolic.Types.Response where
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics
 import Language.Marlowe.Core.V1.Semantics (TransactionInput, TransactionWarning)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 
 data Result = Valid
             | CounterExample
                 { initialSlot        :: Integer
-                , transactionList    :: [TransactionInput]
-                , transactionWarning :: [TransactionWarning]
+                , transactionList    :: [TransactionInput Token]
+                , transactionWarning :: [TransactionWarning Token]
                 }
             | Error String
   deriving (Generic)

--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -85,6 +85,8 @@ library
     Language.Marlowe
     Language.Marlowe.Extended.V1
     Language.Marlowe.Core.V1.Semantics
+    Language.Marlowe.Core.V1.Semantics.Money
+    Language.Marlowe.Core.V1.Semantics.Token
     Language.Marlowe.Core.V1.Semantics.Types
     Language.Marlowe.FindInputs
     Language.Marlowe.Client

--- a/marlowe/src/Language/Marlowe.hs
+++ b/marlowe/src/Language/Marlowe.hs
@@ -7,6 +7,7 @@ module Language.Marlowe
     , module Language.Marlowe.Util
     , module Language.Marlowe.Pretty
     , POSIXTime (..)
+    , PubKeyHash (..)
     , adaSymbol
     , adaToken
     , (%)
@@ -20,7 +21,7 @@ import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types hiding (getAction)
 import Language.Marlowe.Pretty
 import Language.Marlowe.Util
-import Ledger (POSIXTime (..))
+import Ledger (POSIXTime (..), PubKeyHash (..))
 import Ledger.Ada (adaSymbol, adaToken)
 import PlutusTx.Ratio as P
 

--- a/marlowe/src/Language/Marlowe.hs
+++ b/marlowe/src/Language/Marlowe.hs
@@ -1,5 +1,7 @@
 module Language.Marlowe
     ( module Language.Marlowe.Core.V1.Semantics
+     ,module Language.Marlowe.Core.V1.Semantics.Money
+    , module Language.Marlowe.Core.V1.Semantics.Token
     , module Language.Marlowe.Core.V1.Semantics.Types
     , module Language.Marlowe.Client
     , module Language.Marlowe.Util
@@ -13,6 +15,8 @@ where
 
 import Language.Marlowe.Client
 import Language.Marlowe.Core.V1.Semantics
+import Language.Marlowe.Core.V1.Semantics.Money
+import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types hiding (getAction)
 import Language.Marlowe.Pretty
 import Language.Marlowe.Util

--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -392,7 +392,7 @@ addFreshSlotsToState sState =
 -- that happened then the current case would never be reached, we keep adding conditions
 -- to the function and pass it to the next iteration of isValidAndFailsWhen.
 -- - pos - Is the position of the current Case clause [1..], 0 means timeout branch.
-isValidAndFailsWhen :: Bool -> SBool -> [Case (Contract Token)] -> Timeout -> Contract Token -> (SymInput -> SymState -> SBool)
+isValidAndFailsWhen :: Bool -> SBool -> [Case (Contract Token) Token] -> Timeout -> Contract Token -> (SymInput -> SymState -> SBool)
                     -> SymState -> Integer -> Symbolic SBool
 isValidAndFailsWhen oa hasErr [] timeout cont previousMatch sState pos =
   do newLowSlot <- sInteger_
@@ -513,7 +513,7 @@ countWhens (Let va vb c)       = countWhens c
 countWhens (Assert o c)        = countWhens c
 
 -- Same as countWhens but it starts with a Case list
-countWhensCaseList :: [Case (Contract Token)] -> Integer
+countWhensCaseList :: [Case (Contract Token) Token] -> Integer
 countWhensCaseList (Case uu c : tail)           = max (countWhens c) (countWhensCaseList tail)
 countWhensCaseList (MerkleizedCase uu c : tail) = countWhensCaseList tail
 countWhensCaseList []                           = 0
@@ -572,7 +572,7 @@ groupResult _ _ = error "Wrong number of labels generated"
 
 -- Reconstructs an input from a Case list a Case position and a value (deposit amount or
 -- chosen value)
-caseToInput :: [Case a] -> Integer -> Integer -> Input
+caseToInput :: [Case a Token] -> Integer -> Integer -> Input
 caseToInput [] _ _ = error "Wrong number of cases interpreting result"
 caseToInput (Case h _:t) c v
   | c > 1 = caseToInput t (c - 1) v

--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -178,7 +178,7 @@ convertToSymbolicTrace refL symL =
  else error "Provided symbolic trace is not long enough"
 
 -- Symbolic version evalValue
-symEvalVal :: Ord t => Value (Observation t) t -> SymState t -> SInteger
+symEvalVal :: Ord t => Value t -> SymState t -> SInteger
 symEvalVal (AvailableMoney accId tok) symState =
   M.findWithDefault (literal 0) (accId, tok) (symAccounts symState)
 symEvalVal (Constant inte) symState = literal inte
@@ -397,7 +397,7 @@ addFreshSlotsToState sState =
 -- to the function and pass it to the next iteration of isValidAndFailsWhen.
 -- - pos - Is the position of the current Case clause [1..], 0 means timeout branch.
 isValidAndFailsWhen :: Ord t
-                    => Bool -> SBool -> [Case (Contract t) t] -> Timeout -> Contract t -> (SymInput t -> SymState t -> SBool)
+                    => Bool -> SBool -> [Case t] -> Timeout -> Contract t -> (SymInput t -> SymState t -> SBool)
                     -> SymState t -> Integer -> Symbolic SBool
 isValidAndFailsWhen oa hasErr [] timeout cont previousMatch sState pos =
   do newLowSlot <- sInteger_
@@ -518,7 +518,7 @@ countWhens (Let va vb c)       = countWhens c
 countWhens (Assert o c)        = countWhens c
 
 -- Same as countWhens but it starts with a Case list
-countWhensCaseList :: [Case (Contract t) t] -> Integer
+countWhensCaseList :: [Case t] -> Integer
 countWhensCaseList (Case uu c : tail)           = max (countWhens c) (countWhensCaseList tail)
 countWhensCaseList (MerkleizedCase uu c : tail) = countWhensCaseList tail
 countWhensCaseList []                           = 0
@@ -578,7 +578,7 @@ groupResult _ _ = error "Wrong number of labels generated"
 
 -- Reconstructs an input from a Case list a Case position and a value (deposit amount or
 -- chosen value)
-caseToInput :: [Case a t] -> Integer -> Integer -> Input t
+caseToInput :: [Case t] -> Integer -> Integer -> Input t
 caseToInput [] _ _ = error "Wrong number of cases interpreting result"
 caseToInput (Case h _:t) c v
   | c > 1 = caseToInput t (c - 1) v

--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -572,7 +572,7 @@ groupResult _ _ = error "Wrong number of labels generated"
 
 -- Reconstructs an input from a Case list a Case position and a value (deposit amount or
 -- chosen value)
-caseToInput :: [Case a Token] -> Integer -> Integer -> Input
+caseToInput :: [Case a Token] -> Integer -> Integer -> Input Token
 caseToInput [] _ _ = error "Wrong number of cases interpreting result"
 caseToInput (Case h _:t) c v
   | c > 1 = caseToInput t (c - 1) v
@@ -593,7 +593,7 @@ caseToInput (MerkleizedCase _ _:t) c v
 -- Input is passed as a combination and function from input list to transaction input and
 -- input list for convenience. The list of 4-uples is passed through because it is used
 -- to recursively call executeAndInterpret (co-recursive funtion).
-computeAndContinue :: ([Input] -> TransactionInput) -> [Input] -> State -> Contract Token
+computeAndContinue :: ([Input Token] -> TransactionInput) -> [Input Token] -> State -> Contract Token
                    -> [(Integer, Integer, Integer, Integer)]
                    -> [([TransactionInput], [TransactionWarning])]
 computeAndContinue transaction inps sta cont t =

--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -177,7 +177,7 @@ convertToSymbolicTrace refL symL =
  else error "Provided symbolic trace is not long enough"
 
 -- Symbolic version evalValue
-symEvalVal :: Value Observation -> SymState -> SInteger
+symEvalVal :: Value (Observation Token) Token -> SymState -> SInteger
 symEvalVal (AvailableMoney accId tok) symState =
   M.findWithDefault (literal 0) (accId, tok) (symAccounts symState)
 symEvalVal (Constant inte) symState = literal inte
@@ -211,7 +211,7 @@ symEvalVal (Cond cond v1 v2) symState = ite (symEvalObs cond symState)
                                             (symEvalVal v2 symState)
 
 -- Symbolic version evalObservation
-symEvalObs :: Observation -> SymState -> SBool
+symEvalObs :: Observation Token -> SymState -> SBool
 symEvalObs (AndObs obs1 obs2) symState = symEvalObs obs1 symState .&&
                                          symEvalObs obs2 symState
 symEvalObs (OrObs obs1 obs2) symState = symEvalObs obs1 symState .||

--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -595,7 +595,7 @@ caseToInput (MerkleizedCase _ _:t) c v
 -- to recursively call executeAndInterpret (co-recursive funtion).
 computeAndContinue :: ([Input Token] -> TransactionInput Token) -> [Input Token] -> State Token -> Contract Token
                    -> [(Integer, Integer, Integer, Integer)]
-                   -> [([TransactionInput Token], [TransactionWarning])]
+                   -> [([TransactionInput Token], [TransactionWarning Token])]
 computeAndContinue transaction inps sta cont t =
   case computeTransaction (transaction inps) sta cont of
     Error TEUselessTransaction -> executeAndInterpret sta t cont
@@ -608,7 +608,7 @@ computeAndContinue transaction inps sta cont t =
 -- Takes a list of 4-uples (and state and contract) and interprets it as a list of
 -- transactions and also computes the resulting list of warnings.
 executeAndInterpret :: State Token -> [(Integer, Integer, Integer, Integer)] -> Contract Token
-                    -> [([TransactionInput Token], [TransactionWarning])]
+                    -> [([TransactionInput Token], [TransactionWarning Token])]
 executeAndInterpret _ [] _ = []
 executeAndInterpret sta ((l, h, v, b):t) cont
   | b == 0 = computeAndContinue transaction [] sta cont t
@@ -629,7 +629,7 @@ executeAndInterpret sta ((l, h, v, b):t) cont
 -- It wraps executeAndInterpret so that it takes an optional State, and also
 -- combines the results of executeAndInterpret in one single tuple.
 interpretResult :: [(Integer, Integer, Integer, Integer)] -> Contract Token -> Maybe (State Token)
-                -> (POSIXTime, [TransactionInput Token], [TransactionWarning])
+                -> (POSIXTime, [TransactionInput Token], [TransactionWarning Token])
 interpretResult [] _ _ = error "Empty result"
 interpretResult t@((l, _, _, _):_) c maybeState = (POSIXTime l, tin, twa)
    where (tin, twa) = foldl' (\(accInp, accWarn) (elemInp, elemWarn) ->
@@ -642,7 +642,7 @@ interpretResult t@((l, _, _, _):_) c maybeState = (POSIXTime l, tin, twa)
 -- It interprets the counter example found by SBV (SMTModel), given the contract,
 -- and initial state (optional), and the list of variables used.
 extractCounterExample :: SMTModel -> Contract Token -> Maybe (State Token) -> [String]
-                      -> (POSIXTime, [TransactionInput Token], [TransactionWarning])
+                      -> (POSIXTime, [TransactionInput Token], [TransactionWarning Token])
 extractCounterExample smtModel cont maybeState maps = interpretedResult
   where assocs = map (\(a, b) -> (a, fromCV b :: Integer)) $ modelAssocs smtModel
         counterExample = groupResult maps (M.fromList assocs)
@@ -654,7 +654,7 @@ warningsTraceCustom :: Bool
               -> Contract Token
               -> Maybe (State Token)
               -> IO (Either ThmResult
-                            (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning])))
+                            (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning Token])))
 warningsTraceCustom onlyAssertions con maybeState =
     do thmRes@(ThmResult result) <- satCommand
        return (case result of
@@ -673,20 +673,20 @@ warningsTraceCustom onlyAssertions con maybeState =
 warningsTraceWithState :: Contract Token
               -> Maybe (State Token)
               -> IO (Either ThmResult
-                            (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning])))
+                            (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning Token])))
 warningsTraceWithState = warningsTraceCustom False
 
 -- Like warningsTraceCustom but only checks assertions.
 onlyAssertionsWithState :: Contract Token
               -> Maybe (State Token)
               -> IO (Either ThmResult
-                            (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning])))
+                            (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning Token])))
 onlyAssertionsWithState = warningsTraceCustom True
 
 -- Like warningsTraceWithState but without initialState.
 warningsTrace :: Contract Token
               -> IO (Either ThmResult
-                            (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning])))
+                            (Maybe (POSIXTime, [TransactionInput Token], [TransactionWarning Token])))
 warningsTrace con = warningsTraceWithState con Nothing
 
 

--- a/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -18,6 +18,7 @@ import qualified Data.SBV.Tuple as ST
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Marlowe.Core.V1.Semantics
+import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types
 import Ledger (POSIXTime (..))
 import qualified PlutusTx.AssocMap as AssocMap

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -1327,7 +1327,7 @@ mkStep MarloweParams{..} typedValidator timeInterval@(minTime, maxTime) clientIn
     collectDeposits (IDeposit _ _ (Token cur tok) amount) = Val.singleton cur tok amount
     collectDeposits _                                     = P.zero
 
-    payoutByParty :: Payment -> AssocMap.Map Party Val.Value
+    payoutByParty :: Payment Token -> AssocMap.Map Party Val.Value
     payoutByParty (Payment _ (Party party) money) = AssocMap.singleton party (moneyToValue money)
     payoutByParty (Payment _ (Account _) _)       = AssocMap.empty
 

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -182,16 +182,16 @@ type RoleOwners = AssocMap.Map Val.TokenName (AddressInEra ShelleyEra)
 -- Now we are not able to notify about role payouts before the contract is on the chain.
 data ContractHistory =
     ContractHistory
-        { chParams         :: MarloweParams      -- ^ The "instance id" of the contract
-        , chInitialData    :: MarloweData        -- ^ The initial Contract + State
-        , chHistory        :: [TransactionInput] -- ^ All the transaction that affected the contract.
-                                                 --   The current state and intermediate states can
-                                                 --   be recalculated by using computeTransaction
-                                                 --   of each TransactionInput to the initial state
-        , chAddress        :: Address            -- ^ The script address of the marlowe contract
-        , chUnspentPayouts :: UnspentPayouts     -- ^ All UTxOs associated with our payout script.
-                                                 --   Please note that in theory we include here outpus
-                                                 --   which possible were created by an "external" transactions.
+        { chParams         :: MarloweParams            -- ^ The "instance id" of the contract
+        , chInitialData    :: MarloweData              -- ^ The initial Contract + State
+        , chHistory        :: [TransactionInput Token] -- ^ All the transaction that affected the contract.
+                                                       --   The current state and intermediate states can
+                                                       --   be recalculated by using computeTransaction
+                                                       --   of each TransactionInput to the initial state
+        , chAddress        :: Address                  -- ^ The script address of the marlowe contract
+        , chUnspentPayouts :: UnspentPayouts           -- ^ All UTxOs associated with our payout script.
+                                                       --   Please note that in theory we include here outpus
+                                                       --   which possible were created by an "external" transactions.
         }
         deriving stock (Show, Generic)
         deriving anyclass (FromJSON, ToJSON)

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -62,6 +62,7 @@ import Language.Marlowe.Client.History (History (..), IncludePkhTxns (IncludePkh
                                         txRoleData)
 import Language.Marlowe.Core.V1.Semantics
 import qualified Language.Marlowe.Core.V1.Semantics as Marlowe
+import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types hiding (Contract, getAction)
 import qualified Language.Marlowe.Core.V1.Semantics.Types as Marlowe
 import Language.Marlowe.Scripts
@@ -1283,7 +1284,8 @@ mkStep MarloweParams{..} typedValidator timeInterval@(minTime, maxTime) clientIn
                             Close -> txConstraints
                             _ -> let
                                 finalBalance = let
-                                    contractBalance = totalBalance (accounts marloweState)
+                                    contractBalance, totalIncome, totalPayouts :: Val.Value
+                                    contractBalance = moneyToValue $ totalBalance (accounts marloweState)
                                     totalIncome = P.foldMap (collectDeposits . getInputContent) inputs
                                     totalPayouts = P.foldMap snd payoutsByParty
                                     in contractBalance P.+ totalIncome P.- totalPayouts
@@ -1326,7 +1328,7 @@ mkStep MarloweParams{..} typedValidator timeInterval@(minTime, maxTime) clientIn
     collectDeposits _                                     = P.zero
 
     payoutByParty :: Payment -> AssocMap.Map Party Val.Value
-    payoutByParty (Payment _ (Party party) money) = AssocMap.singleton party money
+    payoutByParty (Payment _ (Party party) money) = AssocMap.singleton party (moneyToValue money)
     payoutByParty (Payment _ (Account _) _)       = AssocMap.empty
 
     payoutConstraints :: [(Party, Val.Value)] -> TxConstraints i0 o0

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -960,7 +960,7 @@ shelleyAddressToKeys (AddressInEra _ (Shelley.ShelleyAddress _ paymentCredential
             pure (ppkh,  Just . StakePubKeyHash . PubKeyHash . toBuiltin $ serialiseToRawBytes stakeHash)
 shelleyAddressToKeys _ = throwError $ OtherContractError $ Contract.OtherContractError "Byron Addresses not supported"
 
-getAction :: MarloweTimeRange -> Party -> MarloweData -> ([TransactionWarning], PartyAction)
+getAction :: MarloweTimeRange -> Party -> MarloweData -> ([TransactionWarning Token], PartyAction)
 getAction timeRange party MarloweData{marloweContract,marloweState} = let
     env = Environment timeRange
     in case reduceContractUntilQuiescent env marloweState marloweContract of

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -107,7 +107,7 @@ import PlutusTx.Traversable (for)
 
 
 data MarloweClientInput = ClientInput InputContent
-                        | ClientMerkleizedInput InputContent Marlowe.Contract
+                        | ClientMerkleizedInput InputContent (Marlowe.Contract Token)
   deriving stock (Eq, Show, Generic)
 
 instance FromJSON MarloweClientInput where
@@ -118,7 +118,7 @@ instance ToJSON MarloweClientInput where
   toJSON (ClientMerkleizedInput content contract) = toJSON (content, contract)
 
 
-type CreateEndpointSchema = (UUID, AssocMap.Map Val.TokenName (AddressInEra ShelleyEra), Marlowe.Contract)
+type CreateEndpointSchema = (UUID, AssocMap.Map Val.TokenName (AddressInEra ShelleyEra), Marlowe.Contract Token)
 type ApplyInputsEndpointSchema = (UUID, MarloweParams, Maybe TimeInterval, [MarloweClientInput])
 type ApplyInputsNonMerkleizedEndpointSchema = (UUID, MarloweParams, Maybe TimeInterval, [InputContent])
 type AutoEndpointSchema = (UUID, MarloweParams, Party, POSIXTime)
@@ -997,7 +997,7 @@ getAction timeRange party MarloweData{marloweContract,marloweState} = let
 
 
 
-canAutoExecuteContractForParty :: Party -> Marlowe.Contract -> Bool
+canAutoExecuteContractForParty :: Party -> Marlowe.Contract Token -> Bool
 canAutoExecuteContractForParty party = check
   where
     check cont =

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -1254,7 +1254,7 @@ mkStep MarloweParams{..} typedValidator timeInterval@(minTime, maxTime) clientIn
     evaluateTxContstraints :: MarloweData Token
         -> Ledger.POSIXTimeRange
         -> Tx.TxOutRef
-        -> Contract w MarloweSchema MarloweError (TxConstraints [MarloweTxInput] (MarloweData Token), MarloweData Token)
+        -> Contract w MarloweSchema MarloweError (TxConstraints [MarloweTxInput Token] (MarloweData Token), MarloweData Token)
     evaluateTxContstraints MarloweData{..} times marloweTxOutRef = do
         let (inputs, inputsConstraints) = foldMap clientInputToInputAndConstraints clientInputs
         let txInput = TransactionInput {

--- a/marlowe/src/Language/Marlowe/Client/History.hs
+++ b/marlowe/src/Language/Marlowe/Client/History.hs
@@ -104,7 +104,7 @@ data History =
     Created
     {
       historyTxOutRef :: TxOutRef          -- ^ The UTxO that created the contract.
-    , historyData     :: MarloweData       -- ^ The Marlowe data attached to the UTxO.
+    , historyData     :: MarloweData Token -- ^ The Marlowe data attached to the UTxO.
     , historyNext     :: Maybe History     -- ^ The next step in the history, if known.
     }
     -- | Input was applied to the contract.
@@ -112,7 +112,7 @@ data History =
     {
       historyInput    :: TransactionInput Token  -- ^ The Marlowe input that was applied.
     , historyTxOutRef :: TxOutRef                -- ^ The UTxO that resulted from the input being applied.
-    , historyData     :: MarloweData             -- ^ The Marlowe data attached to the UTxO.
+    , historyData     :: MarloweData Token       -- ^ The Marlowe data attached to the UTxO.
     , historyNext     :: Maybe History           -- ^ The next step in the history, if known.
     }
     -- | The contract was closed.
@@ -334,8 +334,8 @@ marloweStatesFrom validator citx =
 
 
 -- | Extract the Marlowe state from a Marlowe-specific output.
-toMarloweState :: MarloweTxOutRef  -- ^ The Marlowe-specific output.
-               -> MarloweData      -- ^ The Marlowe data.
+toMarloweState :: MarloweTxOutRef    -- ^ The Marlowe-specific output.
+               -> MarloweData Token  -- ^ The Marlowe data.
 toMarloweState = tyTxOutData . tyTxOutRefOut
 
 toRolePayout :: RolePayoutTxOutRef  -- ^ Role payout specific output

--- a/marlowe/src/Language/Marlowe/Client/History.hs
+++ b/marlowe/src/Language/Marlowe/Client/History.hs
@@ -56,6 +56,7 @@ import Data.Maybe (catMaybes, isJust, isNothing, mapMaybe)
 import Data.Tuple.Extra (secondM)
 import GHC.Generics (Generic)
 import Language.Marlowe.Core.V1.Semantics (MarloweData, MarloweParams (..), TransactionInput (TransactionInput))
+import Language.Marlowe.Core.V1.Semantics.Types (Token)
 import Language.Marlowe.Scripts (SmallTypedValidator, TypedMarloweValidator, TypedRolePayoutValidator,
                                  smallUntypedValidator)
 import Ledger (ChainIndexTxOut (..), ciTxOutAddress, toTxOut)
@@ -109,16 +110,16 @@ data History =
     -- | Input was applied to the contract.
   | InputApplied
     {
-      historyInput    :: TransactionInput  -- ^ The Marlowe input that was applied.
-    , historyTxOutRef :: TxOutRef          -- ^ The UTxO that resulted from the input being applied.
-    , historyData     :: MarloweData       -- ^ The Marlowe data attached to the UTxO.
-    , historyNext     :: Maybe History     -- ^ The next step in the history, if known.
+      historyInput    :: TransactionInput Token  -- ^ The Marlowe input that was applied.
+    , historyTxOutRef :: TxOutRef                -- ^ The UTxO that resulted from the input being applied.
+    , historyData     :: MarloweData             -- ^ The Marlowe data attached to the UTxO.
+    , historyNext     :: Maybe History           -- ^ The next step in the history, if known.
     }
     -- | The contract was closed.
   | Closed
     {
-      historyInput :: TransactionInput  -- ^ The Marlowe input that was applied.
-    , historyTxId  :: TxId              -- ^ The transaction that resulted from the input being applied.
+      historyInput :: TransactionInput Token  -- ^ The Marlowe input that was applied.
+    , historyTxId  :: TxId                    -- ^ The transaction that resulted from the input being applied.
     }
     deriving stock (Eq, Generic, Show)
     deriving anyclass (ToJSON, FromJSON)
@@ -429,9 +430,9 @@ txDatums citx =
 
 
 -- | Extract Marlowe input from a transaction.
-txInputs :: SlotConfig                      -- ^ The slot configuration.
-         -> ChainIndexTx                    -- ^ The transaction.
-         -> [(TxOutRef, TransactionInput)]  -- ^ The inputs that have Marlowe inputs.
+txInputs :: SlotConfig                            -- ^ The slot configuration.
+         -> ChainIndexTx                          -- ^ The transaction.
+         -> [(TxOutRef, TransactionInput Token)]  -- ^ The inputs that have Marlowe inputs.
 txInputs slotConfig citx =
   case slotRangeToPOSIXTimeRange slotConfig $ citx ^. citxValidRange of
     Interval (LowerBound (Finite l) True) (UpperBound (Finite h) False) ->

--- a/marlowe/src/Language/Marlowe/Client/History.hs
+++ b/marlowe/src/Language/Marlowe/Client/History.hs
@@ -56,7 +56,7 @@ import Data.Maybe (catMaybes, isJust, isNothing, mapMaybe)
 import Data.Tuple.Extra (secondM)
 import GHC.Generics (Generic)
 import Language.Marlowe.Core.V1.Semantics (MarloweData, MarloweParams (..), TransactionInput (TransactionInput))
-import Language.Marlowe.Core.V1.Semantics.Types (Token)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Scripts (SmallTypedValidator, TypedMarloweValidator, TypedRolePayoutValidator,
                                  smallUntypedValidator)
 import Ledger (ChainIndexTxOut (..), ciTxOutAddress, toTxOut)

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -128,8 +128,8 @@ data ReduceStepResult t = Reduced (ReduceWarning t) ReduceEffect (State t) (Cont
 
 
 -- | Result of 'reduceContractUntilQuiescent'
-data ReduceResult = ContractQuiescent Bool [ReduceWarning Token] [Payment] (State Token) (Contract Token)
-                  | RRAmbiguousTimeIntervalError
+data ReduceResult t = ContractQuiescent Bool [ReduceWarning t] [Payment] (State t) (Contract t)
+                    | RRAmbiguousTimeIntervalError
   deriving stock (Haskell.Show)
 
 
@@ -406,10 +406,10 @@ reduceContractStep env state contract = case contract of
         in Reduced warning ReduceNoPayment state cont
 
 -- | Reduce a contract until it cannot be reduced more
-reduceContractUntilQuiescent :: Environment -> State Token -> Contract Token -> ReduceResult
+reduceContractUntilQuiescent :: Environment -> State Token -> Contract Token -> ReduceResult Token
 reduceContractUntilQuiescent env state contract = let
     reductionLoop
-      :: Bool -> Environment -> State Token -> Contract Token -> [ReduceWarning Token] -> [Payment] -> ReduceResult
+      :: Bool -> Environment -> State Token -> Contract Token -> [ReduceWarning Token] -> [Payment] -> ReduceResult Token
     reductionLoop reduced env state contract warnings payments =
         case reduceContractStep env state contract of
             Reduced warning effect newState cont -> let

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -426,12 +426,12 @@ reduceContractUntilQuiescent env state contract = let
 
     in reductionLoop False env state contract [] []
 
-data ApplyAction = AppliedAction (ApplyWarning Token) (State Token)
-                 | NotAppliedAction
+data ApplyAction t = AppliedAction (ApplyWarning t) (State t)
+                   | NotAppliedAction
   deriving stock (Haskell.Show)
 
 -- | Try to apply a single input content to a single action
-applyAction :: Environment -> State Token -> InputContent Token -> Action Token -> ApplyAction
+applyAction :: Environment -> State Token -> InputContent Token -> Action Token -> ApplyAction Token
 applyAction env state (IDeposit accId1 party1 tok1 amount) (Deposit accId2 party2 tok2 val) =
     if accId1 == accId2 && party1 == party2 && tok1 == tok2 && amount == evalValue env state val
     then let warning = if amount > 0 then ApplyNoWarning

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -192,12 +192,12 @@ instance Pretty t => Pretty (TransactionInput t) where
 
 {-| Marlowe transaction output.
 -}
-data TransactionOutput =
+data TransactionOutput t =
     TransactionOutput
-        { txOutWarnings :: [TransactionWarning Token]
+        { txOutWarnings :: [TransactionWarning t]
         , txOutPayments :: [Payment]
-        , txOutState    :: State Token
-        , txOutContract :: Contract Token }
+        , txOutState    :: State t
+        , txOutContract :: Contract t }
     | Error TransactionError
   deriving stock (Haskell.Show)
 
@@ -540,7 +540,7 @@ isClose Close = True
 isClose _     = False
 
 -- | Try to compute outputs of a transaction given its inputs, a contract, and it's @State@
-computeTransaction :: TransactionInput Token -> State Token -> Contract Token -> TransactionOutput
+computeTransaction :: TransactionInput Token -> State Token -> Contract Token -> TransactionOutput Token
 computeTransaction tx state contract = let
     inputs = txInputs tx
     in case fixInterval (txInterval tx) state of
@@ -557,7 +557,7 @@ computeTransaction tx state contract = let
             ApplyAllHashMismatch -> Error TEHashMismatch
         IntervalError error -> Error (TEIntervalError error)
 
-playTraceAux :: TransactionOutput -> [TransactionInput Token] -> TransactionOutput
+playTraceAux :: TransactionOutput Token -> [TransactionInput Token] -> TransactionOutput Token
 playTraceAux res [] = res
 playTraceAux TransactionOutput
                 { txOutWarnings = warnings
@@ -576,7 +576,7 @@ playTraceAux TransactionOutput
           Error _ -> transRes
 playTraceAux err@(Error _) _ = err
 
-playTrace :: POSIXTime -> Contract Token -> [TransactionInput Token] -> TransactionOutput
+playTrace :: POSIXTime -> Contract Token -> [TransactionInput Token] -> TransactionOutput Token
 playTrace minTime c = playTraceAux TransactionOutput
                                  { txOutWarnings = []
                                  , txOutPayments = []

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -147,10 +147,10 @@ data ApplyResult t = Applied (ApplyWarning t) (State t) (Contract t)
 
 
 -- | Result of 'applyAllInputs'
-data ApplyAllResult = ApplyAllSuccess Bool [TransactionWarning Token] [Payment] (State Token) (Contract Token)
-                    | ApplyAllNoMatchError
-                    | ApplyAllAmbiguousTimeIntervalError
-                    | ApplyAllHashMismatch
+data ApplyAllResult t = ApplyAllSuccess Bool [TransactionWarning t] [Payment] (State t) (Contract t)
+                      | ApplyAllNoMatchError
+                      | ApplyAllAmbiguousTimeIntervalError
+                      | ApplyAllHashMismatch
   deriving stock (Haskell.Show)
 
 
@@ -491,7 +491,7 @@ convertReduceWarnings = foldr (\warn acc -> case warn of
     ) []
 
 -- | Apply a list of Inputs to the contract
-applyAllInputs :: Environment -> State Token -> Contract Token -> [Input Token] -> ApplyAllResult
+applyAllInputs :: Environment -> State Token -> Contract Token -> [Input Token] -> ApplyAllResult Token
 applyAllInputs env state contract inputs = let
     applyAllLoop
         :: Bool
@@ -501,7 +501,7 @@ applyAllInputs env state contract inputs = let
         -> [Input Token]
         -> [TransactionWarning Token]
         -> [Payment]
-        -> ApplyAllResult
+        -> ApplyAllResult Token
     applyAllLoop contractChanged env state contract inputs warnings payments =
         case reduceContractUntilQuiescent env state contract of
             RRAmbiguousTimeIntervalError -> ApplyAllAmbiguousTimeIntervalError

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -121,9 +121,9 @@ data ReduceWarning t = ReduceNoWarning
 
 
 -- | Result of 'reduceContractStep'
-data ReduceStepResult = Reduced (ReduceWarning Token) ReduceEffect (State Token) (Contract Token)
-                      | NotReduced
-                      | AmbiguousTimeIntervalReductionError
+data ReduceStepResult t = Reduced (ReduceWarning t) ReduceEffect (State t) (Contract t)
+                        | NotReduced
+                        | AmbiguousTimeIntervalReductionError
   deriving stock (Haskell.Show)
 
 
@@ -349,7 +349,7 @@ giveMoney accountId payee (Token cur tok) amount accounts = let
 
 
 -- | Carry a step of the contract with no inputs
-reduceContractStep :: Environment -> State Token -> Contract Token -> ReduceStepResult
+reduceContractStep :: Environment -> State Token -> Contract Token -> ReduceStepResult Token
 reduceContractStep env state contract = case contract of
 
     Close -> case refundOne (accounts state) of

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -205,9 +205,9 @@ data TransactionOutput t =
 {-|
     This data type is a content of a contract's /Datum/
 -}
-data MarloweData = MarloweData {
-        marloweState    :: State Token,
-        marloweContract :: Contract Token
+data MarloweData t = MarloweData {
+        marloweState    :: State t,
+        marloweContract :: Contract t
     } deriving stock (Haskell.Show, Haskell.Eq, Generic)
       deriving anyclass (ToJSON, FromJSON)
 

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -221,7 +221,7 @@ data MarloweParams = MarloweParams {
 
 
 {- Checks 'interval' and trim it if necessary. -}
-fixInterval :: TimeInterval -> State Token -> IntervalResult Token
+fixInterval :: TimeInterval -> State t -> IntervalResult t
 fixInterval interval state =
     case interval of
         (low, high)
@@ -241,7 +241,7 @@ fixInterval interval state =
 {-|
   Evaluates @Value@ given current @State@ and @Environment@
 -}
-evalValue :: Environment -> State Token -> Value (Observation Token) Token -> Integer
+evalValue :: Eq t => Environment -> State t -> Value (Observation t) t -> Integer
 evalValue env state value = let
     eval = evalValue env state
     in case value of
@@ -286,7 +286,7 @@ evalValue env state value = let
 
 
 -- | Evaluate 'Observation' to 'Bool'.
-evalObservation :: Environment -> State Token -> Observation Token -> Bool
+evalObservation :: Eq t => Environment -> State t -> Observation t -> Bool
 evalObservation env state obs = let
     evalObs = evalObservation env state
     evalVal = evalValue env state
@@ -315,7 +315,7 @@ refundOne accounts = case Map.toList accounts of
 
 
 -- | Obtains the amount of money available an account
-moneyInAccount :: AccountId -> Token -> Accounts Token -> Integer
+moneyInAccount :: Eq t => AccountId -> t -> Accounts t -> Integer
 moneyInAccount accId token accounts = case Map.lookup (accId, token) accounts of
     Just x  -> x
     Nothing -> 0

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -140,9 +140,9 @@ data ApplyWarning t = ApplyNoWarning
 
 
 -- | Result of 'applyCases'
-data ApplyResult = Applied (ApplyWarning Token) (State Token) (Contract Token)
-                 | ApplyNoMatchError
-                 | ApplyHashMismatch
+data ApplyResult t = Applied (ApplyWarning t) (State t) (Contract t)
+                   | ApplyNoMatchError
+                   | ApplyHashMismatch
   deriving stock (Haskell.Show)
 
 
@@ -458,7 +458,7 @@ getContinuation (MerkleizedInput _ inputContinuationHash continuation) (Merkleiz
     else Nothing
 getContinuation _ _ = Nothing
 
-applyCases :: Environment -> State Token -> Input Token -> [Case (Contract Token) Token] -> ApplyResult
+applyCases :: Environment -> State Token -> Input Token -> [Case (Contract Token) Token] -> ApplyResult Token
 applyCases env state input (headCase : tailCase) =
     let inputContent = getInputContent input :: InputContent Token
         action = getAction headCase :: Action Token
@@ -472,7 +472,7 @@ applyCases env state input (headCase : tailCase) =
 applyCases _ _ _ [] = ApplyNoMatchError
 
 -- | Apply a single @Input@ to a current contract
-applyInput :: Environment -> State Token -> Input Token -> Contract Token -> ApplyResult
+applyInput :: Environment -> State Token -> Input Token -> Contract Token -> ApplyResult Token
 applyInput env state input (When cases _ _) = applyCases env state input cases
 applyInput _ _ _ _                          = ApplyNoMatchError
 

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -429,7 +429,7 @@ data ApplyAction = AppliedAction ApplyWarning State
   deriving stock (Haskell.Show)
 
 -- | Try to apply a single input content to a single action
-applyAction :: Environment -> State -> InputContent -> Action -> ApplyAction
+applyAction :: Environment -> State -> InputContent -> Action Token -> ApplyAction
 applyAction env state (IDeposit accId1 party1 tok1 amount) (Deposit accId2 party2 tok2 val) =
     if accId1 == accId2 && party1 == party2 && tok1 == tok2 && amount == evalValue env state val
     then let warning = if amount > 0 then ApplyNoWarning
@@ -448,7 +448,7 @@ applyAction env state INotify (Notify obs)
 applyAction _ _ _ _ = NotAppliedAction
 
 -- | Try to get a continuation from a pair of Input and Case
-getContinuation :: Input -> Case (Contract Token) -> Maybe (Contract Token)
+getContinuation :: Input -> Case (Contract Token) Token -> Maybe (Contract Token)
 getContinuation (NormalInput _) (Case _ continuation) = Just continuation
 getContinuation (MerkleizedInput _ inputContinuationHash continuation) (MerkleizedCase _ continuationHash) =
     if inputContinuationHash == continuationHash
@@ -456,10 +456,10 @@ getContinuation (MerkleizedInput _ inputContinuationHash continuation) (Merkleiz
     else Nothing
 getContinuation _ _ = Nothing
 
-applyCases :: Environment -> State -> Input -> [Case (Contract Token)] -> ApplyResult
+applyCases :: Environment -> State -> Input -> [Case (Contract Token) Token] -> ApplyResult
 applyCases env state input (headCase : tailCase) =
     let inputContent = getInputContent input :: InputContent
-        action = getAction headCase :: Action
+        action = getAction headCase :: Action Token
         maybeContinuation = getContinuation input headCase :: Maybe (Contract Token)
     in case applyAction env state inputContent action of
          AppliedAction warning newState ->

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -54,10 +54,10 @@ import Data.Text (pack)
 import Deriving.Aeson
 import Language.Marlowe.Core.V1.Semantics.Money (Money)
 import qualified Language.Marlowe.Core.V1.Semantics.Money as Money
-import Language.Marlowe.Core.V1.Semantics.Types (AccountId, Accounts, Action (..), Case (..), Contract (..),
+import Language.Marlowe.Core.V1.Semantics.Types (AccountId, Accounts, Action (..), Case, Case_ (..), Contract (..),
                                                  Environment (..), Input (..), InputContent (..), IntervalError (..),
                                                  IntervalResult (..), Observation (..), Party, Payee (..), State (..),
-                                                 TimeInterval, Value (..), ValueId, emptyState, getAction,
+                                                 TimeInterval, Value, ValueId, Value_ (..), emptyState, getAction,
                                                  getInputContent, inBounds)
 import Language.Marlowe.ParserUtil (getInteger, withInteger)
 import Language.Marlowe.Pretty (Pretty (..))
@@ -241,7 +241,7 @@ fixInterval interval state =
 {-|
   Evaluates @Value@ given current @State@ and @Environment@
 -}
-evalValue :: Eq t => Environment -> State t -> Value (Observation t) t -> Integer
+evalValue :: Eq t => Environment -> State t -> Value t -> Integer
 evalValue env state value = let
     eval = evalValue env state
     in case value of
@@ -450,7 +450,7 @@ applyAction env state INotify (Notify obs)
 applyAction _ _ _ _ = NotAppliedAction
 
 -- | Try to get a continuation from a pair of Input and Case
-getContinuation :: Input t -> Case (Contract t) t -> Maybe (Contract t)
+getContinuation :: Input t -> Case t -> Maybe (Contract t)
 getContinuation (NormalInput _) (Case _ continuation) = Just continuation
 getContinuation (MerkleizedInput _ inputContinuationHash continuation) (MerkleizedCase _ continuationHash) =
     if inputContinuationHash == continuationHash
@@ -458,7 +458,7 @@ getContinuation (MerkleizedInput _ inputContinuationHash continuation) (Merkleiz
     else Nothing
 getContinuation _ _ = Nothing
 
-applyCases :: forall t. Eq t => Environment -> State t -> Input t -> [Case (Contract t) t] -> ApplyResult t
+applyCases :: forall t. Eq t => Environment -> State t -> Input t -> [Case t] -> ApplyResult t
 applyCases env state input (headCase : tailCase) =
     let inputContent = getInputContent input :: InputContent t
         action = getAction headCase :: Action t

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -239,7 +239,7 @@ fixInterval interval state =
 {-|
   Evaluates @Value@ given current @State@ and @Environment@
 -}
-evalValue :: Environment -> State -> Value Observation -> Integer
+evalValue :: Environment -> State -> Value (Observation Token) Token -> Integer
 evalValue env state value = let
     eval = evalValue env state
     in case value of
@@ -284,7 +284,7 @@ evalValue env state value = let
 
 
 -- | Evaluate 'Observation' to 'Bool'.
-evalObservation :: Environment -> State -> Observation -> Bool
+evalObservation :: Environment -> State -> Observation Token -> Bool
 evalObservation env state obs = let
     evalObs = evalObservation env state
     evalVal = evalValue env state

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -134,13 +134,13 @@ data ReduceResult t = ContractQuiescent Bool [ReduceWarning t] [Payment] (State 
 
 
 -- | Warning of 'applyCases'
-data ApplyWarning = ApplyNoWarning
-                  | ApplyNonPositiveDeposit Party AccountId Token Integer
+data ApplyWarning t = ApplyNoWarning
+                    | ApplyNonPositiveDeposit Party AccountId t Integer
   deriving stock (Haskell.Show)
 
 
 -- | Result of 'applyCases'
-data ApplyResult = Applied ApplyWarning (State Token) (Contract Token)
+data ApplyResult = Applied (ApplyWarning Token) (State Token) (Contract Token)
                  | ApplyNoMatchError
                  | ApplyHashMismatch
   deriving stock (Haskell.Show)
@@ -426,7 +426,7 @@ reduceContractUntilQuiescent env state contract = let
 
     in reductionLoop False env state contract [] []
 
-data ApplyAction = AppliedAction ApplyWarning (State Token)
+data ApplyAction = AppliedAction (ApplyWarning Token) (State Token)
                  | NotAppliedAction
   deriving stock (Haskell.Show)
 
@@ -528,7 +528,7 @@ applyAllInputs env state contract inputs = let
                     ApplyHashMismatch -> ApplyAllHashMismatch
     in applyAllLoop False env state contract inputs [] []
   where
-    convertApplyWarning :: ApplyWarning -> [TransactionWarning Token]
+    convertApplyWarning :: ApplyWarning Token -> [TransactionWarning Token]
     convertApplyWarning warn =
         case warn of
             ApplyNoWarning -> []

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics/Money.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics/Money.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MonoLocalBinds        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+-- Big hammer, but helps
+{-# OPTIONS_GHC -fno-specialise               #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-warn-orphans             #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas   #-}
+
+-- | Ledger independent representation of Money
+--
+-- Intended for qualified import
+--
+-- > import Language.Marlowe.Core.V1.Semantics.Money (Money)
+-- > import qualified Language.Marlowe.Core.V1.Semantics.Money as Money
+module Language.Marlowe.Core.V1.Semantics.Money (
+    Money(..)
+  , singleton
+  , toList
+  ) where
+
+import PlutusTx.Prelude hiding (toList, zero)
+import qualified Prelude as Haskell
+
+import qualified Data.List as Haskell
+import GHC.Generics (Generic)
+import PlutusTx.AssocMap (Map)
+import PlutusTx.Lift (makeLift)
+
+import qualified PlutusTx.AssocMap as Map
+
+{-------------------------------------------------------------------------------
+  Basic API
+-------------------------------------------------------------------------------}
+
+-- | Ledger-independent representation of money
+newtype Money t = Money (Map t Integer)
+  deriving stock (Haskell.Show,Generic)
+
+singleton :: t -> Integer -> Money t
+{-# INLINEABLE singleton #-}
+singleton t v = Money (Map.singleton t v)
+
+toList :: Money t -> [(t, Integer)]
+{-# INLINEABLE toList #-}
+toList (Money m) = Map.toList m
+
+{-------------------------------------------------------------------------------
+  Haskell Prelude instances
+
+  We jump through a few hoops to make sure that the Haskell instances only
+  have Haskell superclass constraints.
+-------------------------------------------------------------------------------}
+
+normalizeHaskell :: forall t. Haskell.Ord t => Map t Integer -> Map t Integer
+normalizeHaskell = Map.fromList . go . Map.toList
+  where
+    go :: [(t, Integer)] -> [(t, Integer)]
+    go = Haskell.sort . Haskell.filter ((/= 0) . snd)
+
+instance Haskell.Ord t => Haskell.Eq (Money t) where
+  Money m == Money m' = normalizeHaskell m Haskell.== normalizeHaskell m'
+
+instance Haskell.Ord t => Haskell.Semigroup (Money t) where
+  Money m <> Money m' = Money $
+      Map.fromList $
+        go (Map.toList $ normalizeHaskell m)
+           (Map.toList $ normalizeHaskell m')
+    where
+      go :: [(t, Integer)] -> [(t, Integer)] -> [(t, Integer)]
+      go [] ys = ys
+      go xs [] = xs
+      go ((x,v):xs) ((y,v'):ys)
+        | x Haskell.< y = (x,v)    : go        xs  ((y,v'):ys )
+        | x Haskell.> y = (y,v')   : go ((x,v):xs)         ys
+        | otherwise     = (x,v+v') : go xs ys
+
+instance Haskell.Ord t => Haskell.Monoid (Money t) where
+  mempty = Money Map.empty
+
+{-------------------------------------------------------------------------------
+  Plutus Prelude instances
+-------------------------------------------------------------------------------}
+
+normalizePlutus :: forall t. Ord t => Map t Integer -> Map t Integer
+{-# INLINEABLE normalizePlutus #-}
+normalizePlutus = Map.fromList . go . Map.toList
+  where
+    go :: [(t, Integer)] -> [(t, Integer)]
+    go = sort . filter ((/= 0) . snd)
+
+instance Ord t => Eq (Money t) where
+  {-# INLINEABLE (==) #-}
+  Money m == Money m' = normalizePlutus m == normalizePlutus m'
+
+instance Ord t => Semigroup (Money t) where
+  {-# INLINEABLE (<>) #-}
+  Money m <> Money m' = Money $
+      Map.fromList $
+        go (Map.toList $ normalizePlutus m)
+           (Map.toList $ normalizePlutus m')
+    where
+      go :: [(t, Integer)] -> [(t, Integer)] -> [(t, Integer)]
+      go [] ys = ys
+      go xs [] = xs
+      go ((x,v):xs) ((y,v'):ys)
+        | x < y = (x,v)    : go        xs  ((y,v'):ys )
+        | x > y = (y,v')   : go ((x,v):xs)         ys
+        | otherwise     = (x,v+v') : go xs ys
+
+instance Ord t => Monoid (Money t) where
+  {-# INLINEABLE mempty #-}
+  mempty = Money Map.empty
+
+makeLift ''Money

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics/Token.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics/Token.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+
+-- | Tokens as used on the Cardano blockchain
+--
+-- Intended for unqualified import.
+module Language.Marlowe.Core.V1.Semantics.Token (
+    Token(..)
+  , moneyToValue
+  , moneyFromValue
+  ) where
+
+import PlutusTx.Prelude hiding ((<$>), (<*>))
+import Prelude ((<$>), (<*>))
+import qualified Prelude as Haskell
+
+import Data.Aeson.Types hiding (Error, Value)
+import Data.Text.Encoding as Text (decodeUtf8, encodeUtf8)
+import GHC.Generics
+import Language.Marlowe.Core.V1.Semantics.Money
+import Language.Marlowe.Pretty (Pretty (..))
+import Ledger (Value)
+import Ledger.Value (CurrencySymbol (..), TokenName (..))
+import PlutusTx (makeIsDataIndexed)
+import PlutusTx.Lift (makeLift)
+
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Extras as JSON
+import qualified Ledger.Value as Val
+import qualified PlutusTx.AssocMap as Map
+
+{-| Token - represents a currency or token, it groups
+    a pair of a currency symbol and token name.
+-}
+data Token = Token CurrencySymbol TokenName
+  deriving stock (Generic,Haskell.Eq,Haskell.Ord)
+  deriving anyclass (Pretty)
+
+instance Haskell.Show Token where
+  showsPrec p (Token cs tn) =
+    Haskell.showParen (p Haskell.>= 11) (Haskell.showString $ "Token \"" Haskell.++ Haskell.show cs Haskell.++ "\" " Haskell.++ Haskell.show tn)
+
+instance FromJSON Token where
+  parseJSON = withObject "Token" (\v ->
+       Token <$> (Val.currencySymbol <$> (JSON.decodeByteString =<< (v .: "currency_symbol")))
+             <*> (Val.tokenName . Text.encodeUtf8 <$> (v .: "token_name"))
+                                 )
+
+instance ToJSON Token where
+  toJSON (Token currSym tokName) = object
+      [ "currency_symbol" .= (JSON.String $ JSON.encodeByteString $ fromBuiltin $ unCurrencySymbol currSym)
+      , "token_name" .= (JSON.String $ Text.decodeUtf8 $ fromBuiltin $ unTokenName tokName)
+      ]
+
+instance Eq Token where
+    {-# INLINABLE (==) #-}
+    (Token n1 p1) == (Token n2 p2) = (n1, p1) == (n2, p2)
+
+instance Ord Token where
+    {-# INLINABLE compare #-}
+    (Token n1 p1) `compare` (Token n2 p2) = (n1, p1) `compare` (n2, p2)
+
+moneyToValue :: Money Token -> Value
+moneyToValue (Money m) =
+    mconcat $ map aux $ Map.toList m
+  where
+    aux :: (Token, Integer) -> Value
+    aux (Token symbol name, n) = Val.singleton symbol name n
+
+moneyFromValue :: Value -> Money Token
+moneyFromValue = Money . Map.fromList . map aux . Val.flattenValue
+  where
+    aux :: (CurrencySymbol, TokenName, Integer) -> (Token, Integer)
+    aux (symbol, name, n) = (Token symbol name, n)
+
+makeLift ''Token
+makeIsDataIndexed ''Token [('Token,0)]
+

--- a/marlowe/src/Language/Marlowe/Extended/V1.hs
+++ b/marlowe/src/Language/Marlowe/Extended/V1.hs
@@ -133,7 +133,7 @@ instance ToCore Contract (S.Contract S.Token) where
   toCore (Let varId val cont) = pure (S.Let varId) <*> toCore val <*> toCore cont
   toCore (Assert obs cont) = S.Assert <$> toCore obs <*> toCore cont
 
-instance ToCore Value (S.Value S.Observation) where
+instance ToCore Value (S.Value (S.Observation S.Token) S.Token) where
   toCore (Constant c)               = Just $ S.Constant c
   toCore (ConstantParam _)          = Nothing
   toCore (AvailableMoney accId tok) = Just $ S.AvailableMoney accId tok
@@ -148,7 +148,7 @@ instance ToCore Value (S.Value S.Observation) where
   toCore (UseValue vId)             = Just $ S.UseValue vId
   toCore (Cond obs lhs rhs)         = S.Cond <$> toCore obs <*> toCore lhs <*> toCore rhs
 
-instance ToCore Observation S.Observation where
+instance ToCore Observation (S.Observation S.Token) where
   toCore (AndObs lhs rhs)       = S.AndObs <$> toCore lhs <*> toCore rhs
   toCore (OrObs lhs rhs)        = S.OrObs <$> toCore lhs <*> toCore rhs
   toCore (NotObs v)             = S.NotObs <$> toCore v

--- a/marlowe/src/Language/Marlowe/Extended/V1.hs
+++ b/marlowe/src/Language/Marlowe/Extended/V1.hs
@@ -33,6 +33,7 @@ import qualified Data.Foldable as F
 import Data.Ratio ((%))
 import Data.Text (pack)
 import GHC.Generics
+import qualified Language.Marlowe.Core.V1.Semantics.Token as S
 import qualified Language.Marlowe.Core.V1.Semantics.Types as S
 import Language.Marlowe.ParserUtil (getInteger, withInteger)
 import Language.Marlowe.Pretty (Pretty (..), pretty)

--- a/marlowe/src/Language/Marlowe/Extended/V1.hs
+++ b/marlowe/src/Language/Marlowe/Extended/V1.hs
@@ -161,7 +161,7 @@ instance ToCore Observation S.Observation where
   toCore TrueObs                = Just S.TrueObs
   toCore FalseObs               = Just S.FalseObs
 
-instance ToCore Action S.Action where
+instance ToCore Action (S.Action S.Token) where
   toCore (Deposit accId party tok val) = pure (S.Deposit accId party tok) <*> toCore val
   toCore (Choice choId bounds)         = Just $ S.Choice choId bounds
   toCore (Notify obs)                  = S.Notify <$> toCore obs
@@ -174,7 +174,7 @@ instance ToCore Payee S.Payee where
   toCore (Account accId)  = Just $ S.Account accId
   toCore (Party roleName) = Just $ S.Party roleName
 
-instance ToCore Case (S.Case (S.Contract S.Token)) where
+instance ToCore Case (S.Case (S.Contract S.Token) S.Token) where
   toCore (Case act c) = S.Case <$> toCore act <*> toCore c
 
 instance FromJSON Value where

--- a/marlowe/src/Language/Marlowe/Extended/V1.hs
+++ b/marlowe/src/Language/Marlowe/Extended/V1.hs
@@ -134,7 +134,7 @@ instance ToCore Contract (S.Contract S.Token) where
   toCore (Let varId val cont) = pure (S.Let varId) <*> toCore val <*> toCore cont
   toCore (Assert obs cont) = S.Assert <$> toCore obs <*> toCore cont
 
-instance ToCore Value (S.Value (S.Observation S.Token) S.Token) where
+instance ToCore Value (S.Value S.Token) where
   toCore (Constant c)               = Just $ S.Constant c
   toCore (ConstantParam _)          = Nothing
   toCore (AvailableMoney accId tok) = Just $ S.AvailableMoney accId tok
@@ -175,7 +175,7 @@ instance ToCore Payee S.Payee where
   toCore (Account accId)  = Just $ S.Account accId
   toCore (Party roleName) = Just $ S.Party roleName
 
-instance ToCore Case (S.Case (S.Contract S.Token) S.Token) where
+instance ToCore Case (S.Case S.Token) where
   toCore (Case act c) = S.Case <$> toCore act <*> toCore c
 
 instance FromJSON Value where

--- a/marlowe/src/Language/Marlowe/Extended/V1.hs
+++ b/marlowe/src/Language/Marlowe/Extended/V1.hs
@@ -125,7 +125,7 @@ data Contract = Close
 class ToCore a b where
   toCore :: a -> Maybe b
 
-instance ToCore Contract S.Contract where
+instance ToCore Contract (S.Contract S.Token) where
   toCore Close = Just S.Close
   toCore (Pay accId payee tok val cont) = pure (S.Pay accId) <*> toCore payee <*> pure tok <*> toCore val <*> toCore cont
   toCore (If obs cont1 cont2) = S.If <$> toCore obs <*> toCore cont1 <*> toCore cont2
@@ -174,7 +174,7 @@ instance ToCore Payee S.Payee where
   toCore (Account accId)  = Just $ S.Account accId
   toCore (Party roleName) = Just $ S.Party roleName
 
-instance ToCore Case (S.Case S.Contract) where
+instance ToCore Case (S.Case (S.Contract S.Token)) where
   toCore (Case act c) = S.Case <$> toCore act <*> toCore c
 
 instance FromJSON Value where

--- a/marlowe/src/Language/Marlowe/FindInputs.hs
+++ b/marlowe/src/Language/Marlowe/FindInputs.hs
@@ -19,15 +19,15 @@ removeAsserts = go
         go (Let vi va con)        = Let vi va (go con)
         go (Assert _ con)         = con
 
-        goCase :: Case (Contract Token) -> Case (Contract Token)
+        goCase :: Case (Contract Token) Token -> Case (Contract Token) Token
         goCase (Case ac con)           = Case ac (go con)
         goCase mc@(MerkleizedCase _ _) = mc
 
-expandCase :: Case (Contract Token) -> [Case (Contract Token)]
+expandCase :: Case (Contract Token) Token -> [Case (Contract Token) Token]
 expandCase (Case ac con)        = [Case ac c | c <- expandContract con]
 expandCase (MerkleizedCase _ _) = []
 
-expandCases :: [Case (Contract Token)] -> [[Case (Contract Token)]]
+expandCases :: [Case (Contract Token) Token] -> [[Case (Contract Token) Token]]
 expandCases [] = []
 expandCases (firstCase:restOfCases) =
        [c:restOfCases | c <- expandCase firstCase]

--- a/marlowe/src/Language/Marlowe/FindInputs.hs
+++ b/marlowe/src/Language/Marlowe/FindInputs.hs
@@ -43,13 +43,13 @@ expandContract (When cas sl con) = [When cas sl c | c <- expandContract con]
 expandContract (Let vi va con) = [Let vi va c | c <- expandContract con]
 expandContract (Assert _ con) = expandContract con
 
-getInputs :: Contract Token -> IO (Either (ThmResult, Contract Token) (Maybe (POSIXTime, [TransactionInput])))
+getInputs :: Contract Token -> IO (Either (ThmResult, Contract Token) (Maybe (POSIXTime, [TransactionInput Token])))
 getInputs c = bimap (\tr -> (tr, c)) (fmap (\(s, t, _) -> (s, t))) <$> onlyAssertionsWithState c Nothing
 
 -- | Uses static analysis to obtain a list of "unit tests" (lists of transactions) that
 -- | cover the different branches of the given contract. If static analysis fails
 -- | it returns a tuple that includes the error by the solver and the offending
 -- | extension of the contract
-getAllInputs :: Contract Token -> IO (Either (ThmResult, Contract Token) [(POSIXTime, [TransactionInput])])
+getAllInputs :: Contract Token -> IO (Either (ThmResult, Contract Token) [(POSIXTime, [TransactionInput Token])])
 getAllInputs c = second catMaybes . sequence <$> mapM getInputs (expandContract (removeAsserts c))
 

--- a/marlowe/src/Language/Marlowe/FindInputs.hs
+++ b/marlowe/src/Language/Marlowe/FindInputs.hs
@@ -5,7 +5,8 @@ import Data.Maybe (catMaybes)
 import Data.SBV (ThmResult)
 import Language.Marlowe.Analysis.FSSemantics (onlyAssertionsWithState)
 import Language.Marlowe.Core.V1.Semantics (TransactionInput)
-import Language.Marlowe.Core.V1.Semantics.Types (Case (..), Contract (..), Observation (..), Token)
+import Language.Marlowe.Core.V1.Semantics.Token (Token)
+import Language.Marlowe.Core.V1.Semantics.Types (Case (..), Contract (..), Observation (..))
 import Plutus.V1.Ledger.Api (POSIXTime)
 
 -- | Removes all the assertions from a contract

--- a/marlowe/src/Language/Marlowe/FindInputs.hs
+++ b/marlowe/src/Language/Marlowe/FindInputs.hs
@@ -5,7 +5,7 @@ import Data.Maybe (catMaybes)
 import Data.SBV (ThmResult)
 import Language.Marlowe.Analysis.FSSemantics (onlyAssertionsWithState)
 import Language.Marlowe.Core.V1.Semantics (TransactionInput)
-import Language.Marlowe.Core.V1.Semantics.Types (Case (..), Contract (..), Observation (..))
+import Language.Marlowe.Core.V1.Semantics.Types (Case, Case_ (..), Contract (..), Observation (..))
 import Plutus.V1.Ledger.Api (POSIXTime)
 import qualified PlutusTx.Prelude as P
 
@@ -20,15 +20,15 @@ removeAsserts = go
         go (Let vi va con)        = Let vi va (go con)
         go (Assert _ con)         = con
 
-        goCase :: Case (Contract t) t -> Case (Contract t) t
+        goCase :: Case t -> Case t
         goCase (Case ac con)           = Case ac (go con)
         goCase mc@(MerkleizedCase _ _) = mc
 
-expandCase :: Case (Contract t) t -> [Case (Contract t) t]
+expandCase :: Case t -> [Case t]
 expandCase (Case ac con)        = [Case ac c | c <- expandContract con]
 expandCase (MerkleizedCase _ _) = []
 
-expandCases :: [Case (Contract t) t] -> [[Case (Contract t) t]]
+expandCases :: [Case t] -> [[Case t]]
 expandCases [] = []
 expandCases (firstCase:restOfCases) =
        [c:restOfCases | c <- expandCase firstCase]

--- a/marlowe/src/Language/Marlowe/FindInputs.hs
+++ b/marlowe/src/Language/Marlowe/FindInputs.hs
@@ -5,14 +5,14 @@ import Data.Maybe (catMaybes)
 import Data.SBV (ThmResult)
 import Language.Marlowe.Analysis.FSSemantics (onlyAssertionsWithState)
 import Language.Marlowe.Core.V1.Semantics (TransactionInput)
-import Language.Marlowe.Core.V1.Semantics.Token (Token)
 import Language.Marlowe.Core.V1.Semantics.Types (Case (..), Contract (..), Observation (..))
 import Plutus.V1.Ledger.Api (POSIXTime)
+import qualified PlutusTx.Prelude as P
 
 -- | Removes all the assertions from a contract
-removeAsserts :: Contract Token -> Contract Token
+removeAsserts :: Contract t -> Contract t
 removeAsserts = go
-  where go :: Contract Token -> Contract Token
+  where go :: Contract t -> Contract t
         go Close                  = Close
         go (Pay pa pa' to va con) = Pay pa pa' to va (go con)
         go (If ob con con')       = If ob (go con) (go con')
@@ -20,21 +20,21 @@ removeAsserts = go
         go (Let vi va con)        = Let vi va (go con)
         go (Assert _ con)         = con
 
-        goCase :: Case (Contract Token) Token -> Case (Contract Token) Token
+        goCase :: Case (Contract t) t -> Case (Contract t) t
         goCase (Case ac con)           = Case ac (go con)
         goCase mc@(MerkleizedCase _ _) = mc
 
-expandCase :: Case (Contract Token) Token -> [Case (Contract Token) Token]
+expandCase :: Case (Contract t) t -> [Case (Contract t) t]
 expandCase (Case ac con)        = [Case ac c | c <- expandContract con]
 expandCase (MerkleizedCase _ _) = []
 
-expandCases :: [Case (Contract Token) Token] -> [[Case (Contract Token) Token]]
+expandCases :: [Case (Contract t) t] -> [[Case (Contract t) t]]
 expandCases [] = []
 expandCases (firstCase:restOfCases) =
        [c:restOfCases | c <- expandCase firstCase]
     ++ [firstCase:ec | ec <- expandCases restOfCases]
 
-expandContract :: Contract Token -> [Contract Token]
+expandContract :: Contract t -> [Contract t]
 expandContract Close = [Assert FalseObs Close]
 expandContract (Pay pa pa' to va con) = [Pay pa pa' to va c | c <- expandContract con]
 expandContract (If ob con con') = [If ob c con' | c <- expandContract con]
@@ -44,13 +44,13 @@ expandContract (When cas sl con) = [When cas sl c | c <- expandContract con]
 expandContract (Let vi va con) = [Let vi va c | c <- expandContract con]
 expandContract (Assert _ con) = expandContract con
 
-getInputs :: Contract Token -> IO (Either (ThmResult, Contract Token) (Maybe (POSIXTime, [TransactionInput Token])))
+getInputs :: (P.Eq t, Ord t) => Contract t -> IO (Either (ThmResult, Contract t) (Maybe (POSIXTime, [TransactionInput t])))
 getInputs c = bimap (\tr -> (tr, c)) (fmap (\(s, t, _) -> (s, t))) <$> onlyAssertionsWithState c Nothing
 
 -- | Uses static analysis to obtain a list of "unit tests" (lists of transactions) that
 -- | cover the different branches of the given contract. If static analysis fails
 -- | it returns a tuple that includes the error by the solver and the offending
 -- | extension of the contract
-getAllInputs :: Contract Token -> IO (Either (ThmResult, Contract Token) [(POSIXTime, [TransactionInput Token])])
+getAllInputs :: (P.Eq t, Ord t) => Contract t -> IO (Either (ThmResult, Contract t) [(POSIXTime, [TransactionInput t])])
 getAllInputs c = second catMaybes . sequence <$> mapM getInputs (expandContract (removeAsserts c))
 

--- a/marlowe/src/Language/Marlowe/FindInputs.hs
+++ b/marlowe/src/Language/Marlowe/FindInputs.hs
@@ -5,13 +5,13 @@ import Data.Maybe (catMaybes)
 import Data.SBV (ThmResult)
 import Language.Marlowe.Analysis.FSSemantics (onlyAssertionsWithState)
 import Language.Marlowe.Core.V1.Semantics (TransactionInput)
-import Language.Marlowe.Core.V1.Semantics.Types (Case (..), Contract (..), Observation (..))
+import Language.Marlowe.Core.V1.Semantics.Types (Case (..), Contract (..), Observation (..), Token)
 import Plutus.V1.Ledger.Api (POSIXTime)
 
 -- | Removes all the assertions from a contract
-removeAsserts :: Contract -> Contract
+removeAsserts :: Contract Token -> Contract Token
 removeAsserts = go
-  where go :: Contract -> Contract
+  where go :: Contract Token -> Contract Token
         go Close                  = Close
         go (Pay pa pa' to va con) = Pay pa pa' to va (go con)
         go (If ob con con')       = If ob (go con) (go con')
@@ -19,21 +19,21 @@ removeAsserts = go
         go (Let vi va con)        = Let vi va (go con)
         go (Assert _ con)         = con
 
-        goCase :: Case Contract -> Case Contract
+        goCase :: Case (Contract Token) -> Case (Contract Token)
         goCase (Case ac con)           = Case ac (go con)
         goCase mc@(MerkleizedCase _ _) = mc
 
-expandCase :: Case Contract -> [Case Contract]
+expandCase :: Case (Contract Token) -> [Case (Contract Token)]
 expandCase (Case ac con)        = [Case ac c | c <- expandContract con]
 expandCase (MerkleizedCase _ _) = []
 
-expandCases :: [Case Contract] -> [[Case Contract]]
+expandCases :: [Case (Contract Token)] -> [[Case (Contract Token)]]
 expandCases [] = []
 expandCases (firstCase:restOfCases) =
        [c:restOfCases | c <- expandCase firstCase]
     ++ [firstCase:ec | ec <- expandCases restOfCases]
 
-expandContract :: Contract -> [Contract]
+expandContract :: Contract Token -> [Contract Token]
 expandContract Close = [Assert FalseObs Close]
 expandContract (Pay pa pa' to va con) = [Pay pa pa' to va c | c <- expandContract con]
 expandContract (If ob con con') = [If ob c con' | c <- expandContract con]
@@ -43,13 +43,13 @@ expandContract (When cas sl con) = [When cas sl c | c <- expandContract con]
 expandContract (Let vi va con) = [Let vi va c | c <- expandContract con]
 expandContract (Assert _ con) = expandContract con
 
-getInputs :: Contract -> IO (Either (ThmResult, Contract) (Maybe (POSIXTime, [TransactionInput])))
+getInputs :: Contract Token -> IO (Either (ThmResult, Contract Token) (Maybe (POSIXTime, [TransactionInput])))
 getInputs c = bimap (\tr -> (tr, c)) (fmap (\(s, t, _) -> (s, t))) <$> onlyAssertionsWithState c Nothing
 
 -- | Uses static analysis to obtain a list of "unit tests" (lists of transactions) that
 -- | cover the different branches of the given contract. If static analysis fails
 -- | it returns a tuple that includes the error by the solver and the offending
 -- | extension of the contract
-getAllInputs :: Contract -> IO (Either (ThmResult, Contract) [(POSIXTime, [TransactionInput])])
+getAllInputs :: Contract Token -> IO (Either (ThmResult, Contract Token) [(POSIXTime, [TransactionInput])])
 getAllInputs c = second catMaybes . sequence <$> mapM getInputs (expandContract (removeAsserts c))
 

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -29,6 +29,7 @@
 module Language.Marlowe.Scripts where
 import GHC.Generics
 import Language.Marlowe.Core.V1.Semantics
+import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types
 import Language.Marlowe.Pretty (Pretty (..))
 import Ledger
@@ -125,7 +126,7 @@ smallMarloweValidator MarloweParams{rolesCurrency, rolePayoutValidatorHash}
 
     -- total balance of all accounts in State
     -- accounts must be positive, and we checked it above
-    let inputBalance = totalBalance (accounts marloweState)
+    let inputBalance = moneyToValue $ totalBalance (accounts marloweState)
 
     -- ensure that a contract TxOut has what it suppose to have
     let balancesOk = traceIfFalse "B1" $ inputBalance == scriptInValue
@@ -236,7 +237,7 @@ smallMarloweValidator MarloweParams{rolesCurrency, rolePayoutValidatorHash}
     collectDeposits _                                     = zero
 
     payoutByParty :: Payment -> AssocMap.Map Party Val.Value
-    payoutByParty (Payment _ (Party party) money) = AssocMap.singleton party money
+    payoutByParty (Payment _ (Party party) money) = AssocMap.singleton party (moneyToValue money)
     payoutByParty (Payment _ (Account _) _)       = AssocMap.empty
 
     payoutConstraints :: [(Party, Val.Value)] -> Bool

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -236,7 +236,7 @@ smallMarloweValidator MarloweParams{rolesCurrency, rolePayoutValidatorHash}
     collectDeposits (IDeposit _ _ (Token cur tok) amount) = Val.singleton cur tok amount
     collectDeposits _                                     = zero
 
-    payoutByParty :: Payment -> AssocMap.Map Party Val.Value
+    payoutByParty :: Payment Token -> AssocMap.Map Party Val.Value
     payoutByParty (Payment _ (Party party) money) = AssocMap.singleton party (moneyToValue money)
     payoutByParty (Payment _ (Account _) _)       = AssocMap.empty
 

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -56,7 +56,7 @@ data TypedMarloweValidator
 {- Type instances for small typed Marlowe validator -}
 instance Scripts.ValidatorTypes TypedMarloweValidator where
     type instance RedeemerType TypedMarloweValidator = MarloweInput
-    type instance DatumType TypedMarloweValidator = MarloweData
+    type instance DatumType TypedMarloweValidator = MarloweData Token
 
 data TypedRolePayoutValidator
 
@@ -94,7 +94,7 @@ defaultRolePayoutValidatorHash = mkRolePayoutValidatorHash adaSymbol
 {-# INLINABLE smallMarloweValidator #-}
 smallMarloweValidator
     :: MarloweParams
-    -> MarloweData
+    -> MarloweData Token
     -> MarloweInput
     -> ScriptContext
     -> Bool
@@ -186,7 +186,7 @@ smallMarloweValidator MarloweParams{rolesCurrency, rolePayoutValidatorHash}
     findDatumHash' :: PlutusTx.ToData o => o -> Maybe DatumHash
     findDatumHash' datum = findDatumHash (Datum $ PlutusTx.toBuiltinData datum) scriptContextTxInfo
 
-    checkOwnOutputConstraint :: MarloweData -> Val.Value -> Bool
+    checkOwnOutputConstraint :: MarloweData Token -> Val.Value -> Bool
     checkOwnOutputConstraint ocDatum ocValue =
         let hsh = findDatumHash' ocDatum
         in traceIfFalse "L1" -- "Output constraint"

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -57,8 +57,8 @@ foldMapContract :: Monoid m
     => (P.BuiltinByteString -> Maybe (Contract Token))
     -> (Contract Token -> m)
     -> (Case (Contract Token) Token -> m)
-    -> (Observation -> m)
-    -> (Value Observation -> m)
+    -> (Observation Token -> m)
+    -> (Value (Observation Token) Token -> m)
     -> Contract Token -> m
 foldMapContract funmerk fcont fcase fobs fvalue contract =
     fcont contract <> case contract of
@@ -96,8 +96,8 @@ foldMapContract funmerk fcont fcase fobs fvalue contract =
 foldMapNonMerkleizedContract :: Monoid m
     => (Contract Token -> m)
     -> (Case (Contract Token) Token -> m)
-    -> (Observation -> m)
-    -> (Value Observation -> m)
+    -> (Observation Token -> m)
+    -> (Value (Observation Token) Token -> m)
     -> Contract Token -> m
 foldMapNonMerkleizedContract = foldMapContract (const Nothing)
 

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Language.Marlowe.Util (ada, addAccountsDiff, emptyAccountsDiff, extractNonMerkleizedContractRoles,
-                              foldMapNonMerkleizedContract, foldMapContract, getAccountsDiff, isEmptyAccountsDiff,
+module Language.Marlowe.Util (ada, {- addAccountsDiff, emptyAccountsDiff, -} extractNonMerkleizedContractRoles,
+                              foldMapNonMerkleizedContract, foldMapContract, {- getAccountsDiff, isEmptyAccountsDiff, -}
                               merkleizedCase) where
-import Data.List (foldl')
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+-- import Data.List (foldl')
+-- import Data.Map.Strict (Map)
+-- import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String
-import Language.Marlowe.Core.V1.Semantics
+-- import Language.Marlowe.Core.V1.Semantics
 import Language.Marlowe.Core.V1.Semantics.Types
 import Ledger.Ada (adaSymbol, adaToken)
 import Ledger.Scripts (dataHash)
@@ -24,8 +24,8 @@ instance IsString Party where
 ada :: Token
 ada = Token adaSymbol adaToken
 
+{-
 type AccountsDiff = Map Party Money
-
 
 emptyAccountsDiff :: AccountsDiff
 emptyAccountsDiff = Map.empty
@@ -51,6 +51,7 @@ getAccountsDiff payments inputs =
   where
     incomes  = [ (p, Val.singleton cur tok m) | IDeposit _ p (Token cur tok) m <- map getInputContent inputs ]
     outcomes = [ (p, P.negate m) | Payment _ (Party p) m  <- payments ]
+-}
 
 
 foldMapContract :: Monoid m

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -45,7 +45,7 @@ addAccountsDiff party diffValue trOut = let
 
 
 -- | Extract total outcomes from transaction inputs and outputs
-getAccountsDiff :: [Payment] -> [Input] -> AccountsDiff
+getAccountsDiff :: [Payment] -> [Input Token] -> AccountsDiff
 getAccountsDiff payments inputs =
     foldl' (\acc (p, m) -> addAccountsDiff p m acc) emptyAccountsDiff (incomes ++ outcomes)
   where

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -54,12 +54,12 @@ getAccountsDiff payments inputs =
 
 
 foldMapContract :: Monoid m
-    => (P.BuiltinByteString -> Maybe Contract)
-    -> (Contract -> m)
-    -> (Case Contract -> m)
+    => (P.BuiltinByteString -> Maybe (Contract Token))
+    -> (Contract Token -> m)
+    -> (Case (Contract Token) -> m)
     -> (Observation -> m)
     -> (Value Observation -> m)
-    -> Contract -> m
+    -> Contract Token -> m
 foldMapContract funmerk fcont fcase fobs fvalue contract =
     fcont contract <> case contract of
         Close                -> mempty
@@ -94,15 +94,15 @@ foldMapContract funmerk fcont fcase fobs fvalue contract =
 
 
 foldMapNonMerkleizedContract :: Monoid m
-    => (Contract -> m)
-    -> (Case Contract -> m)
+    => (Contract Token -> m)
+    -> (Case (Contract Token) -> m)
     -> (Observation -> m)
     -> (Value Observation -> m)
-    -> Contract -> m
+    -> Contract Token -> m
 foldMapNonMerkleizedContract = foldMapContract (const Nothing)
 
 
-extractNonMerkleizedContractRoles :: Contract -> Set Val.TokenName
+extractNonMerkleizedContractRoles :: Contract Token -> Set Val.TokenName
 extractNonMerkleizedContractRoles = foldMapNonMerkleizedContract extract extractCase (const mempty) (const mempty)
   where
     extract (Pay from payee _ _ _) = fromParty from <> fromPayee payee
@@ -119,7 +119,7 @@ extractNonMerkleizedContractRoles = foldMapNonMerkleizedContract extract extract
     fromPayee (Account party) = fromParty party
 
 
-merkleizedCase :: Action -> Contract -> Case Contract
+merkleizedCase :: Action -> Contract Token -> Case (Contract Token)
 merkleizedCase action continuation = let
     hash = dataHash (PlutusTx.toBuiltinData continuation)
     in MerkleizedCase action hash

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -56,12 +56,12 @@ getAccountsDiff payments inputs =
 
 
 foldMapContract :: Monoid m
-    => (P.BuiltinByteString -> Maybe (Contract Token))
-    -> (Contract Token -> m)
-    -> (Case (Contract Token) Token -> m)
-    -> (Observation Token -> m)
-    -> (Value (Observation Token) Token -> m)
-    -> Contract Token -> m
+    => (P.BuiltinByteString -> Maybe (Contract t))
+    -> (Contract t -> m)
+    -> (Case (Contract t) t -> m)
+    -> (Observation t -> m)
+    -> (Value (Observation t) t -> m)
+    -> Contract t -> m
 foldMapContract funmerk fcont fcase fobs fvalue contract =
     fcont contract <> case contract of
         Close                -> mempty
@@ -96,15 +96,15 @@ foldMapContract funmerk fcont fcase fobs fvalue contract =
 
 
 foldMapNonMerkleizedContract :: Monoid m
-    => (Contract Token -> m)
-    -> (Case (Contract Token) Token -> m)
-    -> (Observation Token -> m)
-    -> (Value (Observation Token) Token -> m)
-    -> Contract Token -> m
+    => (Contract t -> m)
+    -> (Case (Contract t) t -> m)
+    -> (Observation t -> m)
+    -> (Value (Observation t) t -> m)
+    -> Contract t -> m
 foldMapNonMerkleizedContract = foldMapContract (const Nothing)
 
 
-extractNonMerkleizedContractRoles :: Contract Token -> Set Val.TokenName
+extractNonMerkleizedContractRoles :: Contract t -> Set Val.TokenName
 extractNonMerkleizedContractRoles = foldMapNonMerkleizedContract extract extractCase (const mempty) (const mempty)
   where
     extract (Pay from payee _ _ _) = fromParty from <> fromPayee payee
@@ -121,7 +121,7 @@ extractNonMerkleizedContractRoles = foldMapNonMerkleizedContract extract extract
     fromPayee (Account party) = fromParty party
 
 
-merkleizedCase :: Action Token -> Contract Token -> Case (Contract Token) Token
+merkleizedCase :: PlutusTx.ToData t => Action t -> Contract t -> Case (Contract t) t
 merkleizedCase action continuation = let
     hash = dataHash (PlutusTx.toBuiltinData continuation)
     in MerkleizedCase action hash

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -10,6 +10,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String
 -- import Language.Marlowe.Core.V1.Semantics
+import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types
 import Ledger.Ada (adaSymbol, adaToken)
 import Ledger.Scripts (dataHash)
@@ -36,7 +37,7 @@ isEmptyAccountsDiff = all Val.isZero
 
 
 -- Adds a value to the map of outcomes
-addAccountsDiff :: Party -> Money -> AccountsDiff -> AccountsDiff
+addAccountsDiff :: Party -> Money Token -> AccountsDiff -> AccountsDiff
 addAccountsDiff party diffValue trOut = let
     newValue = case Map.lookup party trOut of
         Just value -> value P.+ diffValue

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -58,9 +58,9 @@ getAccountsDiff payments inputs =
 foldMapContract :: Monoid m
     => (P.BuiltinByteString -> Maybe (Contract t))
     -> (Contract t -> m)
-    -> (Case (Contract t) t -> m)
+    -> (Case t -> m)
     -> (Observation t -> m)
-    -> (Value (Observation t) t -> m)
+    -> (Value t -> m)
     -> Contract t -> m
 foldMapContract funmerk fcont fcase fobs fvalue contract =
     fcont contract <> case contract of
@@ -97,9 +97,9 @@ foldMapContract funmerk fcont fcase fobs fvalue contract =
 
 foldMapNonMerkleizedContract :: Monoid m
     => (Contract t -> m)
-    -> (Case (Contract t) t -> m)
+    -> (Case t -> m)
     -> (Observation t -> m)
-    -> (Value (Observation t) t -> m)
+    -> (Value t -> m)
     -> Contract t -> m
 foldMapNonMerkleizedContract = foldMapContract (const Nothing)
 
@@ -121,7 +121,7 @@ extractNonMerkleizedContractRoles = foldMapNonMerkleizedContract extract extract
     fromPayee (Account party) = fromParty party
 
 
-merkleizedCase :: PlutusTx.ToData t => Action t -> Contract t -> Case (Contract t) t
+merkleizedCase :: PlutusTx.ToData t => Action t -> Contract t -> Case t
 merkleizedCase action continuation = let
     hash = dataHash (PlutusTx.toBuiltinData continuation)
     in MerkleizedCase action hash

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -56,7 +56,7 @@ getAccountsDiff payments inputs =
 foldMapContract :: Monoid m
     => (P.BuiltinByteString -> Maybe (Contract Token))
     -> (Contract Token -> m)
-    -> (Case (Contract Token) -> m)
+    -> (Case (Contract Token) Token -> m)
     -> (Observation -> m)
     -> (Value Observation -> m)
     -> Contract Token -> m
@@ -95,7 +95,7 @@ foldMapContract funmerk fcont fcase fobs fvalue contract =
 
 foldMapNonMerkleizedContract :: Monoid m
     => (Contract Token -> m)
-    -> (Case (Contract Token) -> m)
+    -> (Case (Contract Token) Token -> m)
     -> (Observation -> m)
     -> (Value Observation -> m)
     -> Contract Token -> m
@@ -119,7 +119,7 @@ extractNonMerkleizedContractRoles = foldMapNonMerkleizedContract extract extract
     fromPayee (Account party) = fromParty party
 
 
-merkleizedCase :: Action -> Contract Token -> Case (Contract Token)
+merkleizedCase :: Action Token -> Contract Token -> Case (Contract Token) Token
 merkleizedCase action continuation = let
     hash = dataHash (PlutusTx.toBuiltinData continuation)
     in MerkleizedCase action hash

--- a/marlowe/test/Spec/Marlowe/Arbitrary.hs
+++ b/marlowe/test/Spec/Marlowe/Arbitrary.hs
@@ -36,9 +36,10 @@ module Spec.Marlowe.Arbitrary (
 import Control.Monad (replicateM)
 import Data.Function (on)
 import Data.List (nub, nubBy)
+import Language.Marlowe.Core.V1.Semantics.Token (Token (..))
 import Language.Marlowe.Core.V1.Semantics.Types (AccountId, Accounts, Bound (..), Case, ChoiceId (..), ChoiceName,
                                                  ChosenNum, Contract, Environment (..), Party (..), Payee (..),
-                                                 State (..), TimeInterval, Token (..), ValueId (..))
+                                                 State (..), TimeInterval, ValueId (..))
 import Plutus.V1.Ledger.Api (CurrencySymbol (..), POSIXTime (..), PubKeyHash (..), TokenName (..), adaSymbol, adaToken)
 import PlutusTx.Builtins (BuiltinByteString, lengthOfByteString)
 import Spec.Marlowe.Common (caseRelGenSized, simpleIntegerGen)

--- a/marlowe/test/Spec/Marlowe/Arbitrary.hs
+++ b/marlowe/test/Spec/Marlowe/Arbitrary.hs
@@ -394,5 +394,5 @@ instance Arbitrary Environment where
   shrink (Environment x) = Environment <$> shrink x
 
 
-caseGen :: Gen (Case (Contract Token))
+caseGen :: Gen (Case (Contract Token) Token)
 caseGen = sized $ (simpleIntegerGen >>=) . caseRelGenSized

--- a/marlowe/test/Spec/Marlowe/Arbitrary.hs
+++ b/marlowe/test/Spec/Marlowe/Arbitrary.hs
@@ -38,8 +38,8 @@ import Data.Function (on)
 import Data.List (nub, nubBy)
 import Language.Marlowe.Core.V1.Semantics.Token (Token (..))
 import Language.Marlowe.Core.V1.Semantics.Types (AccountId, Accounts, Bound (..), Case, ChoiceId (..), ChoiceName,
-                                                 ChosenNum, Contract, Environment (..), Party (..), Payee (..),
-                                                 State (..), TimeInterval, ValueId (..))
+                                                 ChosenNum, Environment (..), Party (..), Payee (..), State (..),
+                                                 TimeInterval, ValueId (..))
 import Plutus.V1.Ledger.Api (CurrencySymbol (..), POSIXTime (..), PubKeyHash (..), TokenName (..), adaSymbol, adaToken)
 import PlutusTx.Builtins (BuiltinByteString, lengthOfByteString)
 import Spec.Marlowe.Common (caseRelGenSized, simpleIntegerGen)
@@ -396,5 +396,5 @@ instance Arbitrary Environment where
   shrink (Environment x) = Environment <$> shrink x
 
 
-caseGen :: Gen (Case (Contract Token) Token)
+caseGen :: Gen (Case Token)
 caseGen = sized $ (simpleIntegerGen >>=) . caseRelGenSized

--- a/marlowe/test/Spec/Marlowe/Arbitrary.hs
+++ b/marlowe/test/Spec/Marlowe/Arbitrary.hs
@@ -1,4 +1,5 @@
 
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 
@@ -327,16 +328,16 @@ shrinkAssocMap am =
   ]
 
 
-arbitraryAccounts :: Gen Accounts
+arbitraryAccounts :: Gen (Accounts Token)
 arbitraryAccounts =
   arbitraryAssocMap
     ((,) <$> arbitrary <*> arbitrary)
     arbitraryPositiveAmount
 
-shrinkAccounts :: Accounts -> [Accounts]
+shrinkAccounts :: Accounts Token -> [Accounts Token]
 shrinkAccounts = shrinkAssocMap
 
-arbitraryFromAccounts :: Accounts -> Gen ((AccountId, Token), Integer)
+arbitraryFromAccounts :: Accounts Token -> Gen ((AccountId, Token), Integer)
 arbitraryFromAccounts accounts'
   | AM.null accounts' = (,) <$> ((,) <$> arbitrary <*> arbitrary) <*> arbitrary
   | otherwise =
@@ -373,7 +374,7 @@ shrinkBoundValues :: AM.Map ValueId Integer -> [AM.Map ValueId Integer]
 shrinkBoundValues = shrinkAssocMap
 
 
-instance Arbitrary State where
+instance Arbitrary (State Token) where
   arbitrary =
     do
       accounts' <- arbitraryAccounts

--- a/marlowe/test/Spec/Marlowe/Arbitrary.hs
+++ b/marlowe/test/Spec/Marlowe/Arbitrary.hs
@@ -186,7 +186,7 @@ randomRoleNames =
   , "Urbanus Roland Alison Ty Ryoichi"
   ]
 
-instance Arbitrary Party where
+instance Arbitrary (Party PubKeyHash) where
   arbitrary =
     do
        isPubKeyHash <- frequency [(2, pure True), (8, pure False)]
@@ -197,7 +197,7 @@ instance Arbitrary Party where
   shrink (Role x) = Role <$> shrinkByteString (\(TokenName y) -> y) randomRoleNames x
 
 
-instance Arbitrary Payee where
+instance Arbitrary (Payee PubKeyHash) where
   arbitrary =
     do
       isParty <- arbitrary
@@ -236,7 +236,7 @@ shrinkChoiceName :: ChoiceName -> [ChoiceName]
 shrinkChoiceName = shrinkByteString id randomChoiceNames
 
 
-instance Arbitrary ChoiceId where
+instance Arbitrary (ChoiceId PubKeyHash) where
   arbitrary = ChoiceId <$> arbitraryChoiceName <*> arbitrary
   shrink (ChoiceId n p) = [ChoiceId n' p' | n' <- shrinkChoiceName n, p' <- shrink p]
 
@@ -329,16 +329,16 @@ shrinkAssocMap am =
   ]
 
 
-arbitraryAccounts :: Gen (Accounts Token)
+arbitraryAccounts :: Gen (Accounts PubKeyHash Token)
 arbitraryAccounts =
   arbitraryAssocMap
     ((,) <$> arbitrary <*> arbitrary)
     arbitraryPositiveAmount
 
-shrinkAccounts :: Accounts Token -> [Accounts Token]
+shrinkAccounts :: Accounts PubKeyHash Token -> [Accounts PubKeyHash Token]
 shrinkAccounts = shrinkAssocMap
 
-arbitraryFromAccounts :: Accounts Token -> Gen ((AccountId, Token), Integer)
+arbitraryFromAccounts :: Accounts PubKeyHash Token -> Gen ((AccountId PubKeyHash, Token), Integer)
 arbitraryFromAccounts accounts'
   | AM.null accounts' = (,) <$> ((,) <$> arbitrary <*> arbitrary) <*> arbitrary
   | otherwise =
@@ -359,13 +359,13 @@ arbitraryFromAccounts accounts'
         (False, False) -> (,) <$> ((,) <$> chooseAccountId <*> chooseToken) <*> chooseAmount
 
 
-arbitraryChoices :: Gen (AM.Map ChoiceId ChosenNum)
+arbitraryChoices :: Gen (AM.Map (ChoiceId PubKeyHash) ChosenNum)
 arbitraryChoices = arbitraryAssocMap arbitrary arbitrary
 
-shrinkChoices :: AM.Map ChoiceId ChosenNum -> [AM.Map ChoiceId ChosenNum]
+shrinkChoices :: AM.Map (ChoiceId PubKeyHash) ChosenNum -> [AM.Map (ChoiceId PubKeyHash) ChosenNum]
 shrinkChoices = shrinkAssocMap
 
-arbitraryChoiceIdFromParty :: Gen Party -> Gen ChoiceId
+arbitraryChoiceIdFromParty :: Gen (Party PubKeyHash) -> Gen (ChoiceId PubKeyHash)
 arbitraryChoiceIdFromParty party = ChoiceId <$> arbitraryChoiceName <*> party
 
 arbitraryBoundValues :: Gen (AM.Map ValueId Integer)
@@ -375,7 +375,7 @@ shrinkBoundValues :: AM.Map ValueId Integer -> [AM.Map ValueId Integer]
 shrinkBoundValues = shrinkAssocMap
 
 
-instance Arbitrary (State Token) where
+instance Arbitrary (State PubKeyHash Token) where
   arbitrary =
     do
       accounts' <- arbitraryAccounts
@@ -396,5 +396,5 @@ instance Arbitrary Environment where
   shrink (Environment x) = Environment <$> shrink x
 
 
-caseGen :: Gen (Case Token)
+caseGen :: Gen (Case PubKeyHash Token)
 caseGen = sized $ (simpleIntegerGen >>=) . caseRelGenSized

--- a/marlowe/test/Spec/Marlowe/Arbitrary.hs
+++ b/marlowe/test/Spec/Marlowe/Arbitrary.hs
@@ -394,5 +394,5 @@ instance Arbitrary Environment where
   shrink (Environment x) = Environment <$> shrink x
 
 
-caseGen :: Gen (Case Contract)
+caseGen :: Gen (Case (Contract Token))
 caseGen = sized $ (simpleIntegerGen >>=) . caseRelGenSized

--- a/marlowe/test/Spec/Marlowe/Common.hs
+++ b/marlowe/test/Spec/Marlowe/Common.hs
@@ -267,18 +267,18 @@ shrinkAction action = case action of
     Notify obs -> [Notify x | x <- shrinkObservation obs]
 
 
-caseRelGenSized :: Int -> Integer -> Gen (Case Contract)
+caseRelGenSized :: Int -> Integer -> Gen (Case (Contract Token))
 caseRelGenSized s bn = frequency [ (9, Case <$> actionGenSized s <*> contractRelGenSized s bn)
                                  , (1, merkleizedCase <$> actionGenSized s <*> contractRelGenSized s bn)
                                  ]
 
-shrinkCase :: Case Contract -> [Case Contract]
+shrinkCase :: Case (Contract Token) -> [Case (Contract Token)]
 shrinkCase (Case act cont) = [Case act x | x <- shrinkContract cont]
                               ++ [Case y cont | y <- shrinkAction act]
 shrinkCase (MerkleizedCase act bs) = [MerkleizedCase y bs | y <- shrinkAction act]
 
 
-contractRelGenSized :: Int -> Integer -> Gen Contract
+contractRelGenSized :: Int -> Integer -> Gen (Contract Token)
 contractRelGenSized s bn
   | s > 0 = oneof [ return Close
                   , Pay <$> partyGen <*> payeeGen <*> tokenGen
@@ -301,15 +301,15 @@ contractRelGenSized s bn
   | otherwise = return Close
 
 
-contractGenSized :: Int -> Gen Contract
+contractGenSized :: Int -> Gen (Contract Token)
 contractGenSized s = do iniBn <- simpleIntegerGen
                         contractRelGenSized s iniBn
 
-contractGen :: Gen Contract
+contractGen :: Gen (Contract Token)
 contractGen = sized contractGenSized
 
 
-shrinkContract :: Contract -> [Contract]
+shrinkContract :: Contract Token -> [Contract Token]
 shrinkContract cont = case cont of
     Close -> []
     Let vid val cont -> Close : cont : ([Let vid v cont | v <- shrinkValue val]
@@ -336,7 +336,7 @@ shrinkContract cont = case cont of
               ++ [Assert obs y | y <- shrinkContract cont])
 
 
-pangramContract :: Contract
+pangramContract :: Contract Token
 pangramContract = let
     alicePk = PK . unPaymentPubKeyHash . mockWalletPaymentPubKeyHash $ knownWallet 1
     aliceAcc = alicePk

--- a/marlowe/test/Spec/Marlowe/Common.hs
+++ b/marlowe/test/Spec/Marlowe/Common.hs
@@ -115,7 +115,7 @@ rationalGen = do
     return $ a % b
 
 
-valueGenSized :: Int -> Gen (Value (Observation Token) Token)
+valueGenSized :: Int -> Gen (Value Token)
 valueGenSized s
   | s > 0 = oneof [ AvailableMoney <$> partyGen <*> tokenGen
                   , Constant <$> simpleIntegerGen
@@ -140,11 +140,11 @@ valueGenSized s
                       ]
 
 
-valueGen ::  Gen (Value (Observation Token) Token)
+valueGen ::  Gen (Value Token)
 valueGen = sized valueGenSized
 
 
-shrinkValue :: Value (Observation Token) Token -> [Value (Observation Token) Token]
+shrinkValue :: Value Token -> [Value Token]
 shrinkValue value = case value of
     Constant x -> [Constant y | y <- shrinkSimpleInteger x]
     TimeIntervalStart -> [Constant 0]
@@ -267,12 +267,12 @@ shrinkAction action = case action of
     Notify obs -> [Notify x | x <- shrinkObservation obs]
 
 
-caseRelGenSized :: Int -> Integer -> Gen (Case (Contract Token) Token)
+caseRelGenSized :: Int -> Integer -> Gen (Case Token)
 caseRelGenSized s bn = frequency [ (9, Case <$> actionGenSized s <*> contractRelGenSized s bn)
                                  , (1, merkleizedCase <$> actionGenSized s <*> contractRelGenSized s bn)
                                  ]
 
-shrinkCase :: Case (Contract Token) Token -> [Case (Contract Token) Token]
+shrinkCase :: Case Token -> [Case Token]
 shrinkCase (Case act cont) = [Case act x | x <- shrinkContract cont]
                               ++ [Case y cont | y <- shrinkAction act]
 shrinkCase (MerkleizedCase act bs) = [MerkleizedCase y bs | y <- shrinkAction act]

--- a/marlowe/test/Spec/Marlowe/Common.hs
+++ b/marlowe/test/Spec/Marlowe/Common.hs
@@ -115,7 +115,7 @@ rationalGen = do
     return $ a % b
 
 
-valueGenSized :: Int -> Gen (Value Observation)
+valueGenSized :: Int -> Gen (Value (Observation Token) Token)
 valueGenSized s
   | s > 0 = oneof [ AvailableMoney <$> partyGen <*> tokenGen
                   , Constant <$> simpleIntegerGen
@@ -140,11 +140,11 @@ valueGenSized s
                       ]
 
 
-valueGen ::  Gen (Value Observation)
+valueGen ::  Gen (Value (Observation Token) Token)
 valueGen = sized valueGenSized
 
 
-shrinkValue :: Value Observation -> [Value Observation]
+shrinkValue :: Value (Observation Token) Token -> [Value (Observation Token) Token]
 shrinkValue value = case value of
     Constant x -> [Constant y | y <- shrinkSimpleInteger x]
     TimeIntervalStart -> [Constant 0]
@@ -167,7 +167,7 @@ shrinkValue value = case value of
                          ++ [Cond b val1 y | y <- shrinkValue val2])
 
 
-observationGenSized :: Int -> Gen Observation
+observationGenSized :: Int -> Gen (Observation Token)
 observationGenSized s
   | s > 0 = oneof [ AndObs <$> observationGenSized (s `quot` 2)
                            <*> observationGenSized (s `quot` 2)
@@ -193,11 +193,11 @@ observationGenSized s
                       , return FalseObs
                       ]
 
-observationGen :: Gen Observation
+observationGen :: Gen (Observation Token)
 observationGen = sized observationGenSized
 
 
-shrinkObservation :: Observation -> [Observation]
+shrinkObservation :: Observation Token -> [Observation Token]
 shrinkObservation obs = case obs of
     FalseObs -> []
     TrueObs  -> [FalseObs]

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -422,7 +422,8 @@ valuesFormAbelianGroup = property $ do
 
 divisionRoundingTest :: Property
 divisionRoundingTest = property $ do
-    let eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
+    let eval :: Value (Observation Token) Token -> Integer
+        eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
     -- test half-even rounding
     let gen = do
             n <- amount
@@ -495,7 +496,8 @@ divAnalysisTest = do
     result <- warningsTrace (contract 9 2)
     assertBool "Analysis ok" $ isRight result && either (const False) isJust result
 
-    let eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
+    let eval :: Value (Observation Token) Token -> Integer
+        eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
     eval (DivValue (Constant 0) (Constant 2)) @=? 0
     eval (DivValue (Constant 1) (Constant 0)) @=? 0
     eval (DivValue (Constant 5) (Constant 2)) @=? 2
@@ -506,7 +508,8 @@ divAnalysisTest = do
 
 divTest :: IO ()
 divTest = do
-    let eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
+    let eval :: Value (Observation Token) Token -> Integer
+        eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
     eval (DivValue (Constant 0) (Constant 2)) @=? 0
     eval (DivValue (Constant 1) (Constant 0)) @=? 0
     eval (DivValue (Constant 5) (Constant 2)) @=? 2

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -329,7 +329,7 @@ trustFundTest = checkPredicateOptions defaultCheckOptions "Trust Fund Contract"
 
         roles = Set.fromList ["alice", "bob"]
 
-        (params, _ :: TxConstraints MarloweInput MarloweData, _) =
+        (params, _ :: TxConstraints MarloweInput (MarloweData Token), _) =
             let con = setupMarloweParams @MarloweSchema @MarloweError
                         (AssocMap.fromList [("alice", walletAddress alice), ("bob", walletAddress bob)])
                         roles

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -423,7 +423,7 @@ valuesFormAbelianGroup = property $ do
 
 divisionRoundingTest :: Property
 divisionRoundingTest = property $ do
-    let eval :: Value (Observation Token) Token -> Integer
+    let eval :: Value Token -> Integer
         eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
     -- test half-even rounding
     let gen = do
@@ -453,7 +453,7 @@ divZeroTest = property $ do
 valueSerialization :: Property
 valueSerialization = property $
     forAll valueGen $ \a ->
-        let decoded :: Maybe (Value (Observation Token) Token)
+        let decoded :: Maybe (Value Token)
             decoded = decode $ encode a
         in Just a === decoded
 
@@ -497,7 +497,7 @@ divAnalysisTest = do
     result <- warningsTrace (contract 9 2)
     assertBool "Analysis ok" $ isRight result && either (const False) isJust result
 
-    let eval :: Value (Observation Token) Token -> Integer
+    let eval :: Value Token -> Integer
         eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
     eval (DivValue (Constant 0) (Constant 2)) @=? 0
     eval (DivValue (Constant 1) (Constant 0)) @=? 0
@@ -509,7 +509,7 @@ divAnalysisTest = do
 
 divTest :: IO ()
 divTest = do
-    let eval :: Value (Observation Token) Token -> Integer
+    let eval :: Value Token -> Integer
         eval = evalValue (Environment (POSIXTime 10, POSIXTime 1000)) (emptyState (POSIXTime 10))
     eval (DivValue (Constant 0) (Constant 2)) @=? 0
     eval (DivValue (Constant 1) (Constant 0)) @=? 0
@@ -538,7 +538,7 @@ tokenShowTest :: IO ()
 tokenShowTest = do
     -- SCP-834, CurrencySymbol is HEX encoded ByteString,
     -- and TokenSymbol as UTF8 encoded Unicode string
-    let actual :: Value (Observation Token) Token
+    let actual :: Value Token
         actual = AvailableMoney (Role "alice") (Token "00010afF" "ÚSD©")
 
     show actual @=? "AvailableMoney \"alice\" (Token \"00010aff\" \"ÚSD©\")"

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -451,7 +451,7 @@ divZeroTest = property $ do
 valueSerialization :: Property
 valueSerialization = property $
     forAll valueGen $ \a ->
-        let decoded :: Maybe (Value Observation)
+        let decoded :: Maybe (Value (Observation Token) Token)
             decoded = decode $ encode a
         in Just a === decoded
 
@@ -534,7 +534,7 @@ tokenShowTest :: IO ()
 tokenShowTest = do
     -- SCP-834, CurrencySymbol is HEX encoded ByteString,
     -- and TokenSymbol as UTF8 encoded Unicode string
-    let actual :: Value Observation
+    let actual :: Value (Observation Token) Token
         actual = AvailableMoney (Role "alice") (Token "00010afF" "ÚSD©")
 
     show actual @=? "AvailableMoney \"alice\" (Token \"00010aff\" \"ÚSD©\")"

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -330,7 +330,7 @@ trustFundTest = checkPredicateOptions defaultCheckOptions "Trust Fund Contract"
 
         roles = Set.fromList ["alice", "bob"]
 
-        (params, _ :: TxConstraints MarloweInput (MarloweData Token), _) =
+        (params, _ :: TxConstraints (MarloweInput Token) (MarloweData Token), _) =
             let con = setupMarloweParams @MarloweSchema @MarloweError
                         (AssocMap.fromList [("alice", walletAddress alice), ("bob", walletAddress bob)])
                         roles

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -523,7 +523,7 @@ pangramContractSerialization = do
     -- T.putStrLn json
     Just pangramContract @=? (decode $ encode pangramContract)
     contract <- readFile "test/contract.json"
-    let decoded :: Maybe Contract
+    let decoded :: Maybe (Contract Token)
         decoded = decode (fromString contract)
     case decoded of
         Just cont -> cont @=? pangramContract
@@ -568,7 +568,7 @@ prop_showWorksForContracts :: Property
 prop_showWorksForContracts = forAllShrink contractGen shrinkContract showWorksForContract
 
 
-showWorksForContract :: Contract -> Property
+showWorksForContract :: Contract Token -> Property
 showWorksForContract contract = unsafePerformIO $ do
   res <- runInterpreter $ setImports ["Language.Marlowe"]
                         >> set [ languageExtensions := [ OverloadedStrings ] ]
@@ -578,11 +578,11 @@ showWorksForContract contract = unsafePerformIO $ do
             Left err -> counterexample (show err) False)
 
 
-interpretContractString :: MonadInterpreter m => String -> m Contract
-interpretContractString contractStr = interpret contractStr (as :: Contract)
+interpretContractString :: MonadInterpreter m => String -> m (Contract Token)
+interpretContractString contractStr = interpret contractStr (as :: Contract Token)
 
 
-noFalsePositivesForContract :: Contract -> Property
+noFalsePositivesForContract :: Contract Token -> Property
 noFalsePositivesForContract cont =
   unsafePerformIO (do res <- catch (wrapLeft $ warningsTrace cont)
                                    (\exc -> return $ Left (Left (exc :: SomeException)))
@@ -610,7 +610,7 @@ wrapLeft r = do tempRes <- r
 prop_noFalsePositives :: Property
 prop_noFalsePositives = forAllShrink contractGen shrinkContract noFalsePositivesForContract
 
-jsonLoops :: Contract -> Property
+jsonLoops :: Contract Token -> Property
 jsonLoops cont = decode (encode cont) === Just cont
 
 prop_jsonLoops :: Property

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -555,7 +555,7 @@ inputSerialization = do
 stateSerialization :: IO ()
 stateSerialization = do
     state <- readFile "test/state.json"
-    let decoded :: Maybe State
+    let decoded :: Maybe (State Token)
         decoded = decode (fromString state)
     case decoded of
         Just st ->

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -46,6 +46,7 @@ import qualified Language.Marlowe as M ((%))
 import Language.Marlowe.Analysis.FSSemantics
 import Language.Marlowe.Client
 import Language.Marlowe.Core.V1.Semantics
+import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types
 import Language.Marlowe.Scripts (MarloweInput, rolePayoutScript, smallTypedValidator, smallUntypedValidator)
 import Language.Marlowe.Util

--- a/marlowe/test/Spec/Marlowe/Semantics.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics.hs
@@ -434,7 +434,8 @@ checkFalseObs = do
 
 checkApplyActionMismatch :: Property
 checkApplyActionMismatch = property $ do
-  let gen = do
+  let gen :: Gen (InputContent Token, Action Token)
+      gen = do
         let
           inputs = [IDeposit undefined undefined undefined undefined, IChoice undefined undefined, INotify]
           actions = [Deposit undefined undefined undefined undefined, Choice undefined undefined, Notify undefined]
@@ -495,7 +496,8 @@ checkIDeposit accountMatches partyMatches tokenMatches amountMatches = property 
 
 checkIChoice :: Maybe Bool -> Maybe Bool -> Property
 checkIChoice choiceMatches choiceInBounds = property $ do
-  let gen = do
+  let gen :: Gen (Environment, State Token, ChoiceId, ChosenNum, Action Token, Bool)
+      gen = do
         choiceMatches' <- maybe arbitrary pure choiceMatches
         choiceInBounds' <- maybe arbitrary pure choiceInBounds
         environment <- arbitrary

--- a/marlowe/test/Spec/Marlowe/Semantics.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics.hs
@@ -168,8 +168,8 @@ checkFixInterval invalid inPast =
 
 
 checkValue :: Show a
-           => (Environment -> State -> Gen a)
-           -> ((Value (Observation Token) Token -> Integer) -> (Observation Token -> Bool) -> Environment -> State -> a -> Bool)
+           => (Environment -> State Token -> Gen a)
+           -> ((Value (Observation Token) Token -> Integer) -> (Observation Token -> Bool) -> Environment -> State Token -> a -> Bool)
            -> Property
 checkValue gen f =
   property $ do

--- a/marlowe/test/Spec/Marlowe/Semantics.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics.hs
@@ -153,7 +153,8 @@ tests =
 checkFixInterval :: Bool -> Bool -> Property
 checkFixInterval invalid inPast =
   property $ do
-  let gen = do
+  let gen :: Gen ((POSIXTime, POSIXTime), State Token)
+      gen = do
         state <- arbitrary
         end   <- arbitrary `suchThat` (\t -> (t < minTime state) == inPast)
         start <- arbitrary `suchThat` (\t -> (t > end) == invalid && (t < minTime state) == inPast)
@@ -238,9 +239,11 @@ checkMulValue =
 
 
 checkDivValueNumeratorDenominatorZero :: Assertion
-checkDivValueNumeratorDenominatorZero =
+checkDivValueNumeratorDenominatorZero = do
+  let eval :: Value (Observation Token) Token -> Integer
+      eval = evalValue undefined undefined
   assertBool "DivValue 0 0 = 0"
-    $ evalValue undefined undefined (DivValue (Constant 0) (Constant 0)) == 0
+    $ eval (DivValue (Constant 0) (Constant 0)) == 0
 
 
 checkDivValueNumeratorZero :: Property
@@ -413,15 +416,19 @@ checkValueEQ =
 
 
 checkTrueObs :: Assertion
-checkTrueObs =
+checkTrueObs = do
+  let eval :: Observation Token -> Bool
+      eval = evalObservation undefined undefined
   assertBool "TrueObs is true."
-    $ evalObservation undefined undefined TrueObs
+    $ eval TrueObs
 
 
 checkFalseObs :: Assertion
-checkFalseObs =
+checkFalseObs = do
+  let eval :: Observation Token -> Bool
+      eval = evalObservation undefined undefined
   assertBool "FalseObs is false."
-    . not $ evalObservation undefined undefined FalseObs
+    . not $ eval FalseObs
 
 
 checkApplyActionMismatch :: Property

--- a/marlowe/test/Spec/Marlowe/Semantics.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics.hs
@@ -169,7 +169,7 @@ checkFixInterval invalid inPast =
 
 checkValue :: Show a
            => (Environment -> State -> Gen a)
-           -> ((Value Observation -> Integer) -> (Observation -> Bool) -> Environment -> State -> a -> Bool)
+           -> ((Value (Observation Token) Token -> Integer) -> (Observation Token -> Bool) -> Environment -> State -> a -> Bool)
            -> Property
 checkValue gen f =
   property $ do

--- a/marlowe/test/Spec/Marlowe/Semantics.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics.hs
@@ -171,7 +171,7 @@ checkFixInterval invalid inPast =
 
 checkValue :: Show a
            => (Environment -> State Token -> Gen a)
-           -> ((Value (Observation Token) Token -> Integer) -> (Observation Token -> Bool) -> Environment -> State Token -> a -> Bool)
+           -> ((Value Token -> Integer) -> (Observation Token -> Bool) -> Environment -> State Token -> a -> Bool)
            -> Property
 checkValue gen f =
   property $ do
@@ -241,7 +241,7 @@ checkMulValue =
 
 checkDivValueNumeratorDenominatorZero :: Assertion
 checkDivValueNumeratorDenominatorZero = do
-  let eval :: Value (Observation Token) Token -> Integer
+  let eval :: Value Token -> Integer
       eval = evalValue undefined undefined
   assertBool "DivValue 0 0 = 0"
     $ eval (DivValue (Constant 0) (Constant 0)) == 0

--- a/marlowe/test/Spec/Marlowe/Semantics.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics.hs
@@ -10,6 +10,7 @@ module Spec.Marlowe.Semantics (
 
 import Data.Maybe (fromMaybe, isNothing)
 import Language.Marlowe.Core.V1.Semantics
+import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types
 import Plutus.V1.Ledger.Api (CurrencySymbol, POSIXTime (..), PubKeyHash, TokenName)
 import Spec.Marlowe.Arbitrary

--- a/marlowe/test/Spec/Marlowe/Util.hs
+++ b/marlowe/test/Spec/Marlowe/Util.hs
@@ -13,8 +13,10 @@ module Spec.Marlowe.Util (
 import Control.Monad (replicateM)
 import Data.Function (on)
 import Data.List (group, sort)
+import Language.Marlowe.Core.V1.Semantics.Money (Money)
+import qualified Language.Marlowe.Core.V1.Semantics.Money as Money
+import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types
-import Plutus.V1.Ledger.Value (flattenValue)
 import Spec.Marlowe.Util.AssocMap
 import Test.Tasty.HUnit (Assertion, assertBool)
 import Test.Tasty.QuickCheck (Gen, generate)
@@ -35,8 +37,8 @@ stateEq :: State Token -> State Token -> Bool
 stateEq = (==) `on` canonicalState
 
 
-flattenMoney :: Money -> [(Token, Integer)]
-flattenMoney = fmap (\(s, n, a) -> (Token s n, a)) .  flattenValue
+flattenMoney :: Money Token -> [(Token, Integer)]
+flattenMoney = Money.toList
 
 
 roundedDivide :: Integer

--- a/marlowe/test/Spec/Marlowe/Util.hs
+++ b/marlowe/test/Spec/Marlowe/Util.hs
@@ -22,7 +22,7 @@ import Test.Tasty.QuickCheck (Gen, generate)
 import qualified PlutusTx.Prelude as P
 
 
-canonicalState :: State -> State
+canonicalState :: State Token -> State Token
 canonicalState State{..} =
   State
     (assocMapSort accounts)
@@ -31,7 +31,7 @@ canonicalState State{..} =
     minTime
 
 
-stateEq :: State -> State -> Bool
+stateEq :: State Token -> State Token -> Bool
 stateEq = (==) `on` canonicalState
 
 

--- a/marlowe/test/Spec/Marlowe/Util.hs
+++ b/marlowe/test/Spec/Marlowe/Util.hs
@@ -17,6 +17,7 @@ import Language.Marlowe.Core.V1.Semantics.Money (Money)
 import qualified Language.Marlowe.Core.V1.Semantics.Money as Money
 import Language.Marlowe.Core.V1.Semantics.Token
 import Language.Marlowe.Core.V1.Semantics.Types
+import Ledger (PubKeyHash)
 import Spec.Marlowe.Util.AssocMap
 import Test.Tasty.HUnit (Assertion, assertBool)
 import Test.Tasty.QuickCheck (Gen, generate)
@@ -24,7 +25,7 @@ import Test.Tasty.QuickCheck (Gen, generate)
 import qualified PlutusTx.Prelude as P
 
 
-canonicalState :: State Token -> State Token
+canonicalState :: State PubKeyHash Token -> State PubKeyHash Token
 canonicalState State{..} =
   State
     (assocMapSort accounts)
@@ -33,7 +34,7 @@ canonicalState State{..} =
     minTime
 
 
-stateEq :: State Token -> State Token -> Bool
+stateEq :: State PubKeyHash Token -> State PubKeyHash Token -> Bool
 stateEq = (==) `on` canonicalState
 
 


### PR DESCRIPTION
In the literature, Marlowe is described as being agnostic to a particular choice of blockchain, be it UTxO based, account based, or otherwise. This is _mostly_ true for the implementation, but not quite. There are a few places where the Marlowe semantics refer to Cardano specific concepts; specifically, the Cardano-specific notion of a `Token`, and the Cardano-specific notion of identity (`PubKeyHash`). I am in the process of modifying the implementation so it abstracts over these concepts; of course, the validation function and off-chain could would still be specific to Cardano, but the core types and the core semantics would not be. This PR is work in progress; I'm not sure if this generalization would be welcomed by the Marlowe team. If not, of course feel free to say so and I will close this PR again. But if it is, then I will update this PR when I'm finished and make it ready for review. 