### PR TITLE
Scp 4327/extend initialize for template contracts

### DIFF
--- a/marlowe-cli/examples/simple/run-simple.sh
+++ b/marlowe-cli/examples/simple/run-simple.sh
@@ -75,21 +75,7 @@ BYSTANDER_PREFIX="$TREASURY/christopher-marlowe"
 BYSTANDER_NAME="Christopher Marlowe"
 BYSTANDER_PAYMENT_SKEY="$BYSTANDER_PREFIX".skey
 BYSTANDER_PAYMENT_VKEY="$BYSTANDER_PREFIX".vkey
-
-if [[ ! -e "$BYSTANDER_PAYMENT_SKEY" ]]
-then
-  cardano-cli address key-gen --signing-key-file "$BYSTANDER_PAYMENT_SKEY"      \
-                              --verification-key-file "$BYSTANDER_PAYMENT_VKEY"
-fi
-
-BYSTANDER_ADDRESS=$(
-  cardano-cli address build --testnet-magic "$MAGIC"                                  \
-                            --payment-verification-key-file "$BYSTANDER_PAYMENT_VKEY" \
-)
-BYSTANDER_PUBKEYHASH=$(
-  cardano-cli address key-hash --payment-verification-key-file "$BYSTANDER_PAYMENT_VKEY"
-)
-
+if [[ ! -e "$BYSTANDER_PAYMENT_SKEY" ]] then cardano-cli address key-gen --signing-key-file "$BYSTANDER_PAYMENT_SKEY"      \ --verification-key-file "$BYSTANDER_PAYMENT_VKEY" fi BYSTANDER_ADDRESS=$( cardano-cli address build --testnet-magic "$MAGIC"                                  \ --payment-verification-key-file "$BYSTANDER_PAYMENT_VKEY" \) BYSTANDER_PUBKEYHASH=$( cardano-cli address key-hash --payment-verification-key-file "$BYSTANDER_PAYMENT_VKEY")
 marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --socket-path "$CARDANO_NODE_SOCKET_PATH" \
                         --out-file /dev/null                      \

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command.hs
@@ -33,7 +33,8 @@ import Language.Marlowe.CLI.Command.PAB (PabCommand, parsePabCommand, runPabComm
 import Language.Marlowe.CLI.Command.Query (QueryCommand, parseQueryCommand, runQueryCommand)
 import Language.Marlowe.CLI.Command.Role (RoleCommand, parseRoleCommand, runRoleCommand)
 import Language.Marlowe.CLI.Command.Run (RunCommand, parseRunCommand, runRunCommand)
-import Language.Marlowe.CLI.Command.Template (TemplateCommand, parseTemplateCommand, runTemplateCommand)
+import Language.Marlowe.CLI.Command.Template (OutputFiles (..), TemplateCommand, parseTemplateCommand,
+                                              parseTemplateCommandOutputFiles, runTemplateCommand)
 import Language.Marlowe.CLI.Command.Test (TestCommand, parseTestCommand, runTestCommand)
 import Language.Marlowe.CLI.Command.Transaction (TransactionCommand, parseTransactionCommand, runTransactionCommand)
 import Language.Marlowe.CLI.Command.Util (UtilCommand, parseUtilCommand, runUtilCommand)
@@ -58,7 +59,7 @@ data Command =
     -- | Role-related commands.
   | RoleCommand RoleCommand
     -- | Template-related commands.
-  | TemplateCommand TemplateCommand
+  | TemplateCommand TemplateCommand OutputFiles
     -- | Transaction-related commands.
   | TransactionCommand TransactionCommand
     -- | Query commands.
@@ -92,16 +93,16 @@ runCommand :: MonadError CliError m
            => MonadIO m
            => Command  -- ^ The command.
            -> m ()     -- ^ Action to run the command.
-runCommand (RunCommand         command) = runRunCommand         command
-runCommand (PabCommand         command) = runPabCommand         command
-runCommand (ContractCommand    command) = runContractCommand    command
-runCommand (TestCommand        command) = runTestCommand        command
-runCommand (InputCommand       command) = runInputCommand       command
-runCommand (QueryCommand       command) = runQueryCommand       command
-runCommand (RoleCommand        command) = runRoleCommand        command
-runCommand (TemplateCommand    command) = runTemplateCommand    command
-runCommand (TransactionCommand command) = runTransactionCommand command
-runCommand (UtilCommand        command) = runUtilCommand        command
+runCommand (RunCommand         command)          = runRunCommand         command
+runCommand (PabCommand         command)          = runPabCommand         command
+runCommand (ContractCommand    command)          = runContractCommand    command
+runCommand (TestCommand        command)          = runTestCommand        command
+runCommand (InputCommand       command)          = runInputCommand       command
+runCommand (QueryCommand       command)          = runQueryCommand       command
+runCommand (RoleCommand        command)          = runRoleCommand        command
+runCommand (TemplateCommand command outputFiles) = runTemplateCommand command outputFiles
+runCommand (TransactionCommand command)          = runTransactionCommand command
+runCommand (UtilCommand        command)          = runUtilCommand        command
 
 
 -- | Command parseCommand for the tool version.
@@ -121,7 +122,7 @@ parseCommand networkId socketPath version =
                    O.commandGroup "High-level commands:"
                 <> O.command "run"         (O.info (RunCommand      <$> parseRunCommand networkId socketPath ) $ O.progDesc "Run a contract."                   )
                 <> O.command "pab"         (O.info (PabCommand      <$> parsePabCommand                      ) $ O.progDesc "Run a contract via the PAB."       )
-                <> O.command "template"    (O.info (TemplateCommand <$> parseTemplateCommand                 ) $ O.progDesc "Create a contract from a template.")
+                <> O.command "template"    (O.info (TemplateCommand <$> parseTemplateCommand <*> parseTemplateCommandOutputFiles ) $ O.progDesc "Create a contract from a template.")
                 <> O.command "test"        (O.info (TestCommand     <$> parseTestCommand networkId socketPath) $ O.progDesc "Test contracts."                   )
               )
           , O.hsubparser

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
@@ -32,7 +32,8 @@ import Cardano.Api (AlonzoEra, CardanoMode, LocalNodeConnectInfo (..), NetworkId
 import Control.Monad (void)
 import Control.Monad.Except (MonadError, MonadIO, catchError, liftIO, throwError)
 import Control.Monad.State.Strict (MonadState, execStateT, get)
-import Language.Marlowe.CLI.Test.Types (ScriptOperation (..), ScriptTest (..), TransactionNickname)
+import Language.Marlowe.CLI.Test.Types (ScriptContract (InlineContract, TemplateContract), ScriptOperation (..),
+                                        ScriptTest (..), TransactionNickname)
 import Language.Marlowe.CLI.Types (CliError (..), MarloweTransaction (MarloweTransaction))
 import Plutus.V1.Ledger.Api (CostModelParams)
 
@@ -81,13 +82,17 @@ interpret Initialize {..} = do
     marloweParams = Client.marloweParams parsedRoleCurrency
     marloweState = initialMarloweState soOwner soMinAda
 
+  testContract <- case soContract of
+    InlineContract contract -> pure contract
+    TemplateContract _      -> throwError $ CliError "Not implemented yet"
+
   transaction <- initializeTransactionImpl
     marloweParams
     seSlotConfig
     seConstModelParams
     seNetworkId
     NoStakeAddress
-    soContract
+    testContract
     marloweState
     True
     True

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -88,6 +88,7 @@ import qualified Data.HashMap.Strict
 import qualified Data.Map.Strict as M (Map)
 import Data.Maybe (fromMaybe)
 import Data.Text
+import Language.Marlowe.CLI.Command.Template (TemplateCommand)
 import Ledger (CurrencySymbol)
 import Options.Applicative (optional)
 import qualified Test.QuickCheck.Property as Aeson
@@ -157,21 +158,21 @@ data PabTest =
 
 type TransactionNickname = String
 
-data ScriptContract = InlineContract Contract | TemplateContract String
+data ScriptContract = InlineContract Contract | TemplateContract TemplateCommand
     deriving stock (Eq, Generic, Show)
 
 instance ToJSON ScriptContract where
-    toJSON (InlineContract c)              = Aeson.object [("inline", toJSON c)]
-    toJSON (TemplateContract templateName) = Aeson.object [("template", toJSON templateName)]
+    toJSON (InlineContract c)                 = Aeson.object [("inline", toJSON c)]
+    toJSON (TemplateContract templateCommand) = Aeson.object [("template", toJSON templateCommand)]
 
 instance FromJSON ScriptContract where
     parseJSON json = case json of
       Aeson.Object (Data.HashMap.Strict.toList -> [("inline", contractJson)]) -> do
         parsedContract <- parseJSON contractJson
         pure $ InlineContract parsedContract
-      Aeson.Object (Data.HashMap.Strict.toList -> [("template", templateNameJson)]) -> do
-        parsedTemplateName <- parseJSON templateNameJson
-        pure $ TemplateContract parsedTemplateName
+      Aeson.Object (Data.HashMap.Strict.toList -> [("template", templateCommandJson)]) -> do
+        parsedTemplateCommand <- parseJSON templateCommandJson
+        pure $ TemplateContract parsedTemplateCommand
       _ -> fail "Expected object with a single field of either `inline` or `template`"
 
 

--- a/marlowe-cli/test/non-pab/inline/trivial.yaml
+++ b/marlowe-cli/test/non-pab/inline/trivial.yaml
@@ -1,4 +1,4 @@
-stTestName: Sample Test
+stTestName: Inline Simple Contract
 
 stScriptOperations:
 

--- a/marlowe-cli/test/non-pab/template/trivial.yaml
+++ b/marlowe-cli/test/non-pab/template/trivial.yaml
@@ -1,0 +1,42 @@
+stTestName: Non-PAB Trivial Contract Test
+
+stScriptOperations:
+
+  - tag: Initialize
+    soOwner:
+      role_token: "bystander"
+    soTransaction: "TestTransaction-1"
+    soRoleCurrency: "1c964b2b89b6c9d2a8e2d564a3541b3b355d0451825ad0481a63f86c"
+    soMinAda: 1000000
+    soContract:
+      template:
+        tag: "TemplateTrivial"
+        bystander:
+          role_token: "bystander"
+        minAda: 1000000
+        party:
+          role_token: "party"
+        depositLovelace: 15000000
+        withdrawalLovelace: 15000000
+        timeout:
+          tag: "POSIXTime"
+          contents: 1961123625000
+
+  - tag: Prepare
+    soTransaction: "TestTransaction-1"
+    soInputs:
+      - input_from_party:
+          role_token: "party"
+        that_deposits: 15000000
+        of_token:
+          currency_symbol: ""
+          token_name: ""
+        into_account:
+          role_token: "party"
+    soOwner:
+      role_token: "bystander"
+    soMinimumTime: 1645590825000
+    soMaximumTime: 1898051625000
+
+  - tag: Fail
+    soFailureMessage: "Failure Invoked"

--- a/marlowe-cli/test/test-nonpab-script.yaml
+++ b/marlowe-cli/test/test-nonpab-script.yaml
@@ -9,25 +9,26 @@ stScriptOperations:
     soRoleCurrency: "1c964b2b89b6c9d2a8e2d564a3541b3b355d0451825ad0481a63f86c"
     soMinAda: 1000000
     soContract:
-      when:
-      - case:
-          party:
-            role_token: PAB
-          deposits: 15000000
-          into_account:
-            role_token: PAB
-          of_token:
-            currency_symbol: ''
-            token_name: ''
-        then:
-          when:
-          - case:
-              notify_if: true
-            then: close
-          timeout: 1961123625000
-          timeout_continuation: close
-      timeout: 1929587625000
-      timeout_continuation: close
+      inline:
+        when:
+        - case:
+            party:
+              role_token: PAB
+            deposits: 15000000
+            into_account:
+              role_token: PAB
+            of_token:
+              currency_symbol: ''
+              token_name: ''
+          then:
+            when:
+            - case:
+                notify_if: true
+              then: close
+            timeout: 1961123625000
+            timeout_continuation: close
+        timeout: 1929587625000
+        timeout_continuation: close
 
   - tag: Prepare
     soTransaction: "TestTransaction-1"

--- a/marlowe/src/Language/Marlowe/Extended/V1.hs
+++ b/marlowe/src/Language/Marlowe/Extended/V1.hs
@@ -44,7 +44,8 @@ import Text.PrettyPrint.Leijen (parens, text)
 
 data Timeout = TimeParam String
              | POSIXTime Integer
-  deriving stock (Show,Generic)
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
 
 instance Pretty Timeout where
     prettyFragment (POSIXTime n)    = prettyFragment n


### PR DESCRIPTION
Description:
  In this PR, we implement a way to use contract templates in marlowe cli tests. We started full implementation of the Trivial Contract.

In coming PRs, we will implement the rest of the run-simple.sh automated test, which includes the address, execute and utils marlowe cli commands.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
