### PR TITLE
Some work done to upgrade era from Alonzo to Babbage

### DIFF
--- a/marlowe-cli/src/Language/Marlowe/CLI/IO.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/IO.hs
@@ -33,7 +33,7 @@ module Language.Marlowe.CLI.IO (
 ) where
 
 
-import Cardano.Api (AlonzoEra, AsType (..), FromSomeType (..), HasTextEnvelope, NetworkId (..), NetworkMagic (..),
+import Cardano.Api (AsType (..), BabbageEra, FromSomeType (..), HasTextEnvelope, NetworkId (..), NetworkMagic (..),
                     ScriptDataJsonSchema (..), TxMetadataInEra (..), TxMetadataJsonSchema (..),
                     TxMetadataSupportedInEra (..), metadataFromJson, readFileTextEnvelopeAnyOf, scriptDataFromJson,
                     serialiseToTextEnvelope, writeFileTextEnvelope)
@@ -157,13 +157,13 @@ maybeWriteJson (Just outputFile) = liftIO . LBS.writeFile outputFile . encodePre
 readMaybeMetadata :: MonadError CliError m
                   => MonadIO m
                   => Maybe FilePath                 -- ^ The metadata file, if any.
-                  -> m (TxMetadataInEra AlonzoEra)  -- ^ Action for reading the metadata.
+                  -> m (TxMetadataInEra BabbageEra)  -- ^ Action for reading the metadata.
 readMaybeMetadata file =
   do
     metadata <- sequence $ decodeFileStrict <$> file
     maybe
       (pure TxMetadataNone)
-      (fmap (TxMetadataInEra TxMetadataInAlonzoEra) . liftCli . metadataFromJson TxMetadataJsonNoSchema)
+      (fmap (TxMetadataInEra TxMetadataInBabbageEra) . liftCli . metadataFromJson TxMetadataJsonNoSchema)
       metadata
 
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
@@ -27,7 +27,7 @@
 
 module Language.Marlowe.CLI.Test.Script where
 
-import Cardano.Api (AlonzoEra, CardanoMode, LocalNodeConnectInfo (..), NetworkId,
+import Cardano.Api (BabbageEra, CardanoMode, LocalNodeConnectInfo (..), NetworkId,
                     StakeAddressReference (NoStakeAddress))
 import Control.Monad (void)
 import Control.Monad.Except (MonadError, MonadIO, catchError, liftIO, throwError)
@@ -56,7 +56,7 @@ import Language.Marlowe.CLI.Types (CliError (..))
 import Plutus.V1.Ledger.SlotConfig (SlotConfig (..))
 
 newtype ScriptState = ScriptState
-  { transactions :: Map String (MarloweTransaction AlonzoEra)
+  { transactions :: Map String (MarloweTransaction BabbageEra)
   }
 
 data ScriptEnv = ScriptEnv
@@ -111,7 +111,7 @@ interpret Prepare {..} = do
 
 interpret (Fail message) = throwError $ CliError message
 
-insertMarloweTransaction :: TransactionNickname -> MarloweTransaction AlonzoEra -> ScriptState -> ScriptState
+insertMarloweTransaction :: TransactionNickname -> MarloweTransaction BabbageEra -> ScriptState -> ScriptState
 insertMarloweTransaction nickname transaction scriptState@ScriptState { transactions } =
   scriptState{ transactions = Map.insert nickname transaction transactions }
 
@@ -119,7 +119,7 @@ insertMarloweTransaction nickname transaction scriptState@ScriptState { transact
 findMarloweTransaction :: MonadError CliError m
                 => MonadState ScriptState m
                 => TransactionNickname   -- ^ The nickname.
-                -> m (MarloweTransaction AlonzoEra) -- ^ Action returning the instance.
+                -> m (MarloweTransaction BabbageEra) -- ^ Action returning the instance.
 findMarloweTransaction nickname = do
   ScriptState { transactions } <- get
   case M.lookup nickname transactions of


### PR DESCRIPTION
I'd like to merge this with cardano-node-1.35 before it diverges too far but don't want to break anyone's work. Here's what's happened so far:

Work has also been started here to get the non-PAB tests working on the
public networks. To facilitate this, changes have been made to
Language.Marlowe.CLI.Transaction buildFaucet (not buildFaucet') to allow
the use of any wallet addr/skey as a "faucet" to fund another address.

The `marlowe-cli util faucet` command now uses buildFaucet (not
buildFaucet' as it did before) and switches have been added for
specifying the source fund addr/skey.

This relates to (but does not yet close) SCP-4364 and SCP-4146