### PR TITLE
SCP-4276 Follow a Contract

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,6 +10,7 @@ packages:
   marlowe-cli
   marlowe-contracts
   marlowe-protocols
+  marlowe-protocols-test
   marlowe-runtime
 
   libs/aeson-via-serialise

--- a/marlowe-chain-sync/app/Main.hs
+++ b/marlowe-chain-sync/app/Main.hs
@@ -1,12 +1,13 @@
 module Main where
 
-import Cardano.Api (CardanoMode, ConsensusModeParams (..), EpochSlots (..), LocalNodeConnectInfo (..))
+import Cardano.Api (CardanoMode, ConsensusModeParams (..), EpochSlots (..), LocalNodeConnectInfo (..),
+                    queryNodeLocalState)
 import qualified Cardano.Api as Cardano
 import Cardano.Api.Byron (toByronRequiresNetworkMagic)
 import qualified Cardano.Chain.Genesis as Byron
 import Cardano.Crypto (abstractHashToBytes, decodeAbstractHash)
 import Control.Concurrent.STM (atomically, modifyTVar, newTVarIO, readTVar)
-import Control.Exception (bracket, bracketOnError)
+import Control.Exception (bracket, bracketOnError, throwIO)
 import Control.Monad ((<=<))
 import Control.Monad.Trans.Except (ExceptT (ExceptT), runExceptT, withExceptT)
 import Data.ByteString.Lazy.Base16 (encodeBase16)
@@ -21,11 +22,16 @@ import Language.Marlowe.Runtime.ChainSync (ChainSync (..), ChainSyncDependencies
 import Language.Marlowe.Runtime.ChainSync.Database (hoistDatabaseQueries)
 import qualified Language.Marlowe.Runtime.ChainSync.Database.PostgreSQL as PostgreSQL
 import Language.Marlowe.Runtime.ChainSync.Genesis (computeByronGenesisBlock)
+import Language.Marlowe.Runtime.ChainSync.QueryServer (RunQueryServer (..))
 import Network.Channel (effectChannel, socketAsChannel)
+import Network.Protocol.Driver (mkDriver)
+import Network.Protocol.Query.Codec (codecQuery)
+import Network.Protocol.Query.Server (queryServerPeer)
 import Network.Socket (AddrInfo (..), AddrInfoFlag (..), SockAddr, SocketOption (ReuseAddr), SocketType (..), bind,
                        close, defaultHints, getAddrInfo, listen, openSocket, setCloseOnExecIfNeeded, setSocketOption,
                        withFdSocket, withSocketsDo)
 import Network.Socket.Address (accept)
+import Network.TypedProtocol (runPeerWithDriver, startDState)
 import Options (Options (..), getOptions)
 import System.IO (hPrint, hPutStr, stderr)
 
@@ -34,35 +40,44 @@ main = run =<< getOptions "0.0.0.0"
 
 run :: Options -> IO ()
 run Options{..} = withSocketsDo do
-  addr <- resolve
-  bracket (open addr) close \socket -> do
-    socketIdVar <- newTVarIO @Int 0
-    pool <- Pool.acquire (100, secondsToNominalDiffTime 5, fromString databaseUri)
-    genesisConfigResult <- runExceptT do
-      hash <- ExceptT $ pure $ decodeAbstractHash genesisConfigHash
-      (hash,) <$> withExceptT
-        (const "failed to read byron genesis file")
-        (Byron.mkConfigFromFile (toByronRequiresNetworkMagic networkId) genesisConfigFile hash)
-    (hash, genesisConfig) <- either (fail . unpack) pure genesisConfigResult
-    let genesisBlock = computeByronGenesisBlock (abstractHashToBytes hash) genesisConfig
-    chainSync <- atomically $ mkChainSync ChainSyncDependencies
-      { connectToLocalNode = Cardano.connectToLocalNode localNodeConnectInfo
-      , databaseQueries = hoistDatabaseQueries
-          (either throwUsageError pure <=< Pool.use pool)
-          (PostgreSQL.databaseQueries genesisBlock)
-      , persistRateLimit
-      , genesisBlock
-      , acceptChannel = do
-        socketId <- atomically do
-          modifyTVar socketIdVar (+1)
-          readTVar socketIdVar
-        (conn, _ :: SockAddr) <- accept socket
-        pure
-          ( effectChannel (logSend socketId) (logRecv socketId) $ socketAsChannel conn
-          , close conn
-          )
-      }
-    runChainSync chainSync
+  chainSeekAddr <- resolve port
+  queryAddr <- resolve queryPort
+  bracket (open chainSeekAddr) close \chainSeekSocket -> do
+    bracket (open queryAddr) close \querySocket -> do
+      socketIdVar <- newTVarIO @Int 0
+      pool <- Pool.acquire (100, secondsToNominalDiffTime 5, fromString databaseUri)
+      genesisConfigResult <- runExceptT do
+        hash <- ExceptT $ pure $ decodeAbstractHash genesisConfigHash
+        (hash,) <$> withExceptT
+          (const "failed to read byron genesis file")
+          (Byron.mkConfigFromFile (toByronRequiresNetworkMagic networkId) genesisConfigFile hash)
+      (hash, genesisConfig) <- either (fail . unpack) pure genesisConfigResult
+      let genesisBlock = computeByronGenesisBlock (abstractHashToBytes hash) genesisConfig
+      chainSync <- atomically $ mkChainSync ChainSyncDependencies
+        { connectToLocalNode = Cardano.connectToLocalNode localNodeConnectInfo
+        , databaseQueries = hoistDatabaseQueries
+            (either throwUsageError pure <=< Pool.use pool)
+            (PostgreSQL.databaseQueries genesisBlock)
+        , persistRateLimit
+        , genesisBlock
+        , acceptChannel = do
+            socketId <- atomically do
+              modifyTVar socketIdVar (+1)
+              readTVar socketIdVar
+            (conn, _ :: SockAddr) <- accept chainSeekSocket
+            pure
+              ( effectChannel (logSend socketId) (logRecv socketId) $ socketAsChannel conn
+              , close conn
+              )
+        , acceptRunQueryServer = do
+            (conn, _ :: SockAddr) <- accept querySocket
+            let driver = mkDriver throwIO codecQuery $ socketAsChannel conn
+            pure $ RunQueryServer \server -> do
+              let peer = queryServerPeer server
+              fst <$> runPeerWithDriver driver peer (startDState driver)
+        , queryLocalNodeState = queryNodeLocalState localNodeConnectInfo
+        }
+      runChainSync chainSync
   where
     logSend i bytes =
       hPutStr stderr ("send[" <> show i <> "]: ") *> TL.hPutStrLn stderr (encodeBase16 bytes)
@@ -81,9 +96,9 @@ run Options{..} = withSocketsDo do
 
     persistRateLimit = secondsToNominalDiffTime 1
 
-    resolve = do
+    resolve p = do
       let hints = defaultHints { addrFlags = [AI_PASSIVE], addrSocketType = Stream }
-      head <$> getAddrInfo (Just hints) (Just host) (Just $ show port)
+      head <$> getAddrInfo (Just hints) (Just host) (Just $ show p)
 
     open addr = bracketOnError (openSocket addr) close \socket -> do
       setSocketOption socket ReuseAddr 1

--- a/marlowe-chain-sync/example-client/FollowingUTxOs.hs
+++ b/marlowe-chain-sync/example-client/FollowingUTxOs.hs
@@ -3,7 +3,6 @@ module FollowingUTxOs where
 import Data.List (uncons)
 import Data.Maybe (fromMaybe)
 import Language.Marlowe.Runtime.ChainSync.Api
-import Network.Protocol.ChainSeek.Client
 
 -- This client follows a Genesis TxOut through transactions until it finds a
 -- UTxO at index 0 of some tx.

--- a/marlowe-chain-sync/example-client/SkippingBlocks.hs
+++ b/marlowe-chain-sync/example-client/SkippingBlocks.hs
@@ -2,7 +2,6 @@ module SkippingBlocks where
 
 import Data.Void (absurd)
 import Language.Marlowe.Runtime.ChainSync.Api
-import Network.Protocol.ChainSeek.Client
 
 -- This client advances 1000 blocks at a time until it reaches the tip.
 client :: RuntimeChainSeekClient IO ()

--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -61,6 +61,7 @@ library
     Language.Marlowe.Runtime.ChainSync.Genesis
     Language.Marlowe.Runtime.ChainSync.NodeClient
     Language.Marlowe.Runtime.ChainSync.Server
+    Language.Marlowe.Runtime.ChainSync.QueryServer
     Language.Marlowe.Runtime.ChainSync.Store
     Language.Marlowe.Runtime.ChainSync.Api
   other-modules:
@@ -129,6 +130,7 @@ executable chainseekd
     , text
     , time
     , transformers
+    , typed-protocols
 
 executable example-client
   import: lang

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -76,6 +76,7 @@ data Metadata
 data TransactionInput = TransactionInput
   { txId     :: !TxId             -- ^ The txId of the TransactionOutput this input consumes.
   , txIx     :: !TxIx             -- ^ The txIx of the TransactionOutput this input consumes.
+  , address  :: !Address          -- ^ The address of the TransactionOutput this input consumes.
   , redeemer :: !(Maybe Redeemer) -- ^ The script redeemer dataum for this input (if one was provided).
   }
   deriving stock (Show, Read, Eq, Ord, Generic)

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE EmptyDataDeriving     #-}
 {-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 module Language.Marlowe.Runtime.ChainSync.Api where
 
 import Data.Bifunctor (bimap)
-import Data.Binary (Binary (..), Get, Put, get, getWord8, put, putWord8)
+import Data.Binary (Binary (..), get, getWord8, put, putWord8)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 (decodeBase16, encodeBase16)
 import qualified Data.ByteString.Lazy as LBS
@@ -17,13 +18,12 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.These (These (..))
 import Data.Void (Void)
 import Data.Word (Word16, Word64)
-import Debug.Trace (traceShowId)
 import GHC.Generics (Generic)
 import GHC.Natural (Natural)
 import Network.Protocol.ChainSeek.Client (ChainSeekClient)
-import Network.Protocol.ChainSeek.Codec (DeserializeError, SomeQuery (..), codecChainSeek)
+import Network.Protocol.ChainSeek.Codec (DeserializeError, codecChainSeek)
 import Network.Protocol.ChainSeek.Server (ChainSeekServer)
-import Network.Protocol.ChainSeek.Types (ChainSeek, SchemaVersion (SchemaVersion))
+import Network.Protocol.ChainSeek.Types (ChainSeek, Query (..), SchemaVersion (..), SomeTag (..), TagEq (..))
 import Network.TypedProtocol.Codec (Codec)
 import qualified Plutus.V1.Ledger.Api as Plutus
 import Text.Read (Read (..), pfail)
@@ -142,7 +142,7 @@ instance Show Base16 where
   show = show . encodeBase16 . unBase16
 
 instance Read Base16 where
-  readPrec = either (const pfail) (pure . Base16) . decodeBase16 . encodeUtf8 . traceShowId =<< readPrec
+  readPrec = either (const pfail) (pure . Base16) . decodeBase16 . encodeUtf8 =<< readPrec
 
 instance IsString Base16 where
   fromString = either (error . T.unpack) Base16 . decodeBase16 . encodeUtf8 . T.pack
@@ -295,117 +295,154 @@ type RuntimeChainSeekServer = ChainSeekServer Move ChainPoint ChainPoint
 type RuntimeChainSeekCodec m = Codec RuntimeChainSeek DeserializeError m LBS.ByteString
 
 runtimeChainSeekCodec :: Applicative m => RuntimeChainSeekCodec m
-runtimeChainSeekCodec = codecChainSeek putMove getMove putResult getResult putError getError put get put get
+runtimeChainSeekCodec = codecChainSeek
 
-putMove :: SomeQuery Move -> Put
-putMove (SomeQuery move) = case move of
-  Fork m1 m2 -> do
-    putWord8 0x01
-    putMove $ SomeQuery m1
-    putMove $ SomeQuery m2
+instance Query Move where
+  data Tag Move err result where
+    TagFork
+      :: Tag Move err1 result1
+      -> Tag Move err2 result2
+      -> Tag Move (These err1 err2) (These result1 result2)
+    TagAdvanceSlots :: Tag Move Void ()
+    TagAdvanceBlocks :: Tag Move Void ()
+    TagIntersect :: Tag Move IntersectError ()
+    TagFindConsumingTx :: Tag Move UTxOError Transaction
+    TagFindTx :: Tag Move TxError Transaction
 
-  AdvanceSlots slots -> do
-    putWord8 0x02
-    put slots
+  tagFromQuery = \case
+    Fork m1 m2        -> TagFork (tagFromQuery m1) (tagFromQuery m2)
+    AdvanceSlots _    -> TagAdvanceSlots
+    AdvanceBlocks _   -> TagAdvanceBlocks
+    Intersect _       -> TagIntersect
+    FindConsumingTx _ -> TagFindConsumingTx
+    FindTx _          -> TagFindTx
 
-  AdvanceBlocks blocks -> do
-    putWord8 0x03
-    put blocks
+  tagEq = curry \case
+    (TagFork m1 m2, TagFork m3 m4)           ->
+      case (,) <$> tagEq m1 m3 <*> tagEq m2 m4 of
+        Nothing           -> Nothing
+        Just (Refl, Refl) -> Just Refl
+    -- Please don't refactor this to use a single catch-all wildcard pattern.
+    -- The idea of doing it this way is to cause an incomplete pattern match
+    -- warning when a new 'Tag' constructor is added.
+    (TagFork _ _, _)                         -> Nothing
+    (TagAdvanceSlots, TagAdvanceSlots)       -> Just Refl
+    (TagAdvanceSlots, _)                     -> Nothing
+    (TagAdvanceBlocks, TagAdvanceBlocks)     -> Just Refl
+    (TagAdvanceBlocks, _)                    -> Nothing
+    (TagIntersect, TagIntersect)             -> Just Refl
+    (TagIntersect, _)                        -> Nothing
+    (TagFindConsumingTx, TagFindConsumingTx) -> Just Refl
+    (TagFindConsumingTx, _)                  -> Nothing
+    (TagFindTx, TagFindTx)                   -> Just Refl
+    (TagFindTx, _)                           -> Nothing
 
-  FindConsumingTx txOutRef -> do
-    putWord8 0x04
-    put txOutRef
-
-  Intersect points -> do
-    putWord8 0x05
-    put points
-
-  FindTx txId -> do
-    putWord8 0x06
-    put txId
-
-getMove :: Get (SomeQuery Move)
-getMove = do
-  tag <- getWord8
-  case tag of
-    0x01 -> do
-      SomeQuery m1 <- getMove
-      SomeQuery m2 <- getMove
-      pure $ SomeQuery $ Fork m1 m2
-    0x02 -> SomeQuery . AdvanceSlots <$> get
-    0x03 -> SomeQuery . AdvanceBlocks <$> get
-    0x04 -> SomeQuery . FindConsumingTx <$> get
-    0x05 -> SomeQuery . Intersect <$> get
-    0x06 -> SomeQuery . Intersect <$> get
-    _ -> fail $ "Invalid move tag " <> show tag
-
-putResult :: forall err result. Move err result -> result -> Put
-putResult = \case
-  Fork m1 m2 -> \case
-    This r1 -> do
+  putTag = \case
+    TagFork t1 t2 -> do
       putWord8 0x01
-      putResult m1 r1
-    That r2 -> do
-      putWord8 0x02
-      putResult m2 r2
-    These r1 r2 -> do
-      putWord8 0x03
-      putResult m1 r1
-      putResult m2 r2
-  AdvanceSlots _ -> mempty
-  AdvanceBlocks _ -> mempty
-  FindConsumingTx _ -> put
-  FindTx _ -> put
-  Intersect _ -> mempty
+      putTag t1
+      putTag t2
+    TagAdvanceSlots -> putWord8 0x02
+    TagAdvanceBlocks -> putWord8 0x03
+    TagFindConsumingTx -> putWord8 0x04
+    TagIntersect -> putWord8 0x05
+    TagFindTx -> putWord8 0x06
 
-getResult :: forall err result. Move err result -> Get result
-getResult = \case
-  Fork m1 m2    -> do
+  putQuery = \case
+    Fork m1 m2 -> do
+      putQuery m1
+      putQuery m2
+    AdvanceSlots slots -> put slots
+    AdvanceBlocks blocks -> put blocks
+    FindConsumingTx utxo -> put utxo
+    Intersect points -> put points
+    FindTx txId -> put txId
+
+  getTag = do
     tag <- getWord8
     case tag of
-      0x01 -> This <$> getResult m1
-      0x02 -> That <$> getResult m2
-      0x03 -> These <$> getResult m1 <*> getResult m2
-      _    -> fail $ "Invalid align result tag " <> show tag
-  AdvanceSlots _ -> get
-  AdvanceBlocks _ -> get
-  FindConsumingTx _ -> get
-  FindTx _ -> get
-  Intersect _ -> get
+      0x01 -> do
+        SomeTag m1 <- getTag
+        SomeTag m2 <- getTag
+        pure $ SomeTag $ TagFork m1 m2
+      0x02 -> pure $ SomeTag TagAdvanceSlots
+      0x03 -> pure $ SomeTag TagAdvanceBlocks
+      0x04 -> pure $ SomeTag TagFindConsumingTx
+      0x05 -> pure $ SomeTag TagIntersect
+      0x06 -> pure $ SomeTag TagIntersect
+      _ -> fail $ "Invalid move tag " <> show tag
 
-putError :: forall err result. Move err result -> err -> Put
-putError = \case
-  Fork m1 m2 -> \case
-    This e1 -> do
-      putWord8 0x01
-      putError m1 e1
-    That e2 -> do
-      putWord8 0x02
-      putError m2 e2
-    These e1 e2 -> do
-      putWord8 0x03
-      putError m1 e1
-      putError m2 e2
-  AdvanceSlots _ -> put
-  AdvanceBlocks _ -> put
-  FindConsumingTx _ -> put
-  FindTx _ -> put
-  Intersect _ -> put
+  getQuery = \case
+    TagFork t1 t2      -> Fork <$> getQuery t1 <*> getQuery t2
+    TagAdvanceSlots    -> AdvanceSlots <$> get
+    TagAdvanceBlocks   -> AdvanceBlocks <$> get
+    TagFindConsumingTx -> FindConsumingTx <$> get
+    TagIntersect       -> Intersect <$> get
+    TagFindTx          -> FindTx <$> get
 
-getError :: forall err result. Move err result -> Get err
-getError = \case
-  Fork m1 m2    -> do
-    tag <- getWord8
-    case tag of
-      0x01 -> This <$> getError m1
-      0x02 -> That <$> getError m2
-      0x03 -> These <$> getError m1 <*> getError m2
-      _    -> fail $ "Invalid fork error tag " <> show tag
-  AdvanceSlots _ -> get
-  AdvanceBlocks _ -> get
-  FindConsumingTx _ -> get
-  FindTx _ -> get
-  Intersect _ -> get
+  putResult = \case
+    TagFork t1 t2 -> \case
+      This r1 -> do
+        putWord8 0x01
+        putResult t1 r1
+      That r2 -> do
+        putWord8 0x02
+        putResult t2 r2
+      These r1 r2 -> do
+        putWord8 0x03
+        putResult t1 r1
+        putResult t2 r2
+    TagAdvanceSlots -> mempty
+    TagAdvanceBlocks -> mempty
+    TagFindConsumingTx -> put
+    TagFindTx -> put
+    TagIntersect -> mempty
+
+  getResult = \case
+    TagFork t1 t2    -> do
+      tag <- getWord8
+      case tag of
+        0x01 -> This <$> getResult t1
+        0x02 -> That <$> getResult t2
+        0x03 -> These <$> getResult t1 <*> getResult t2
+        _    -> fail $ "Invalid align result tag " <> show tag
+    TagAdvanceSlots -> get
+    TagAdvanceBlocks -> get
+    TagFindConsumingTx -> get
+    TagFindTx -> get
+    TagIntersect -> get
+
+  putErr = \case
+    TagFork t1 t2 -> \case
+      This e1 -> do
+        putWord8 0x01
+        putErr t1 e1
+      That e2 -> do
+        putWord8 0x02
+        putErr t2 e2
+      These e1 e2 -> do
+        putWord8 0x03
+        putErr t1 e1
+        putErr t2 e2
+    TagAdvanceSlots -> put
+    TagAdvanceBlocks -> put
+    TagFindConsumingTx -> put
+    TagFindTx -> put
+    TagIntersect -> put
+
+  getErr = \case
+    TagFork t1 t2    -> do
+      tag <- getWord8
+      case tag of
+        0x01 -> This <$> getErr t1
+        0x02 -> That <$> getErr t2
+        0x03 -> These <$> getErr t1 <*> getErr t2
+        _    -> fail $ "Invalid fork error tag " <> show tag
+    TagAdvanceSlots -> get
+    TagAdvanceBlocks -> get
+    TagFindConsumingTx -> get
+    TagFindTx -> get
+    TagIntersect -> get
 
 schemaVersion1_0 :: SchemaVersion
 schemaVersion1_0 = SchemaVersion "marlowe-chain-sync-1.0"

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -633,33 +633,49 @@ instance Binary SlotConfig where
 
 data ChainSyncQuery delimiter err result where
   GetSlotConfig :: ChainSyncQuery Void () SlotConfig
+  GetSecurityParameter :: ChainSyncQuery Void () Int
 
 instance Query.IsQuery ChainSyncQuery where
   data Tag ChainSyncQuery delimiter err result where
     TagGetSlotConfig :: Query.Tag ChainSyncQuery Void () SlotConfig
-  tagEq TagGetSlotConfig TagGetSlotConfig = Just Query.Refl
+    TagGetSecurityParameter :: Query.Tag ChainSyncQuery Void () Int
+  tagEq TagGetSlotConfig TagGetSlotConfig               = Just Query.Refl
+  tagEq TagGetSlotConfig _                              = Nothing
+  tagEq TagGetSecurityParameter TagGetSecurityParameter = Just Query.Refl
+  tagEq TagGetSecurityParameter _                       = Nothing
   putTag = \case
-    TagGetSlotConfig -> putWord8 0x01
+    TagGetSlotConfig        -> putWord8 0x01
+    TagGetSecurityParameter -> putWord8 0x02
   getTag = do
     word <- getWord8
     case word of
       0x01 -> pure $ Query.SomeTag TagGetSlotConfig
+      0x02 -> pure $ Query.SomeTag TagGetSecurityParameter
       _    -> fail "Invalid ChainSyncQuery tag"
   putQuery = \case
-    GetSlotConfig -> mempty
+    GetSlotConfig        -> mempty
+    GetSecurityParameter -> mempty
   getQuery = \case
-    TagGetSlotConfig -> pure GetSlotConfig
+    TagGetSlotConfig        -> pure GetSlotConfig
+    TagGetSecurityParameter -> pure GetSecurityParameter
   putDelimiter = \case
-    TagGetSlotConfig -> absurd
+    TagGetSlotConfig        -> absurd
+    TagGetSecurityParameter -> absurd
   getDelimiter = \case
-    TagGetSlotConfig -> fail "no delimiter defined"
+    TagGetSlotConfig        -> fail "no delimiter defined"
+    TagGetSecurityParameter -> fail "no delimiter defined"
   putErr = \case
-    TagGetSlotConfig -> put
+    TagGetSlotConfig        -> put
+    TagGetSecurityParameter -> put
   getErr = \case
-    TagGetSlotConfig -> get
+    TagGetSlotConfig        -> get
+    TagGetSecurityParameter -> get
   putResult = \case
-    TagGetSlotConfig -> put
+    TagGetSlotConfig        -> put
+    TagGetSecurityParameter -> put
   getResult = \case
-    TagGetSlotConfig -> get
+    TagGetSlotConfig        -> get
+    TagGetSecurityParameter -> get
   tagFromQuery = \case
-    GetSlotConfig -> TagGetSlotConfig
+    GetSlotConfig        -> TagGetSlotConfig
+    GetSecurityParameter -> TagGetSecurityParameter

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -3,7 +3,61 @@
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-module Language.Marlowe.Runtime.ChainSync.Api where
+module Language.Marlowe.Runtime.ChainSync.Api
+  ( Address(..)
+  , AssetId(..)
+  , Assets(..)
+  , BlockHeader(..)
+  , BlockHeaderHash(..)
+  , BlockNo(..)
+  , CertIx(..)
+  , ChainPoint
+  , Credential(..)
+  , Datum(..)
+  , DatumHash(..)
+  , IntersectError(..)
+  , Lovelace(..)
+  , Metadata
+  , Move(..)
+  , PaymentKeyHash(..)
+  , PolicyId(..)
+  , Quantity(..)
+  , Redeemer(..)
+  , RuntimeChainSeek
+  , RuntimeChainSeekClient
+  , RuntimeChainSeekCodec
+  , RuntimeChainSeekServer
+  , ScriptHash(..)
+  , SlotNo(..)
+  , StakeReference(..)
+  , TokenName(..)
+  , Tokens(..)
+  , Transaction(..)
+  , TransactionInput(..)
+  , TransactionOutput(..)
+  , TxError(..)
+  , TxId(..)
+  , TxIx(..)
+  , TxOutRef(..)
+  , UTxOError(..)
+  , ValidityRange(..)
+  , WithGenesis(..)
+  , fromCardanoStakeAddressPointer
+  , fromDatum
+  , fromPlutusData
+  , isAfter
+  , paymentCredential
+  , runtimeChainSeekCodec
+  , schemaVersion1_0
+  , stakeReference
+  , toCardanoAddress
+  , toDatum
+  , toPlutusData
+  , module Network.Protocol.ChainSeek.Types
+  , module Network.Protocol.ChainSeek.Client
+  , module Network.Protocol.ChainSeek.Server
+  , module Network.Protocol.ChainSeek.Codec
+  ) where
 
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.Shelley as Cardano
@@ -22,13 +76,13 @@ import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.These (These (..))
 import Data.Void (Void)
-import Data.Word (Word16, Word32, Word64)
+import Data.Word (Word16, Word64)
 import GHC.Generics (Generic)
 import GHC.Natural (Natural)
-import Network.Protocol.ChainSeek.Client (ChainSeekClient, ClientStIdle)
-import Network.Protocol.ChainSeek.Codec (DeserializeError, codecChainSeek)
-import Network.Protocol.ChainSeek.Server (ChainSeekServer)
-import Network.Protocol.ChainSeek.Types (ChainSeek, Query (..), SchemaVersion (..), SomeTag (..), TagEq (..))
+import Network.Protocol.ChainSeek.Client
+import Network.Protocol.ChainSeek.Codec
+import Network.Protocol.ChainSeek.Server
+import Network.Protocol.ChainSeek.Types
 import Network.TypedProtocol.Codec (Codec)
 import qualified Plutus.V1.Ledger.Api as Plutus
 
@@ -221,16 +275,6 @@ newtype Lovelace = Lovelace { unLovelace :: Word64 }
   deriving stock (Show, Eq, Ord, Generic)
   deriving newtype (Num, Integral, Real, Enum, Bounded, Binary)
 
-newtype Magic = Magic { unMagic :: Word32 }
-  deriving stock (Show, Eq, Ord, Generic)
-  deriving newtype (Num, Integral, Real, Enum, Bounded, Binary)
-
-data NetworkId
-  = Mainnet
-  | Testnet Magic
-  deriving stock (Show, Eq, Ord, Generic)
-  deriving anyclass (Binary)
-
 newtype Address = Address { unAddress :: ByteString }
   deriving stock (Eq, Ord, Generic)
   deriving newtype (Binary)
@@ -328,6 +372,10 @@ data Move err result where
   -- | Advance to the block containing a transaction.
   FindTx :: TxId -> Move TxError Transaction
 
+deriving instance Show (Move err result)
+deriving instance Eq (Move err result)
+deriving instance Ord (Move err result)
+
 -- | Reasons a 'FindConsumingTx' request can be rejected.
 data UTxOError
   = UTxONotFound
@@ -350,8 +398,6 @@ data IntersectError = IntersectionNotFound
 type RuntimeChainSeek = ChainSeek Move ChainPoint ChainPoint
 
 type RuntimeChainSeekClient = ChainSeekClient Move ChainPoint ChainPoint
-
-type RuntimeClientStIdle = ClientStIdle Move ChainPoint ChainPoint
 
 type RuntimeChainSeekServer = ChainSeekServer Move ChainPoint ChainPoint
 

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -432,7 +432,7 @@ instance Query Move where
       0x03 -> pure $ SomeTag TagAdvanceBlocks
       0x04 -> pure $ SomeTag TagFindConsumingTx
       0x05 -> pure $ SomeTag TagIntersect
-      0x06 -> pure $ SomeTag TagIntersect
+      0x06 -> pure $ SomeTag TagFindTx
       _ -> fail $ "Invalid move tag " <> show tag
 
   getQuery = \case

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -148,10 +148,11 @@ data Metadata
 
 -- | An input of a transaction.
 data TransactionInput = TransactionInput
-  { txId     :: !TxId             -- ^ The txId of the TransactionOutput this input consumes.
-  , txIx     :: !TxIx             -- ^ The txIx of the TransactionOutput this input consumes.
-  , address  :: !Address          -- ^ The address of the TransactionOutput this input consumes.
-  , redeemer :: !(Maybe Redeemer) -- ^ The script redeemer dataum for this input (if one was provided).
+  { txId       :: !TxId             -- ^ The txId of the TransactionOutput this input consumes.
+  , txIx       :: !TxIx             -- ^ The txIx of the TransactionOutput this input consumes.
+  , address    :: !Address          -- ^ The address of the TransactionOutput this input consumes.
+  , datumBytes :: !(Maybe Datum)    -- ^ The script datum for this input
+  , redeemer   :: !(Maybe Redeemer) -- ^ The script redeemer dataum for this input (if one was provided).
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (Binary)

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL.hs
@@ -21,7 +21,6 @@ import Cardano.Binary (ToCBOR (toCBOR), toStrictByteString, unsafeDeserialize')
 import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Babbage.Tx as Babbage
-import Control.Arrow ((&&&))
 import Control.Foldl (Fold (Fold))
 import qualified Control.Foldl as Fold
 import Data.ByteString (ByteString)
@@ -343,7 +342,7 @@ performFindConsumingTxs utxos point = do
   -- did any of the queries indicate that a result should be awaited?
   let encounteredWaits = waits > 0
 
-  case (not $ Map.null aborts, txsFromEarliestBlock, waits > 0) of
+  pure case (not $ Map.null aborts, txsFromEarliestBlock, encounteredWaits) of
     -- There were no errors, no consuming Txs were found, and there were UTxOs to
     -- wait for. In this case, the client should wait for results.
     (False, Nothing, True)              -> MoveWait

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE StrictData            #-}
+
+module Language.Marlowe.Runtime.ChainSync.QueryServer where
+
+import Cardano.Api (AnyCardanoEra (..), CardanoMode, ConsensusMode (..), ConsensusModeIsMultiEra (..), EraInMode (..),
+                    GenesisParameters (..), QueryInEra (..), QueryInMode (..), QueryInShelleyBasedEra (..),
+                    ShelleyBasedEra (..), toEraInMode)
+import qualified Cardano.Api as Cardano
+import Control.Concurrent.Async (Concurrently (Concurrently, runConcurrently))
+import Control.Concurrent.STM (STM, atomically)
+import Control.Exception (SomeException, catch)
+import Control.Monad.Trans.Except (ExceptT (ExceptT), except, runExceptT, throwE, withExceptT)
+import Data.Void (Void, absurd)
+import Language.Marlowe.Runtime.ChainSync.Api (ChainSyncQuery (..), SlotConfig (..))
+import Network.Protocol.Query.Server (QueryServer (..), ServerStInit (..), ServerStNext (..), ServerStPage (..))
+import Network.Protocol.Query.Types (StNextKind (..))
+import Ouroboros.Network.Protocol.LocalStateQuery.Type (AcquireFailure)
+import System.IO (hPutStrLn, stderr)
+
+newtype RunQueryServer m = RunQueryServer (forall a. QueryServer ChainSyncQuery m a -> IO a)
+
+data ChainSyncQueryServerDependencies = ChainSyncQueryServerDependencies
+  { acceptRunQueryServer :: IO (RunQueryServer IO)
+  , queryLocalNodeState
+      :: forall result
+       . Maybe Cardano.ChainPoint
+      -> QueryInMode CardanoMode result
+      -> IO (Either AcquireFailure result)
+  }
+
+newtype ChainSyncQueryServer = ChainSyncQueryServer
+  { runChainSyncQueryServer :: IO Void
+  }
+
+mkChainSyncQueryServer :: ChainSyncQueryServerDependencies -> STM ChainSyncQueryServer
+mkChainSyncQueryServer ChainSyncQueryServerDependencies{..} = do
+  let
+    runChainSyncQueryServer = do
+      runQueryServer <- acceptRunQueryServer
+      Worker{..} <- atomically $ mkWorker WorkerDependencies {..}
+      runConcurrently $
+        Concurrently (runWorker `catch` catchWorker) *> Concurrently runChainSyncQueryServer
+  pure $ ChainSyncQueryServer { runChainSyncQueryServer }
+
+catchWorker :: SomeException -> IO ()
+catchWorker = hPutStrLn stderr . ("Query worker crashed with exception: " <>) . show
+
+data WorkerDependencies = WorkerDependencies
+  { runQueryServer      :: RunQueryServer IO
+  , queryLocalNodeState
+      :: forall result
+       . Maybe Cardano.ChainPoint
+      -> QueryInMode CardanoMode result
+      -> IO (Either AcquireFailure result)
+  }
+
+newtype Worker = Worker
+  { runWorker :: IO ()
+  }
+
+mkWorker :: WorkerDependencies -> STM Worker
+mkWorker WorkerDependencies{..} =
+  let
+    RunQueryServer run = runQueryServer
+  in
+    pure Worker { runWorker = run server }
+
+  where
+    server :: QueryServer ChainSyncQuery IO ()
+    server = QueryServer $ pure $ ServerStInit \case
+      GetSlotConfig -> queryGetSlotConfig
+
+    queryGetSlotConfig :: IO (ServerStNext ChainSyncQuery 'CanReject Void () SlotConfig IO ())
+    queryGetSlotConfig = do
+      result <- runExceptT do
+        AnyCardanoEra era <- withExceptT (const ())
+          $ ExceptT
+          $ queryLocalNodeState Nothing
+          $ QueryCurrentEra CardanoModeIsMultiEra
+        eraInMode <- case toEraInMode era CardanoMode of
+          Nothing        -> throwE ()
+          Just eraInMode -> pure eraInMode
+        shelleyBasedEra <- case eraInMode of
+          ByronEraInCardanoMode   -> throwE ()
+          ShelleyEraInCardanoMode -> pure ShelleyBasedEraShelley
+          AllegraEraInCardanoMode -> pure ShelleyBasedEraAllegra
+          MaryEraInCardanoMode    -> pure ShelleyBasedEraMary
+          AlonzoEraInCardanoMode  -> pure ShelleyBasedEraAlonzo
+          BabbageEraInCardanoMode -> pure ShelleyBasedEraBabbage
+        result <- withExceptT (const ())
+          $ ExceptT
+          $ queryLocalNodeState Nothing
+          $ QueryInEra eraInMode
+          $ QueryInShelleyBasedEra shelleyBasedEra QueryGenesisParameters
+        GenesisParameters{..} <- withExceptT (const ()) $ except result
+        pure $ SlotConfig protocolParamSystemStart protocolParamSlotLength
+
+      case result of
+        Left _ -> pure $ SendMsgReject () ()
+        Right slotConfig -> pure $ SendMsgNextPage slotConfig Nothing $ ServerStPage
+          { recvMsgDone = pure ()
+          , recvMsgRequestNext = absurd
+          }

--- a/marlowe-protocols-test/LICENSE
+++ b/marlowe-protocols-test/LICENSE
@@ -1,0 +1,53 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/marlowe-protocols-test/NOTICE
+++ b/marlowe-protocols-test/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/marlowe-protocols-test/marlowe-protocols-test.cabal
+++ b/marlowe-protocols-test/marlowe-protocols-test.cabal
@@ -1,0 +1,54 @@
+cabal-version: 2.4
+name: marlowe-protocols-test
+version: 0.0.0.0
+synopsis:
+  Testing library for Marlowe protocols
+bug-reports: https://github.com/input-output-hk/marlowe-cardano/issues
+license: Apache-2.0
+author: Jamie Bertram
+maintainer: jamie.bertram@iohk.io
+stability: experimental
+category: Language
+license-files:
+  LICENSE
+  NOTICE
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/marlowe-cardano
+  subdir: marlowe-protocols-test
+
+library
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  default-extensions:
+    BlockArguments
+    DeriveAnyClass
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    ExplicitForAll
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    NamedFieldPuns
+    NumericUnderscores
+    OverloadedStrings
+    RecordWildCards
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TupleSections
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities
+  exposed-modules:
+    Test.Network.Protocol.ChainSeek
+  build-depends:
+      base >= 4.9 && < 5
+    , hspec
+    , marlowe-protocols

--- a/marlowe-protocols-test/src/Test/Network/Protocol/ChainSeek.hs
+++ b/marlowe-protocols-test/src/Test/Network/Protocol/ChainSeek.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE GADTs          #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes     #-}
+
+module Test.Network.Protocol.ChainSeek where
+
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Network.Protocol.ChainSeek.Client
+import Network.Protocol.ChainSeek.Types
+import Test.Hspec (Expectation, expectationFailure)
+
+data ChainSeekServerScript q point tip (m :: * -> *) a
+  = RejectHandshake [SchemaVersion] a
+  | ConfirmHandshake (ServerStIdleScript q point tip m a)
+
+data ServerStIdleScript q point tip (m :: * -> *) a where
+  ExpectDone :: a -> ServerStIdleScript q point tip m a
+  ExpectQuery :: q err result -> ServerStNextScript q point tip 'StCanAwait err result m a -> ServerStIdleScript q point tip m a
+
+data ServerStNextScript q point tip k err result m a where
+  RejectQuery :: err -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip k err result m a
+  RollForward :: result -> point -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip k err result m a
+  RollBackward :: point -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip k err result m a
+  Wait :: ServerStNextScript q point tip 'StMustReply err result m a -> ServerStNextScript q point tip 'StCanAwait err result m a
+
+runClientWithScript
+  :: forall q point tip m a b
+   . (MonadIO m, Query q)
+  => (forall err result. q err result -> String)
+  -> (forall err result. q err result -> q err result -> Expectation)
+  -> ChainSeekServerScript q point tip m a
+  -> ChainSeekClient q point tip m b
+  -> m (a, b)
+runClientWithScript showQuery assertQueryEq script ChainSeekClient{..} = do
+  SendMsgRequestHandshake _ ClientStHandshake{..} <- runChainSeekClient
+  case script of
+    RejectHandshake versions a -> (a,) <$> recvMsgHandshakeRejected versions
+    ConfirmHandshake script'   -> runIdle script' =<< recvMsgHandshakeConfirmed
+  where
+    runIdle
+      :: ServerStIdleScript q point tip m a
+      -> ClientStIdle q point tip m b
+      -> m (a, b)
+    runIdle = \case
+      ExpectDone a -> \case
+        SendMsgDone b -> pure (a, b)
+        SendMsgQueryNext move _ _ -> liftIO do
+          expectationFailure $ "Expected MsgDone, got MsgQueryNext (" <> showQuery move <> ")"
+          undefined
+      ExpectQuery move script' -> \case
+        SendMsgDone _ -> liftIO do
+          expectationFailure $ "Expected MsgQueryNext (" <> showQuery move <> "), got MsgDone"
+          undefined
+        SendMsgQueryNext move' next waitNext -> do
+          let tag = tagFromQuery move
+          let tag' = tagFromQuery move'
+          case tagEq tag tag' of
+            Just Refl -> do
+              liftIO $ move' `assertQueryEq` move
+              runNext next waitNext script'
+            Nothing -> do
+              liftIO $ expectationFailure $ "Expected " <> showQuery move <> ", got " <> showQuery move'
+              undefined
+
+    runNext
+      :: ClientStNext q err result point tip m b
+      -> m (ClientStNext q err result point tip m b)
+      -> ServerStNextScript q point tip k err result m a
+      -> m (a, b)
+    runNext ClientStNext{..} waitNext = \case
+      RejectQuery err tip script' -> runIdle script' =<< recvMsgQueryRejected err tip
+      RollForward result point tip script' -> runIdle script' =<< recvMsgRollForward result point tip
+      RollBackward point tip script' -> runIdle script' =<< recvMsgRollBackward point tip
+      Wait script' -> do
+        next' <- waitNext
+        runNext next' (pure next') script'

--- a/marlowe-protocols-test/src/Test/Network/Protocol/ChainSeek.hs
+++ b/marlowe-protocols-test/src/Test/Network/Protocol/ChainSeek.hs
@@ -15,7 +15,7 @@ data ChainSeekServerScript q point tip (m :: * -> *) a
   | ConfirmHandshake (ServerStIdleScript q point tip m a)
 
 data ServerStIdleScript q point tip (m :: * -> *) a where
-  Assert :: m () -> ServerStIdleScript q point tip m a -> ServerStIdleScript q point tip m a
+  Do :: m () -> ServerStIdleScript q point tip m a -> ServerStIdleScript q point tip m a
   Halt :: a -> ServerStIdleScript q point tip m a
   ExpectDone :: a -> ServerStIdleScript q point tip m a
   ExpectQuery :: q err result -> ServerStNextScript q point tip 'StCanAwait err result m a -> ServerStIdleScript q point tip m a
@@ -45,7 +45,7 @@ runClientWithScript showQuery assertQueryEq script ChainSeekClient{..} = do
       -> ClientStIdle q point tip m b
       -> m (a, Maybe b)
     runIdle = \case
-      Assert action script' -> \client -> action *> runIdle script' client
+      Do action script' -> \client -> action *> runIdle script' client
       Halt a -> \_ -> pure (a, Nothing)
       ExpectDone a -> \case
         SendMsgDone b -> pure (a, Just b)

--- a/marlowe-protocols/marlowe-protocols.cabal
+++ b/marlowe-protocols/marlowe-protocols.cabal
@@ -47,21 +47,22 @@ library
     -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wredundant-constraints -Widentities
   exposed-modules:
-    Network.Channel,
-    Network.Protocol.Driver,
-    Network.Protocol.ChainSeek.Client,
-    Network.Protocol.ChainSeek.Codec,
-    Network.Protocol.ChainSeek.Server,
-    Network.Protocol.ChainSeek.Types,
-    Network.Protocol.Job.Client,
-    Network.Protocol.Job.Codec,
-    Network.Protocol.Job.Server,
-    Network.Protocol.Job.Types,
-    Network.Protocol.Query.Client,
-    Network.Protocol.Query.Types,
+    Network.Channel
+    Network.Protocol.Driver
+    Network.Protocol.ChainSeek.Client
+    Network.Protocol.ChainSeek.Codec
+    Network.Protocol.ChainSeek.Server
+    Network.Protocol.ChainSeek.Types
+    Network.Protocol.Job.Client
+    Network.Protocol.Job.Codec
+    Network.Protocol.Job.Server
+    Network.Protocol.Job.Types
+    Network.Protocol.Query.Client
+    Network.Protocol.Query.Types
     Network.Protocol.Codec
   build-depends:
       base >= 4.9 && < 5
+    , async
     , binary
     , bytestring
     , network

--- a/marlowe-protocols/marlowe-protocols.cabal
+++ b/marlowe-protocols/marlowe-protocols.cabal
@@ -58,6 +58,8 @@ library
     Network.Protocol.Job.Server
     Network.Protocol.Job.Types
     Network.Protocol.Query.Client
+    Network.Protocol.Query.Codec
+    Network.Protocol.Query.Server
     Network.Protocol.Query.Types
     Network.Protocol.Codec
   build-depends:

--- a/marlowe-protocols/src/Network/Protocol/ChainSeek/Client.hs
+++ b/marlowe-protocols/src/Network/Protocol/ChainSeek/Client.hs
@@ -64,6 +64,17 @@ data ClientStNext query err result point tip m a = ClientStNext
   , recvMsgRollBackward  :: point -> tip -> m (ClientStIdle query point tip m a)
   }
 
+mapClientStNext
+  :: (err' -> err)
+  -> (result' -> result)
+  -> ClientStNext q err result point tip m a
+  -> ClientStNext q err' result' point tip m a
+mapClientStNext cmapErr cmapResult ClientStNext{..} = ClientStNext
+  { recvMsgQueryRejected = recvMsgQueryRejected . cmapErr
+  , recvMsgRollForward = recvMsgRollForward . cmapResult
+  , recvMsgRollBackward
+  }
+
 -- | Transform the query, point, and tip types in the client.
 mapChainSeekClient
   :: forall query query' point point' tip tip' m a

--- a/marlowe-protocols/src/Network/Protocol/ChainSeek/Codec.hs
+++ b/marlowe-protocols/src/Network/Protocol/ChainSeek/Codec.hs
@@ -46,11 +46,13 @@ codecChainSeek = binaryCodec putMsg getMsg
 
     putMsg (ServerAgency (TokNext tag _)) (MsgRejectQuery err tip) = do
         putWord8 0x05
+        putTag $ coerceTag tag
         putErr (coerceTag tag) err
         put tip
 
     putMsg (ServerAgency (TokNext tag _)) (MsgRollForward result pos tip) = do
         putWord8 0x06
+        putTag $ coerceTag tag
         putResult (coerceTag tag) result
         put pos
         put tip

--- a/marlowe-protocols/src/Network/Protocol/ChainSeek/Codec.hs
+++ b/marlowe-protocols/src/Network/Protocol/ChainSeek/Codec.hs
@@ -5,43 +5,24 @@
 {-# LANGUAGE PolyKinds                 #-}
 {-# LANGUAGE RankNTypes                #-}
 
-module Network.Protocol.ChainSeek.Codec (DeserializeError, SomeQuery(..), codecChainSeek) where
+module Network.Protocol.ChainSeek.Codec (DeserializeError, codecChainSeek) where
 
 import Data.Binary
 import qualified Data.ByteString.Lazy as LBS
-import Network.Protocol.ChainSeek.Types (ChainSeek, ClientHasAgency (..), Message (..), ServerHasAgency (..),
-                                         TokNextKind (..))
+import Network.Protocol.ChainSeek.Types
 import Network.Protocol.Codec (DeserializeError, GetMessage, PutMessage, binaryCodec)
 import Network.TypedProtocol.Codec
 import Unsafe.Coerce (unsafeCoerce)
 
-data SomeQuery query = forall err result. SomeQuery (query err result)
-
 codecChainSeek
   :: forall query point tip m
-   . Applicative m
-  => (SomeQuery query -> Put)
-  -> Get (SomeQuery query)
-  -> (forall err result. query err result -> result -> Put)
-  -> (forall err result. query err result -> Get result)
-  -> (forall err result. query err result -> err -> Put)
-  -> (forall err result. query err result -> Get err)
-  -> (point -> Put)
-  -> Get point
-  -> (tip -> Put)
-  -> Get tip
-  -> Codec (ChainSeek query point tip) DeserializeError m LBS.ByteString
-codecChainSeek
-  encodeQuery
-  decodeQuery
-  encodeResult
-  decodeResult
-  encodeError
-  decodeError
-  encodePoint
-  decodePoint
-  encodeTip
-  decodeTip = binaryCodec putMsg getMsg
+   . ( Applicative m
+     , Query query
+     , Binary point
+     , Binary tip
+     )
+  => Codec (ChainSeek query point tip) DeserializeError m LBS.ByteString
+codecChainSeek = binaryCodec putMsg getMsg
   where
     putMsg :: PutMessage (ChainSeek query point tip)
     putMsg (ClientAgency TokInit) msg = case msg of
@@ -52,7 +33,9 @@ codecChainSeek
     putMsg (ClientAgency TokIdle) msg = case msg of
       MsgQueryNext query -> do
         putWord8 0x04
-        encodeQuery $ SomeQuery query
+        let tag = tagFromQuery query
+        putTag tag
+        putQuery query
       MsgDone            -> putWord8 0x09
 
     putMsg (ServerAgency TokHandshake) msg = case msg of
@@ -61,23 +44,21 @@ codecChainSeek
        putWord8 0x03
        put supportedVersions
 
-    putMsg (ServerAgency (TokNext query _)) (MsgRejectQuery err tip) = do
+    putMsg (ServerAgency (TokNext tag _)) (MsgRejectQuery err tip) = do
         putWord8 0x05
-        -- FIXME how to do this without unsafeCoerce?
-        encodeError (unsafeCoerce query) err
-        encodeTip tip
+        putErr (coerceTag tag) err
+        put tip
 
-    putMsg (ServerAgency (TokNext query _)) (MsgRollForward result pos tip) = do
+    putMsg (ServerAgency (TokNext tag _)) (MsgRollForward result pos tip) = do
         putWord8 0x06
-        -- FIXME how to do this without unsafeCoerce?
-        encodeResult (unsafeCoerce query) result
-        encodePoint pos
-        encodeTip tip
+        putResult (coerceTag tag) result
+        put pos
+        put tip
 
     putMsg (ServerAgency TokNext{}) (MsgRollBackward pos tip) = do
         putWord8 0x07
-        encodePoint pos
-        encodeTip tip
+        put pos
+        put tip
 
     putMsg (ServerAgency TokNext{}) MsgWait = putWord8 0x08
 
@@ -92,8 +73,8 @@ codecChainSeek
         (0x01, ClientAgency TokInit) -> SomeMessage . MsgRequestHandshake <$> get
 
         (0x04, ClientAgency TokIdle) -> do
-          SomeQuery query <- decodeQuery
-          pure $ SomeMessage $ MsgQueryNext query
+          SomeTag qtag <- getTag
+          SomeMessage . MsgQueryNext <$> getQuery qtag
 
         (0x09, ClientAgency TokIdle) -> pure $ SomeMessage MsgDone
 
@@ -101,22 +82,28 @@ codecChainSeek
 
         (0x03, ServerAgency TokHandshake) -> SomeMessage . MsgRejectHandshake <$> get
 
-        (0x05, ServerAgency (TokNext query _)) -> do
-          err <- decodeError (unsafeCoerce query)
-          tip <- decodeTip
-          -- FIXME how to do this without unsafeCoerce?
-          pure $ unsafeCoerce $ SomeMessage $ MsgRejectQuery err tip
+        (0x05, ServerAgency (TokNext qtag _)) -> do
+          SomeTag qtag' :: SomeTag query <- getTag
+          case tagEq (coerceTag qtag) qtag' of
+            Nothing -> fail "decoded query tag does not match expected query tag"
+            Just Refl -> do
+              err <- getErr qtag'
+              tip <- get
+              pure $ SomeMessage $ MsgRejectQuery err tip
 
-        (0x06, ServerAgency (TokNext query _)) -> do
-          result <- decodeResult (unsafeCoerce query)
-          point <- decodePoint
-          tip <- decodeTip
-          -- FIXME how to do this without unsafeCoerce?
-          pure $ SomeMessage $ unsafeCoerce $ MsgRollForward result point tip
+        (0x06, ServerAgency (TokNext qtag _)) -> do
+          SomeTag qtag' :: SomeTag query <- getTag
+          case tagEq (coerceTag qtag) qtag' of
+            Nothing -> fail "decoded query tag does not match expected query tag"
+            Just Refl -> do
+              result <- getResult qtag'
+              point <- get
+              tip <- get
+              pure $ SomeMessage $ MsgRollForward result point tip
 
         (0x07, ServerAgency (TokNext _ _)) -> do
-          point <- decodePoint
-          tip <- decodeTip
+          point <- get
+          tip <- get
           pure $ SomeMessage $ MsgRollBackward point tip
 
         (0x08, ServerAgency (TokNext _ TokCanAwait)) -> pure $ SomeMessage MsgWait
@@ -126,3 +113,10 @@ codecChainSeek
         (0x0b, ClientAgency TokPing) -> pure $ SomeMessage MsgPong
 
         _ -> fail $ "Unexpected tag " <> show tag
+
+    -- Unfortunately, the poly-kinded query parameter doesn't play nicely with
+    -- the `PeerHasAgency` type and it gets confused, thinking that 'query1'
+    -- and 'query' are unrelated types. So we have to coerce them (they will
+    -- absolutely be the same type constructor though).
+    coerceTag :: forall query1 err result. Tag query1 err result -> Tag query err result
+    coerceTag = unsafeCoerce

--- a/marlowe-protocols/src/Network/Protocol/Query/Types.hs
+++ b/marlowe-protocols/src/Network/Protocol/Query/Types.hs
@@ -13,7 +13,28 @@
 -- query is active.
 module Network.Protocol.Query.Types where
 
+import Data.Binary (Get, Put)
 import Network.TypedProtocol
+
+data SomeTag q = forall delimiter err result. SomeTag (Tag q delimiter err result)
+
+data TagEq delimiter delimiter' err err' result result' where
+  Refl :: TagEq delimiter delimiter err err result result
+
+class IsQuery (q :: * -> * -> * -> *) where
+  data Tag q :: * -> * -> * -> *
+  tagFromQuery :: q delimiter err result -> Tag q delimiter err result
+  tagEq :: Tag q delimiter err result -> Tag q delimiter' err' result' -> Maybe (TagEq delimiter delimiter' err err' result result')
+  putTag :: Tag q delimiter err result -> Put
+  getTag :: Get (SomeTag q)
+  putQuery :: q delimiter err result -> Put
+  getQuery :: Tag q delimiter err result -> Get (q delimiter err result)
+  putDelimiter :: Tag q delimiter err result -> delimiter -> Put
+  getDelimiter :: Tag q delimiter err result -> Get delimiter
+  putErr :: Tag q delimiter err result -> err -> Put
+  getErr :: Tag q delimiter err result -> Get err
+  putResult :: Tag q delimiter err result -> result -> Put
+  getResult :: Tag q delimiter err result -> Get result
 
 -- | A state kind for the query protocol.
 data Query (query :: * -> * -> * -> *) where
@@ -49,17 +70,17 @@ instance Protocol (Query query) where
       ('StNext 'CanReject delimiter err results)
 
     -- | Reject the query with an error message.
-    MsgReject :: query delimiter err results -> err -> Message (Query query)
+    MsgReject :: err -> Message (Query query)
       ('StNext 'CanReject delimiter err results)
       'StDone
 
     -- | Send the next page of results to the client
-    MsgNextPage :: query delimiter err results -> results -> Maybe delimiter -> Message (Query query)
+    MsgNextPage :: results -> Maybe delimiter -> Message (Query query)
       ('StNext nextKind delimiter err results)
       ('StPage delimiter err results)
 
     -- | Request the next page of results starting from the delimiter
-    MsgRequestNext :: query delimiter err result -> delimiter -> Message (Query query)
+    MsgRequestNext :: delimiter -> Message (Query query)
       ('StPage delimiter err results)
       ('StNext 'MustReply delimiter err results)
 
@@ -70,10 +91,10 @@ instance Protocol (Query query) where
 
   data ClientHasAgency st where
     TokInit :: ClientHasAgency 'StInit
-    TokPage :: query delimiter err results -> ClientHasAgency ('StPage delimiter err results)
+    TokPage :: Tag query delimiter err results -> ClientHasAgency ('StPage delimiter err results)
 
   data ServerHasAgency st where
-    TokNext :: TokNextKind k -> query delimiter err results -> ServerHasAgency ('StNext k delimiter err resutls)
+    TokNext :: TokNextKind k -> Tag query delimiter err results -> ServerHasAgency ('StNext k delimiter err results)
 
   data NobodyHasAgency st where
     TokDone :: NobodyHasAgency 'StDone

--- a/marlowe-runtime/app/Main.hs
+++ b/marlowe-runtime/app/Main.hs
@@ -1,8 +1,4 @@
 module Main where
 
-import qualified MyLib (someFunc)
-
 main :: IO ()
-main = do
-  putStrLn "Hello, Haskell!"
-  MyLib.someFunc
+main = undefined

--- a/marlowe-runtime/marlowe-follower/Main.hs
+++ b/marlowe-runtime/marlowe-follower/Main.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE GADTs #-}
+module Main where
+
+import Control.Concurrent.Async (race)
+import Control.Concurrent.STM (STM, atomically, retry)
+import Control.Exception (bracket, bracketOnError, throwIO)
+import Control.Monad (forever)
+import Data.Foldable (for_, traverse_)
+import Data.Void (Void)
+import Language.Marlowe.Runtime.ChainSync.Api (RuntimeChainSeekClient, WithGenesis (Genesis), runtimeChainSeekCodec)
+import Language.Marlowe.Runtime.Core.Api (ContractId, MarloweVersion (..), parseContractId)
+import Language.Marlowe.Runtime.History.Follower (ContractChanges (..), ContractStep (..), CreateStep (..),
+                                                  Follower (..), FollowerDependencies (..), SomeContractChanges (..),
+                                                  mkFollower)
+import Network.Channel (socketAsChannel)
+import Network.Protocol.ChainSeek.Client (chainSeekClientPeer)
+import Network.Protocol.Driver (mkDriver)
+import Network.Socket (AddrInfo (..), HostName, PortNumber, SocketType (..), close, connect, defaultHints, getAddrInfo,
+                       openSocket, withSocketsDo)
+import Network.TypedProtocol (runPeerWithDriver, startDState)
+import Options.Applicative (argument, auto, execParser, fullDesc, header, help, info, long, maybeReader, metavar,
+                            option, progDesc, short, strOption, value)
+import System.IO (hPrint, stderr)
+
+main :: IO ()
+main = run =<< getOptions
+
+run :: Options -> IO ()
+run Options{..} = withSocketsDo do
+  let hints = defaultHints { addrSocketType = Stream }
+  addr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show port)
+  bracket (open addr) close \socket -> do
+    let driver = mkDriver throwIO runtimeChainSeekCodec $ socketAsChannel socket
+    let
+      connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
+      connectToChainSeek client = fst <$> runPeerWithDriver driver peer (startDState driver)
+        where peer = chainSeekClientPeer Genesis client
+    Follower{..} <- atomically $ mkFollower FollowerDependencies{..}
+    Left result <- race runFollower (logChanges changes)
+    case result of
+      Left err -> hPrint stderr err
+      Right () -> pure ()
+  where
+    open addr = bracketOnError (openSocket addr) close \sock -> do
+      connect sock $ addrAddress addr
+      pure sock
+
+logChanges :: STM (Maybe SomeContractChanges) -> IO Void
+logChanges readChanges = forever do
+  SomeContractChanges version ContractChanges{..} <- atomically do
+    mchanges <- readChanges
+    maybe retry pure mchanges
+  for_ rollbackTo \slotNo -> do
+    putStrLn $ "Rollback to slot " <> show slotNo
+  (traverse_ . traverse_) (logStep version) steps
+
+logStep :: MarloweVersion v -> ContractStep v -> IO ()
+logStep version = \case
+  Create CreateStep{..} -> do
+    putStr "Create{scriptHash="
+    putStr $ show scriptHash
+    putStr ",datum="
+    putStr case version of
+      MarloweV1 -> show datum
+    putStr "}"
+  Transaction _ -> error "not implemented"
+  RedeemPayout _ -> error "not implemented"
+
+data Options = Options
+  { port       :: PortNumber
+  , host       :: HostName
+  , contractId :: ContractId
+  }
+
+getOptions :: IO Options
+getOptions = execParser $ info parser infoMod
+  where
+    parser = Options <$> portParser <*> hostParser <*> contractIdParser
+
+    portParser = option auto $ mconcat
+      [ long "port-number"
+      , short 'p'
+      , value 3715
+      , metavar "PORT_NUMBER"
+      , help "The port number of the chain seek server"
+      ]
+
+    hostParser = strOption $ mconcat
+      [ long "host"
+      , short 'p'
+      , value "127.0.0.1"
+      , metavar "HOST_NAME"
+      , help "The host name of the chain seek server"
+      ]
+
+    contractIdParser = argument (maybeReader parseContractId) $ mconcat
+      [ metavar "CONTRACT_ID"
+      , help "The UTxO that created the contract"
+      ]
+
+    infoMod = mconcat
+      [ fullDesc
+      , progDesc "Contract follower for Marlowe Runtime"
+      , header "marlowe-follower : a contract follower for the Marlowe Runtime."
+      ]

--- a/marlowe-runtime/marlowe-follower/Main.hs
+++ b/marlowe-runtime/marlowe-follower/Main.hs
@@ -9,6 +9,7 @@ import Data.Foldable (for_, traverse_)
 import Data.Void (Void)
 import Language.Marlowe.Runtime.ChainSync.Api (RuntimeChainSeekClient, WithGenesis (Genesis), runtimeChainSeekCodec)
 import Language.Marlowe.Runtime.Core.Api (ContractId, MarloweVersion (..), parseContractId)
+import qualified Language.Marlowe.Runtime.Core.Api as Core
 import Language.Marlowe.Runtime.History.Follower (ContractChanges (..), ContractStep (..), CreateStep (..),
                                                   Follower (..), FollowerDependencies (..), SomeContractChanges (..),
                                                   mkFollower)
@@ -35,6 +36,7 @@ run Options{..} = withSocketsDo do
       connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
       connectToChainSeek client = fst <$> runPeerWithDriver driver peer (startDState driver)
         where peer = chainSeekClientPeer Genesis client
+    let getMarloweVersion = Core.getMarloweVersion
     Follower{..} <- atomically $ mkFollower FollowerDependencies{..}
     Left result <- race runFollower (logChanges changes)
     case result of

--- a/marlowe-runtime/marlowe-follower/Main.hs
+++ b/marlowe-runtime/marlowe-follower/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+
 module Main where
 
 import Control.Concurrent.Async (race)

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -134,5 +134,7 @@ test-suite marlowe-runtime-test
     , marlowe-protocols
     , marlowe-protocols-test
     , marlowe-runtime
+    , plutus-tx
     , stm
+    , transformers
   build-tool-depends: hspec-discover:hspec-discover

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -135,6 +135,7 @@ test-suite marlowe-runtime-test
   build-depends:
       base >= 4.9 && < 5
     , async
+    , bytestring
     , containers
     , hspec
     , marlowe
@@ -143,6 +144,7 @@ test-suite marlowe-runtime-test
     , marlowe-protocols-test
     , marlowe-runtime
     , plutus-tx
+    , plutus-ledger-api
     , stm
     , time
     , transformers

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -78,6 +78,7 @@ library
     , marlowe-chain-sync
     , marlowe-protocols
     , plutus-ledger-api
+    , split
     , stm
     , text
     , typed-protocols
@@ -94,3 +95,23 @@ executable marlowed
   build-depends:
       base >= 4.9 && < 5
     , marlowe-runtime
+
+executable marlowe-follower
+  import: lang
+  hs-source-dirs:   marlowe-follower
+  main-is: Main.hs
+  other-modules:
+    Paths_marlowe_runtime
+  autogen-modules:
+    Paths_marlowe_runtime
+  build-depends:
+      base >= 4.9 && < 5
+    , async
+    , base16
+    , marlowe-protocols
+    , marlowe-runtime
+    , marlowe-chain-sync
+    , network
+    , typed-protocols
+    , optparse-applicative
+    , stm

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -81,6 +81,7 @@ library
     , split
     , stm
     , text
+    , time
     , transformers
     , typed-protocols
     , witherable
@@ -142,5 +143,6 @@ test-suite marlowe-runtime-test
     , marlowe-runtime
     , plutus-tx
     , stm
+    , time
     , transformers
   build-tool-depends: hspec-discover:hspec-discover

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -33,35 +33,54 @@ common lang
   default-language: Haskell2010
   default-extensions:
     BlockArguments
+    DeriveAnyClass
     DeriveFoldable
     DeriveFunctor
     DeriveGeneric
     DeriveLift
     DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    EmptyCase
     ExplicitForAll
     GeneralizedNewtypeDeriving
-    DeriveAnyClass
-    DerivingVia
-    DerivingStrategies
+    LambdaCase
+    NamedFieldPuns
+    NumericUnderscores
+    OverloadedStrings
     RecordWildCards
     ScopedTypeVariables
     StandaloneDeriving
     TypeApplications
+    TupleSections
   ghc-options:
     -Wall -Wnoncanonical-monad-instances
     -Wincomplete-uni-patterns -Wincomplete-record-updates
-    -Wredundant-constraints -Widentities
+    -Wredundant-constraints -Widentities -threaded
   if flag(defer-plugin-errors)
     ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
 library
   import: lang
   hs-source-dirs:   src
-  exposed-modules:  MyLib
+  exposed-modules:
+    Language.Marlowe.Runtime.Core.Api
   build-depends:
       base >= 4.9 && < 5
+    , aeson
+    , async
+    , binary
+    , bytestring
+    , containers
+    , marlowe
+    , marlowe-chain-sync
+    , marlowe-protocols
+    , stm
+    , text
+    , typed-protocols
+    , witherable
 
-executable marlowe-runtime
+executable marlowed
   import: lang
   hs-source-dirs:   app
   main-is: Main.hs
@@ -72,5 +91,3 @@ executable marlowe-runtime
   build-depends:
       base >= 4.9 && < 5
     , marlowe-runtime
-  ghc-options:
-    -threaded

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -81,6 +81,7 @@ library
     , split
     , stm
     , text
+    , transformers
     , typed-protocols
     , witherable
 
@@ -106,8 +107,11 @@ executable marlowe-follower
     Paths_marlowe_runtime
   build-depends:
       base >= 4.9 && < 5
+    , ansi-terminal
     , async
     , base16
+    , containers
+    , marlowe
     , marlowe-protocols
     , marlowe-runtime
     , marlowe-chain-sync
@@ -115,6 +119,8 @@ executable marlowe-follower
     , typed-protocols
     , optparse-applicative
     , stm
+    , text
+    , wl-pprint
 
 test-suite marlowe-runtime-test
   import: lang

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -81,6 +81,7 @@ library
     , split
     , stm
     , text
+    , these
     , time
     , transformers
     , typed-protocols

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -65,16 +65,19 @@ library
   hs-source-dirs:   src
   exposed-modules:
     Language.Marlowe.Runtime.Core.Api
+    Language.Marlowe.Runtime.History.Follower
   build-depends:
       base >= 4.9 && < 5
     , aeson
     , async
+    , base16
     , binary
     , bytestring
     , containers
     , marlowe
     , marlowe-chain-sync
     , marlowe-protocols
+    , plutus-ledger-api
     , stm
     , text
     , typed-protocols

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -115,3 +115,24 @@ executable marlowe-follower
     , typed-protocols
     , optparse-applicative
     , stm
+
+test-suite marlowe-runtime-test
+  import: lang
+  hs-source-dirs: test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+    Language.Marlowe.Runtime.History.FollowerSpec
+    Paths_marlowe_runtime
+  build-depends:
+      base >= 4.9 && < 5
+    , async
+    , containers
+    , hspec
+    , marlowe
+    , marlowe-chain-sync
+    , marlowe-protocols
+    , marlowe-protocols-test
+    , marlowe-runtime
+    , stm
+  build-tool-depends: hspec-discover:hspec-discover

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -70,6 +71,10 @@ data MarloweVersionTag
 data MarloweVersion (v :: MarloweVersionTag) where
   MarloweV1 :: MarloweVersion 'V1
 
+deriving instance Show (MarloweVersion v)
+deriving instance Eq (MarloweVersion v)
+deriving instance Ord (MarloweVersion v)
+
 class IsMarloweVersion (v :: MarloweVersionTag) where
   type Contract v :: *
   type Datum v :: *
@@ -95,15 +100,24 @@ data Transaction v = Transaction
   , output        :: TransactionOutput v
   }
 
+deriving instance Show (Transaction 'V1)
+deriving instance Eq (Transaction 'V1)
+
 data TransactionOutput v = TransactionOutput
   { payouts      :: [Payment v]
   , scriptOutput :: Maybe (TransactionScriptOutput v)
   }
 
+deriving instance Show (TransactionOutput 'V1)
+deriving instance Eq (TransactionOutput 'V1)
+
 data TransactionScriptOutput v = TransactionScriptOutput
   { utxo  :: TxOutRef
   , datum :: Datum v
   }
+
+deriving instance Show (TransactionScriptOutput 'V1)
+deriving instance Eq (TransactionScriptOutput 'V1)
 
 data SomeMarloweVersion = forall v. SomeMarloweVersion (MarloweVersion v)
 

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
+
+module Language.Marlowe.Runtime.Core.Api where
+
+import Data.Aeson (FromJSON (..), Result (..), ToJSON (..), Value (..), eitherDecode, encode, object, (.:), (.=))
+import Data.Aeson.Types (Parser, parse)
+import Data.Binary (Binary (..))
+import Data.Binary.Get (getWord32be)
+import Data.Binary.Put (putWord32be)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import qualified Language.Marlowe.Core.V1.Semantics as V1
+import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
+import Language.Marlowe.Runtime.ChainSync.Api (TxOutRef, ValidatorHash)
+
+newtype ContractId = ContractId { unContractId :: TxOutRef }
+  deriving stock (Show, Read, Eq, Ord, Generic)
+  deriving anyclass (Binary)
+
+data MarloweVersionTag
+  = V1
+
+data MarloweVersion (v :: MarloweVersionTag) where
+  MarloweV1 :: MarloweVersion 'V1
+
+class IsMarloweVersion (v :: MarloweVersionTag) where
+  type Contract v :: *
+  type State v :: *
+  type Params v :: *
+  type Redeemer v :: *
+  marloweVersion :: MarloweVersion v
+
+instance IsMarloweVersion 'V1 where
+  type Contract 'V1 = V1.Contract
+  type State 'V1 = V1.State
+  type Params 'V1 = V1.MarloweParams
+  type Redeemer 'V1 = [V1.Input]
+  marloweVersion = MarloweV1
+
+data Datum v = Datum
+  { datumContract :: Contract v
+  , datumParams   :: Params v
+  , datumState    :: State v
+  }
+
+contractToJSON :: MarloweVersion v -> Contract v -> Value
+contractToJSON = \case
+  MarloweV1 -> toJSON
+
+contractFromJSON :: MarloweVersion v -> Value -> Parser (Contract v)
+contractFromJSON = \case
+  MarloweV1 -> parseJSON
+
+stateToJSON :: MarloweVersion v -> State v -> Value
+stateToJSON = \case
+  MarloweV1 -> toJSON
+
+stateFromJSON :: MarloweVersion v -> Value -> Parser (State v)
+stateFromJSON = \case
+  MarloweV1 -> parseJSON
+
+paramsToJSON :: MarloweVersion v -> Params v -> Value
+paramsToJSON = \case
+  MarloweV1 -> toJSON
+
+paramsFromJSON :: MarloweVersion v -> Value -> Parser (Params v)
+paramsFromJSON = \case
+  MarloweV1 -> parseJSON
+
+redeemerToJSON :: MarloweVersion v -> Redeemer v -> Value
+redeemerToJSON = \case
+  MarloweV1 -> toJSON
+
+redeemerFromJSON :: MarloweVersion v -> Value -> Parser (Redeemer v)
+redeemerFromJSON = \case
+  MarloweV1 -> parseJSON
+
+datumToJSON :: MarloweVersion v -> Datum v -> Value
+datumToJSON v Datum{..} = object
+  [ "marloweContract" .= contractToJSON v datumContract
+  , "marloweParams" .= paramsToJSON v datumParams
+  , "marloweState" .= stateToJSON v datumState
+  ]
+
+datumFromJSON :: MarloweVersion v -> Value -> Parser (Datum v)
+datumFromJSON v json = do
+  obj <- parseJSON json
+  datumContract <- contractFromJSON v =<< obj .: "marloweContract"
+  datumParams <- paramsFromJSON v =<< obj .: "marloweParams"
+  datumState <- stateFromJSON v =<< obj .: "marloweState"
+  pure Datum{..}
+
+data SomeMarloweVersion = forall v. SomeMarloweVersion (MarloweVersion v)
+
+instance ToJSON (MarloweVersion v) where
+  toJSON = String . \case
+    MarloweV1 -> "v1"
+
+instance FromJSON SomeMarloweVersion where
+  parseJSON json = do
+    s :: Text <- parseJSON json
+    case s of
+      "v1" -> pure $ SomeMarloweVersion MarloweV1
+      _    -> fail "Invalid marlowe version"
+
+instance Binary SomeMarloweVersion where
+  put (SomeMarloweVersion v) = case v of
+    MarloweV1 -> putWord32be 0x01
+  get = getWord32be >>= \case
+    0x01 -> pure $ SomeMarloweVersion MarloweV1
+    _    -> fail "Invalid marlowe version bytes"
+
+
+data VersionedContract v = VersionedContract (MarloweVersion v) (Contract v)
+data SomeVersionedContract = forall v. SomeVersionedContract (VersionedContract v)
+
+instance ToJSON (VersionedContract v) where
+  toJSON (VersionedContract v c) = object
+    [ "version" .= v
+    , "contract" .= contractToJSON v c
+    ]
+
+instance FromJSON SomeVersionedContract where
+  parseJSON json = do
+    obj <- parseJSON json
+    SomeMarloweVersion v <- obj .: "version"
+    c <- contractFromJSON v =<< obj .: "contract"
+    pure $ SomeVersionedContract $ VersionedContract v c
+
+instance Binary SomeVersionedContract where
+  put (SomeVersionedContract (VersionedContract v c)) = do
+    put $ SomeMarloweVersion v
+    put $ encode $ contractToJSON v c
+  get = do
+    SomeMarloweVersion v <- get
+    bytes <- get
+    case eitherDecode bytes of
+      Left err -> fail err
+      Right json -> case parse (contractFromJSON v) json of
+        Error err -> fail err
+        Success c -> pure $ SomeVersionedContract $ VersionedContract v c
+
+data VersionedRedeemer v = VersionedRedeemer (MarloweVersion v) (Redeemer v)
+data SomeVersionedRedeemer = forall v. SomeVersionedRedeemer (VersionedRedeemer v)
+
+instance ToJSON (VersionedRedeemer v) where
+  toJSON (VersionedRedeemer v r) = object
+    [ "version" .= v
+    , "redeemer" .= redeemerToJSON v r
+    ]
+
+instance FromJSON SomeVersionedRedeemer where
+  parseJSON json = do
+    obj <- parseJSON json
+    SomeMarloweVersion v <- obj .: "version"
+    r <- redeemerFromJSON v =<< obj .: "redeemer"
+    pure $ SomeVersionedRedeemer $ VersionedRedeemer v r
+
+instance Binary SomeVersionedRedeemer where
+  put (SomeVersionedRedeemer (VersionedRedeemer v c)) = do
+    put $ SomeMarloweVersion v
+    put $ encode $ redeemerToJSON v c
+  get = do
+    SomeMarloweVersion v <- get
+    bytes <- get
+    case eitherDecode bytes of
+      Left err -> fail err
+      Right json -> case parse (redeemerFromJSON v) json of
+        Error err -> fail err
+        Success c -> pure $ SomeVersionedRedeemer $ VersionedRedeemer v c
+
+data VersionedDatum v = VersionedDatum (MarloweVersion v) (Datum v)
+data SomeVersionedDatum = forall v. SomeVersionedDatum (VersionedDatum v)
+
+instance ToJSON (VersionedDatum v) where
+  toJSON (VersionedDatum v d) = object
+    [ "version" .= v
+    , "datum" .= datumToJSON v d
+    ]
+
+instance FromJSON SomeVersionedDatum where
+  parseJSON json = do
+    obj <- parseJSON json
+    SomeMarloweVersion v <- obj .: "version"
+    d <- datumFromJSON v =<< obj .: "datum"
+    pure $ SomeVersionedDatum $ VersionedDatum v d
+
+instance Binary SomeVersionedDatum where
+  put (SomeVersionedDatum (VersionedDatum v c)) = do
+    put $ SomeMarloweVersion v
+    put $ encode $ datumToJSON v c
+  get = do
+    SomeMarloweVersion v <- get
+    bytes <- get
+    case eitherDecode bytes of
+      Left err -> fail err
+      Right json -> case parse (datumFromJSON v) json of
+        Error err -> fail err
+        Success c -> pure $ SomeVersionedDatum $ VersionedDatum v c
+
+getMarloweVersion :: ValidatorHash -> Maybe SomeMarloweVersion
+getMarloweVersion = error "not implemented"
+
+getScriptHash :: MarloweVersion v -> ValidatorHash
+getScriptHash = error "not implemented"

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -19,6 +19,7 @@ import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
+import Data.Time (UTCTime)
 import GHC.Generics (Generic)
 import qualified Language.Marlowe.Core.V1.Semantics as V1
 import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
@@ -80,12 +81,13 @@ instance IsMarloweVersion 'V1 where
   marloweVersion = MarloweV1
 
 data Transaction v = Transaction
-  { transactionId :: TxId
-  , contractId    :: ContractId
-  , blockHeader   :: BlockHeader
-  , validityRange :: ValidityRange
-  , redeemer      :: Redeemer v
-  , output        :: TransactionOutput v
+  { transactionId      :: TxId
+  , contractId         :: ContractId
+  , blockHeader        :: BlockHeader
+  , validityLowerBound :: UTCTime
+  , validityUpperBound :: UTCTime
+  , redeemer           :: Redeemer v
+  , output             :: TransactionOutput v
   }
 
 deriving instance Show (Transaction 'V1)
@@ -296,6 +298,3 @@ getMarloweVersion hash
 
 getScriptHashes :: MarloweVersion v -> Set ScriptHash
 getScriptHashes = mempty
-
-getRoleValidatorHashes :: MarloweVersion v -> Set ScriptHash
-getRoleValidatorHashes = mempty

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -50,20 +50,8 @@ renderTxOutRef TxOutRef{..} = mconcat
 parseContractId :: String -> Maybe ContractId
 parseContractId = fmap ContractId . parseTxOutRef
 
-parseTransactionId :: String -> Maybe TransactionId
-parseTransactionId = fmap TransactionId . parseTxOutRef
-
 renderContractId :: ContractId -> Text
 renderContractId = renderTxOutRef . unContractId
-
-renderTransactionId :: TransactionId -> Text
-renderTransactionId = renderTxOutRef . unTransactionId
-
--- | The ID of a transaction is the TxId and TxIx of the script UTxO that it
--- consumes.
-newtype TransactionId = TransactionId { unTransactionId :: TxOutRef }
-  deriving stock (Show, Eq, Ord, Generic)
-  deriving anyclass (Binary)
 
 data MarloweVersionTag
   = V1
@@ -92,7 +80,7 @@ instance IsMarloweVersion 'V1 where
   marloweVersion = MarloweV1
 
 data Transaction v = Transaction
-  { transactionId :: TransactionId
+  { transactionId :: TxId
   , contractId    :: ContractId
   , blockHeader   :: BlockHeader
   , validityRange :: ValidityRange
@@ -285,13 +273,21 @@ datumFromJSON :: MarloweVersion v -> Value -> Parser (Datum v)
 datumFromJSON = \case
   MarloweV1 -> parseJSON
 
-datumToData :: MarloweVersion v -> Datum v -> Chain.Datum
-datumToData = \case
+toChainDatum :: MarloweVersion v -> Datum v -> Chain.Datum
+toChainDatum = \case
   MarloweV1 -> Chain.toDatum
 
-datumFromData :: MarloweVersion v -> Chain.Datum -> Maybe (Datum v)
-datumFromData = \case
+fromChainDatum :: MarloweVersion v -> Chain.Datum -> Maybe (Datum v)
+fromChainDatum = \case
   MarloweV1 -> Chain.fromDatum
+
+toChainRedeemer :: MarloweVersion v -> Redeemer v -> Chain.Redeemer
+toChainRedeemer = \case
+  MarloweV1 -> Chain.toRedeemer
+
+fromChainRedeemer :: MarloweVersion v -> Chain.Redeemer -> Maybe (Redeemer v)
+fromChainRedeemer = \case
+  MarloweV1 -> Chain.fromRedeemer
 
 getMarloweVersion :: ScriptHash -> Maybe SomeMarloweVersion
 getMarloweVersion hash

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -24,7 +24,7 @@ import GHC.Generics (Generic)
 import qualified Language.Marlowe.Core.V1.Semantics as V1
 import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
 import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, ScriptHash, TokenName (..), TxId (..), TxIx (..),
-                                               TxOutRef (..), ValidityRange)
+                                               TxOutRef (..))
 import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
 import Text.Read (readMaybe)
 

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -294,7 +294,9 @@ datumFromData = \case
   MarloweV1 -> Chain.fromDatum
 
 getMarloweVersion :: ScriptHash -> Maybe SomeMarloweVersion
-getMarloweVersion _ = Nothing
+getMarloweVersion hash
+  | hash == "62c56ccfc6217aff5692e1d3ebe89c21053d31fc11882cb21bfdd307" = Just $ SomeMarloweVersion MarloweV1
+  | otherwise = Nothing
 
 getScriptHashes :: MarloweVersion v -> Set ScriptHash
 getScriptHashes = mempty

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
@@ -15,6 +15,7 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import Data.Traversable (for)
+import GHC.Show (showSpace)
 import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, ChainPoint, ChainSeekClient (..), ClientStHandshake (..),
                                                ClientStIdle (..), ClientStInit (..), ClientStNext (..), Move (..),
                                                RuntimeChainSeekClient, ScriptHash (..), SlotNo (..), TxError, TxId,
@@ -65,7 +66,9 @@ instance Show SomeContractChanges where
   showsPrec p (SomeContractChanges version changes) =
     showParen (p >= 11)
       ( showString "SomeContractChanges"
+      . showSpace
       . showsPrec 11 version
+      . showSpace
       . case version of
           MarloweV1 -> showsPrec 11 changes
       )

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE DuplicateRecordFields     #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes                #-}
+
+module Language.Marlowe.Runtime.History.Follower where
+
+import Control.Applicative ((<|>))
+import Control.Concurrent.STM (STM, TVar, atomically, newTVar, readTVar, writeTVar)
+import Control.Monad (guard)
+import Data.Foldable (asum)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import Data.Traversable (for)
+import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, Move (..), RuntimeChainSeekClient, RuntimeClientStIdle,
+                                               ScriptHash (..), SlotNo (..), TxError, TxId, TxOutRef (..),
+                                               WithGenesis (..), isAfter, schemaVersion1_0)
+import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
+import Language.Marlowe.Runtime.Core.Api (ContractId (..), Datum, MarloweVersion, PayoutDatum,
+                                          SomeMarloweVersion (SomeMarloweVersion), Transaction, datumFromData,
+                                          getMarloweVersion)
+import Network.Protocol.ChainSeek.Client (ChainSeekClient (..), ClientStHandshake (..), ClientStIdle (..),
+                                          ClientStInit (..), ClientStNext (..))
+
+data CreateStep v = CreateStep
+  { datum      :: Datum v
+  , scriptHash :: ScriptHash
+  }
+
+data SomeCreateStep = forall v. SomeCreateStep (MarloweVersion v) (CreateStep v)
+
+data RedeemStep v = RedeemStep
+  { utxo        :: TxOutRef
+  , redeemingTx :: TxId
+  , datum       :: PayoutDatum v
+  }
+
+data ContractStep v
+  = Create (CreateStep v)
+  | Transaction (Transaction v)
+  | RedeemPayout (RedeemStep v)
+  -- TODO add TimeoutElapsed
+
+data ContractChanges v = ContractChanges
+  { steps      :: Map BlockHeader [ContractStep v]
+  , rollbackTo :: Maybe SlotNo
+  }
+
+data SomeContractChanges = forall v. SomeContractChanges (MarloweVersion v) (ContractChanges v)
+
+instance Semigroup (ContractChanges v) where
+  ContractChanges{..} <> c2 = c2' { steps = Map.unionWith (<>) steps2 steps }
+    where
+      c2'@ContractChanges{steps=steps2} = maybe c2 (flip applyRollback c2) rollbackTo
+
+instance Monoid (ContractChanges v) where
+  mempty = ContractChanges Map.empty Nothing
+
+applyRollback :: SlotNo -> ContractChanges v -> ContractChanges v
+applyRollback slotNo ContractChanges{..} = ContractChanges
+  { steps = steps'
+  , rollbackTo = asum
+      [ guard (Map.null steps') *> (min (Just slotNo) rollbackTo <|> Just slotNo)
+      , rollbackTo
+      ]
+  }
+  where
+    steps' = Map.filterWithKey (const . not . isAfter slotNo) steps
+
+data FollowerDependencies = FollowerDependencies
+  { contractId         :: ContractId
+  , connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
+  }
+
+data Follower = Follower
+  { runFollower :: IO (Either ContractHistoryError ())
+  , changes     :: STM (Maybe SomeContractChanges)
+  }
+
+data ContractHistoryError
+  = HansdshakeFailed
+  | FindTxFailed TxError
+  | ExtractContractFailed ExtractCreationError
+  deriving stock (Show, Eq, Ord)
+
+data ExtractCreationError
+  = TxIxNotFound
+  | ByronAddress
+  | NonScriptAddress
+  | InvalidScriptHash
+  | NoDatum
+  | InvalidDatum
+  deriving stock (Show, Eq, Ord)
+
+data ContractChangesTVar v = ContractChangesTVar (MarloweVersion v) (TVar (ContractChanges v))
+data SomeContractChangesTVar = forall v. SomeContractChangesTVar (ContractChangesTVar v)
+
+mkFollower :: FollowerDependencies -> STM Follower
+mkFollower FollowerDependencies{..} = do
+  someChangesVar <- newTVar Nothing
+  let
+    stInit = SendMsgRequestHandshake schemaVersion1_0 handshake
+    handshake = ClientStHandshake
+      { recvMsgHandshakeRejected = \_ -> pure $ Left HansdshakeFailed
+      , recvMsgHandshakeConfirmed = findContract
+      }
+
+    findContract = do
+      let move = FindTx $ txId $ unContractId contractId
+      pure $ SendMsgQueryNext move handleContract (pure handleContract)
+
+    handleContract = ClientStNext
+      { recvMsgQueryRejected = \err _ -> pure $ SendMsgDone $ Left $ FindTxFailed err
+      , recvMsgRollForward = \tx point _ -> case point of
+          Genesis -> error "transaction detected at Genesis"
+          At blockHeader -> case exctractCreation contractId tx of
+            Left err ->
+              pure $ SendMsgDone $ Left $ ExtractContractFailed err
+            Right (SomeCreateStep version create) -> do
+              changesVar <- atomically do
+                changesVar <- newTVar ContractChanges
+                  { steps = Map.singleton blockHeader [Create create]
+                  , rollbackTo = Nothing
+                  }
+                writeTVar someChangesVar
+                  $ Just
+                  $ SomeContractChangesTVar
+                  $ ContractChangesTVar version changesVar
+                pure changesVar
+              let scriptUTxO = Just $ unContractId contractId
+              let payoutUTxOs = mempty
+              followContract FollowerState{..}
+      , recvMsgRollBackward = \_ _ -> findContract
+      }
+
+  pure Follower
+    { runFollower = connectToChainSeek $ ChainSeekClient do
+        putStrLn $ "Following contract " <> show contractId
+        pure stInit
+    , changes = do
+        mChangesVar <- readTVar someChangesVar
+        for mChangesVar \(SomeContractChangesTVar (ContractChangesTVar version changesVar)) -> do
+          changes <- readTVar changesVar
+          writeTVar changesVar mempty
+          pure $ SomeContractChanges version changes
+    }
+
+data FollowerState v = FollowerState
+  { version     :: MarloweVersion v
+  , create      :: CreateStep v
+  , contractId  :: ContractId
+  , changesVar  :: TVar (ContractChanges v)
+  , scriptUTxO  :: Maybe TxOutRef
+  , payoutUTxOs :: Set TxOutRef
+  }
+
+exctractCreation :: ContractId -> Chain.Transaction -> Either ExtractCreationError SomeCreateStep
+exctractCreation contractId tx = do
+  Chain.TransactionOutput{address, datum=mdatum} <- getOutput (txIx $ unContractId contractId) tx
+  scriptHash <- getScriptHash address
+  SomeMarloweVersion version <- maybe (Left InvalidScriptHash) Right $ getMarloweVersion scriptHash
+  txDatum <- maybe (Left NoDatum) Right mdatum
+  datum <- maybe (Left InvalidDatum) Right $ datumFromData version txDatum
+  pure $ SomeCreateStep version CreateStep{..}
+
+getScriptHash :: Chain.Address -> Either ExtractCreationError ScriptHash
+getScriptHash address = do
+  credential <- maybe (Left ByronAddress) Right $ Chain.paymentCredential address
+  case credential of
+    Chain.ScriptCredential scriptHash -> pure scriptHash
+    _                                 -> Left NonScriptAddress
+
+getOutput :: Chain.TxIx -> Chain.Transaction -> Either ExtractCreationError Chain.TransactionOutput
+getOutput (Chain.TxIx i) Chain.Transaction{..} = go i outputs
+  where
+    go _ []        = Left TxIxNotFound
+    go 0 (x : _)   = Right x
+    go i' (_ : xs) = go (i' - 1) xs
+
+followContract :: FollowerState v -> IO (RuntimeClientStIdle IO (Either ContractHistoryError ()))
+followContract _ = pure $ SendMsgDone $ Right ()

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
@@ -134,9 +134,7 @@ mkFollower FollowerDependencies{..} = do
       }
 
   pure Follower
-    { runFollower = connectToChainSeek $ ChainSeekClient do
-        putStrLn $ "Following contract " <> show contractId
-        pure stInit
+    { runFollower = connectToChainSeek $ ChainSeekClient $ pure stInit
     , changes = do
         mChangesVar <- readTVar someChangesVar
         for mChangesVar \(SomeContractChangesTVar (ContractChangesTVar version changesVar)) -> do

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
@@ -184,7 +184,7 @@ mkFollower deps@FollowerDependencies{..} = do
       { recvMsgQueryRejected = \err _ -> failWith $ FindTxFailed err
       , recvMsgRollForward = \tx point _ -> case point of
           Genesis -> error "transaction detected at Genesis"
-          At blockHeader -> case exctractCreation deps tx of
+          At blockHeader -> case extractCreation deps tx of
             Left err ->
               failWith $ ExtractContractFailed err
             Right (SomeCreateStep version create@CreateStep{..}) -> do
@@ -243,8 +243,8 @@ data FollowerStateClosed v = FollowerStateClosed
   , previousState :: PreviousState (ClosedPreviousState v)
   }
 
-exctractCreation :: FollowerDependencies -> Chain.Transaction -> Either ExtractCreationError SomeCreateStep
-exctractCreation FollowerDependencies{..} tx@Chain.Transaction{inputs, validityRange} = do
+extractCreation :: FollowerDependencies -> Chain.Transaction -> Either ExtractCreationError SomeCreateStep
+extractCreation FollowerDependencies{..} tx@Chain.Transaction{inputs, validityRange} = do
   Chain.TransactionOutput{ address = scriptAddress, datum = mdatum } <-
     getOutput (txIx $ unContractId contractId) tx
   scriptHash <- getScriptHash scriptAddress
@@ -534,6 +534,7 @@ wouldCloseContract version validityLowerBound validityUpperBound redeemer datum 
     in
       marloweContract == V1.Close || case V1.computeTransaction input marloweState marloweContract of
         V1.TransactionOutput{..} -> txOutContract == V1.Close
+        -- TODO log a warning here when adding structured logging.
         _                        -> False
 
 

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
@@ -13,11 +13,14 @@ import Control.Concurrent.STM (STM, TVar, atomically, modifyTVar, newTVar, readT
 import Control.Monad (guard, when)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..))
+import Control.Monad.Trans.Writer.CPS (WriterT, runWriterT, tell)
+import Data.Bifunctor (first)
 import Data.Foldable (asum, find, for_)
+import Data.Functor (void)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
-import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Traversable (for)
@@ -31,14 +34,15 @@ import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, ChainPoint, ChainSee
                                                schemaVersion1_0, slotToUTCTime)
 import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
 import Language.Marlowe.Runtime.Core.Api (ContractId (..), Datum, IsMarloweVersion (Redeemer), MarloweVersion (..),
-                                          MarloweVersionTag (..), PayoutDatum, SomeMarloweVersion (..),
+                                          MarloweVersionTag (..), Payout (..), PayoutDatum, SomeMarloweVersion (..),
                                           Transaction (..), TransactionOutput (..), TransactionScriptOutput (..),
-                                          fromChainDatum, fromChainRedeemer)
+                                          fromChainDatum, fromChainPayoutDatum, fromChainRedeemer)
 import Plutus.V1.Ledger.Api (POSIXTime (POSIXTime))
 
 data CreateStep v = CreateStep
-  { datum         :: Datum v
-  , scriptAddress :: Chain.Address
+  { datum               :: Datum v
+  , scriptAddress       :: Chain.Address
+  , payoutValidatorHash :: ScriptHash
   }
 
 deriving instance Show (CreateStep 'V1)
@@ -110,7 +114,7 @@ applyRollback slotNo ContractChanges{..} = ContractChanges
 
 data FollowerDependencies = FollowerDependencies
   { contractId         :: ContractId
-  , getMarloweVersion  :: ScriptHash -> Maybe SomeMarloweVersion
+  , getMarloweVersion  :: ScriptHash -> Maybe (SomeMarloweVersion, ScriptHash)
   , connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
   , slotConfig         :: SlotConfig
   }
@@ -125,7 +129,9 @@ data ContractHistoryError
   | FindTxFailed TxError
   | ExtractContractFailed ExtractCreationError
   | FollowScriptUTxOFailed UTxOError
+  | FollowPayoutUTxOsFailed (Map Chain.TxOutRef UTxOError)
   | ExtractMarloweTransactionFailed ExtractMarloweTransactionError
+  | PayoutUTxONotFound Chain.TxOutRef
   deriving stock (Show, Eq, Ord)
 
 data ExtractCreationError
@@ -144,6 +150,8 @@ data ExtractMarloweTransactionError
   | InvalidRedeemer
   | NoTransactionDatum
   | InvalidTransactionDatum
+  | NoPayoutDatum TxOutRef
+  | InvalidPayoutDatum TxOutRef
   | InvalidValidityRange
   deriving stock (Show, Eq, Ord)
 
@@ -179,10 +187,9 @@ mkFollower deps@FollowerDependencies{..} = do
                   $ SomeContractChangesTVar
                   $ ContractChangesTVar version changesVar
                 pure changesVar
-              let scriptUTxO = unContractId contractId
-              let payoutUTxOs = mempty
-              let prevDatum = datum
-              followContract FollowerState{..}
+              let payouts = mempty
+              let scriptOutput = TransactionScriptOutput (unContractId contractId) datum
+              followContract FollowerContext{..} FollowerState{..}
       , recvMsgRollBackward = \_ _ -> error "Rolled back from genesis"
       }
 
@@ -196,16 +203,19 @@ mkFollower deps@FollowerDependencies{..} = do
           pure $ SomeContractChanges version changes
     }
 
+data FollowerContext v = FollowerContext
+  { version             :: MarloweVersion v
+  , create              :: CreateStep v
+  , contractId          :: ContractId
+  , changesVar          :: TVar (ContractChanges v)
+  , scriptAddress       :: Chain.Address
+  , payoutValidatorHash :: ScriptHash
+  , slotConfig          :: SlotConfig
+  }
+
 data FollowerState v = FollowerState
-  { version       :: MarloweVersion v
-  , create        :: CreateStep v
-  , contractId    :: ContractId
-  , changesVar    :: TVar (ContractChanges v)
-  , prevDatum     :: Datum v
-  , scriptUTxO    :: TxOutRef
-  , payoutUTxOs   :: Set TxOutRef
-  , scriptAddress :: Chain.Address
-  , slotConfig    :: SlotConfig
+  { payouts      :: Map Chain.TxOutRef (Payout v)
+  , scriptOutput :: TransactionScriptOutput v
   }
 
 exctractCreation :: FollowerDependencies -> Chain.Transaction -> Either ExtractCreationError SomeCreateStep
@@ -213,7 +223,7 @@ exctractCreation FollowerDependencies{..} tx@Chain.Transaction{inputs, validityR
   Chain.TransactionOutput{ address = scriptAddress, datum = mdatum } <-
     getOutput (txIx $ unContractId contractId) tx
   scriptHash <- getScriptHash scriptAddress
-  SomeMarloweVersion version <- note InvalidScriptHash $ getMarloweVersion scriptHash
+  (SomeMarloweVersion version, payoutValidatorHash) <-note InvalidScriptHash $ getMarloweVersion scriptHash
   let
     wouldCloseContract' mdatum' mredeemer = fromMaybe False do
       datum <- fromChainDatum version =<< mdatum'
@@ -248,32 +258,85 @@ getOutput (Chain.TxIx i) Chain.Transaction{..} = go i outputs
     go i' (_ : xs) = go (i' - 1) xs
 
 followContract
-  :: FollowerState v
+  :: FollowerContext v
+  -> FollowerState v
   -> IO (ClientStIdle Move ChainPoint ChainPoint IO (Either ContractHistoryError ()))
-followContract state@FollowerState{..} = do
-  let move = FindConsumingTx scriptUTxO
-  pure $ SendMsgQueryNext move (followNext state) (pure (followNext state))
+followContract context state@FollowerState{..} = do
+  let move = FindConsumingTxs $ Set.insert scriptUTxO $ Map.keysSet payouts
+  pure $ SendMsgQueryNext move (followNext context state) (pure (followNext context state))
+  where
+    scriptUTxO = let TransactionScriptOutput{..} = scriptOutput in utxo
 
 followNext
-  :: FollowerState v
-  -> ClientStNext Move Chain.UTxOError Chain.Transaction ChainPoint ChainPoint IO (Either ContractHistoryError ())
-followNext state@FollowerState{..} = ClientStNext
-  { recvMsgQueryRejected = \err _ -> failWith $ FollowScriptUTxOFailed err
-  , recvMsgRollForward = \tx point _ -> case point of
+  :: forall v
+   . FollowerContext v
+  -> FollowerState v
+  -> ClientStNext Move (Map Chain.TxOutRef Chain.UTxOError) (Map Chain.TxOutRef Chain.Transaction) ChainPoint ChainPoint IO (Either ContractHistoryError ())
+followNext context@FollowerContext{..} state@FollowerState{..} = ClientStNext
+  { recvMsgQueryRejected = \err _ -> failWith case Map.lookup scriptUTxO err of
+      Nothing   -> FollowPayoutUTxOsFailed err
+      Just err' -> FollowScriptUTxOFailed err'
+  , recvMsgRollForward = \txs point _ -> case point of
       Genesis -> error "transaction detected at Genesis"
-      At blockHeader -> case extractMarloweTransaction version prevDatum slotConfig contractId scriptAddress scriptUTxO blockHeader tx of
-        Left err -> failWith $ ExtractMarloweTransactionFailed err
-        Right marloweTx@Transaction{output} -> do
-          let changes = mempty { steps = Map.singleton blockHeader [ApplyTransaction marloweTx] }
-          atomically $ modifyTVar changesVar (<> changes)
-          let TransactionOutput{..} = output
-          case scriptOutput of
-            Nothing -> pure $ SendMsgDone $ Right ()
-            Just TransactionScriptOutput{..} -> do
-              -- TODO read payouts to payout validator
-              followContract state { scriptUTxO = utxo, prevDatum = datum }
+      At blockHeader -> do
+        let result = runWriterT (processTxs blockHeader context state txs)
+        case result of
+          Left err -> failWith err
+          Right (mOutput, changes) -> do
+            let
+              nextState :: FollowerState v -> FollowerState v
+              nextState state' = state' { payouts = Map.withoutKeys payouts $ Map.keysSet txs }
+            atomically $ modifyTVar changesVar (<> changes)
+            case mOutput of
+              Nothing -> followContract context $ nextState state
+              Just (TransactionOutput newPayouts mScriptOutput) -> case mScriptOutput of
+                Nothing            -> pure $ SendMsgDone $ Right ()
+                Just scriptOutput' -> followContract context $ nextState $ state { scriptOutput = scriptOutput', payouts = Map.union payouts newPayouts }
   , recvMsgRollBackward = \_ _ -> error "not implemented"
   }
+  where
+    scriptUTxO = let TransactionScriptOutput{..} = scriptOutput in utxo
+
+processTxs
+  :: BlockHeader
+  -> FollowerContext v
+  -> FollowerState v
+  -> Map TxOutRef Chain.Transaction
+  -> WriterT (ContractChanges v) (Either ContractHistoryError) (Maybe (TransactionOutput v))
+processTxs blockHeader context state@FollowerState{..} txs = do
+  void $ Map.traverseWithKey (processPayout blockHeader state) $ Map.delete scriptUTxO txs
+  traverse (processScriptTx blockHeader context state) $ Map.lookup scriptUTxO txs
+  where
+    scriptUTxO = let TransactionScriptOutput{..} = scriptOutput in utxo
+
+processPayout
+  :: BlockHeader
+  -> FollowerState v
+  -> TxOutRef
+  -> Chain.Transaction
+  -> WriterT (ContractChanges v) (Either ContractHistoryError) ()
+processPayout blockHeader  FollowerState{..} utxo Chain.Transaction{..} = case Map.lookup utxo payouts of
+  Nothing -> lift $ Left $ PayoutUTxONotFound utxo
+  Just Payout{..} -> do
+    let redeemingTx = txId
+    tellStep blockHeader $ RedeemPayout $ RedeemStep{..}
+
+processScriptTx
+  :: BlockHeader
+  -> FollowerContext v
+  -> FollowerState v
+  -> Chain.Transaction
+  -> WriterT (ContractChanges v) (Either ContractHistoryError) (TransactionOutput v)
+processScriptTx blockHeader FollowerContext{..} FollowerState{..} tx = do
+  let TransactionScriptOutput utxo prevDatum = scriptOutput
+  marloweTx@Transaction{output} <- lift
+    $ first ExtractMarloweTransactionFailed
+    $ extractMarloweTransaction version prevDatum slotConfig contractId scriptAddress payoutValidatorHash utxo blockHeader tx
+  tellStep blockHeader $ ApplyTransaction marloweTx
+  pure output
+
+tellStep :: BlockHeader -> ContractStep v -> WriterT (ContractChanges v) (Either ContractHistoryError) ()
+tellStep blockHeader step = tell mempty { steps = Map.singleton blockHeader [step] }
 
 extractMarloweTransaction
   :: MarloweVersion v
@@ -281,11 +344,12 @@ extractMarloweTransaction
   -> SlotConfig
   -> ContractId
   -> Chain.Address
+  -> Chain.ScriptHash
   -> TxOutRef
   -> BlockHeader
   -> Chain.Transaction
   -> Either ExtractMarloweTransactionError (Transaction v)
-extractMarloweTransaction version prevDatum slotConfig contractId scriptAddress consumedUTxO blockHeader Chain.Transaction{..} = do
+extractMarloweTransaction version prevDatum slotConfig contractId scriptAddress payoutValidatorHash consumedUTxO blockHeader Chain.Transaction{..} = do
   let transactionId = txId
   Chain.TransactionInput { redeemer = mRedeemer } <-
     note TxInNotFound $ find (consumesUTxO consumedUTxO) inputs
@@ -307,7 +371,14 @@ extractMarloweTransaction version prevDatum slotConfig contractId scriptAddress 
       let txIx = Chain.TxIx ix
       let utxo = Chain.TxOutRef{..}
       pure TransactionScriptOutput{..}
-  let payouts = [] -- TODO
+  let
+    payoutOutputs = Map.filter (isToScriptHash payoutValidatorHash)
+      $ Map.fromList
+      $ (\(txIx, output) -> (Chain.TxOutRef{..}, output)) <$> zip [0..] outputs
+  payouts <- flip Map.traverseWithKey payoutOutputs \txOut Chain.TransactionOutput{datum=mPayoutDatum, assets} -> do
+    rawPayoutDatum <- note (NoPayoutDatum txOut) mPayoutDatum
+    payoutDatum <- note (InvalidPayoutDatum txOut) $ fromChainPayoutDatum version rawPayoutDatum
+    pure $ Payout assets payoutDatum
   let output = TransactionOutput{..}
   pure Transaction{..}
 
@@ -324,6 +395,11 @@ wouldCloseContract version validityLowerBound validityUpperBound redeemer datum 
         V1.TransactionOutput{..} -> txOutContract == V1.Close
         _                        -> False
 
+
+isToScriptHash :: Chain.ScriptHash -> Chain.TransactionOutput -> Bool
+isToScriptHash toScriptHash Chain.TransactionOutput{..} = case Chain.paymentCredential address of
+  Just (Chain.ScriptCredential hash) -> hash == toScriptHash
+  _                                  -> False
 
 isToAddress :: Chain.Address -> Chain.TransactionOutput -> Bool
 isToAddress toAddress Chain.TransactionOutput{..} = address == toAddress

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
@@ -23,7 +23,7 @@ import qualified Language.Marlowe.Core.V1.Semantics as V1
 import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
 import Language.Marlowe.Runtime.ChainSync.Api (ChainPoint, ChainSeekClient, Move (..), ScriptHash, SlotConfig (..),
                                                TransactionOutput (address), TxError (..), TxId, TxOutRef (..),
-                                               UTxOError (..), WithGenesis (..), toDatum)
+                                               UTxOError (..), WithGenesis (..), hoistChainSeekClient, toDatum)
 import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
 import Language.Marlowe.Runtime.Core.Api (ContractId (..), MarloweVersion (..), SomeMarloweVersion (..),
                                           Transaction (..), TransactionOutput (..), TransactionScriptOutput (..),
@@ -32,7 +32,6 @@ import Language.Marlowe.Runtime.History.Follower (ContractChanges (..), Contract
                                                   CreateStep (..), ExtractCreationError (..),
                                                   ExtractMarloweTransactionError (..), Follower (..),
                                                   FollowerDependencies (..), SomeContractChanges (..), mkFollower)
-import Network.Protocol.ChainSeek.Client (hoistChainSeekClient)
 import qualified PlutusTx.AssocMap as AMap
 import Test.Hspec (Expectation, Spec, it, shouldBe)
 import Test.Network.Protocol.ChainSeek (ChainSeekServerScript (..), ServerStIdleScript (..), ServerStNextScript (..),
@@ -557,6 +556,7 @@ runFollowerTest marloweVersions' script = do
     let slotZeroTime = posixSecondsToUTCTime 0
     let slotLength = secondsToNominalDiffTime 1
     let slotConfig = SlotConfig{..}
+    let securityParameter = 2160
     follower <- mkFollower FollowerDependencies{..}
     pure (resultVar, follower)
   let

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE GADTs          #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes     #-}
+
+module Language.Marlowe.Runtime.History.FollowerSpec where
+
+import Control.Concurrent.Async (concurrently)
+import Control.Concurrent.STM (atomically, newEmptyTMVar, putTMVar, takeTMVar)
+import Data.Maybe (fromJust)
+import qualified Data.Set as Set
+import Language.Marlowe.Runtime.ChainSync.Api (ChainPoint, ChainSeekClient, Move (..), ScriptHash,
+                                               TransactionOutput (..), TxError (TxNotFound), TxId, TxOutRef (..),
+                                               WithGenesis (..))
+import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
+import Language.Marlowe.Runtime.Core.Api (ContractId (..), MarloweVersion (..), SomeMarloweVersion (SomeMarloweVersion),
+                                          parseContractId)
+import Language.Marlowe.Runtime.History.Follower (ContractHistoryError (..), ExtractCreationError (..), Follower (..),
+                                                  FollowerDependencies (..), SomeContractChanges, mkFollower)
+import Test.Hspec (Expectation, Spec, it, shouldBe)
+import Test.Network.Protocol.ChainSeek (ChainSeekServerScript (..), ServerStIdleScript (..), ServerStNextScript (..),
+                                        runClientWithScript)
+
+spec :: Spec
+spec = do
+  it "terminates with HansdshakeFailed" checkHandshakeRejected
+  it "terminates with FindTxFailed" checkFindTxFailed
+  it "terminates with TxIxNotFound" checkTxIxNotFound
+  it "terminates with ByronAddress" checkByronAddress
+  it "terminates with NonScriptAddress" checkNonScriptAddress
+  it "terminates with InvalidScriptHash" checkInvalidScriptHash
+  it "terminates with NoDatum" checkNoDatum
+  it "terminates with InvalidDatum" checkInvalidDatum
+  it "terminates with NotCreationTransaction" checkNotCreationTransaction
+
+testContractId :: ContractId
+testContractId = fromJust $ parseContractId "036e9b4cfdd668f9682d9153950980d7b065455f29b3b47923b2572bdd791e69#0"
+
+testScriptAddress :: Chain.Address
+testScriptAddress = "7045da42055944c69f7b1c7840fc15bd0d05ff5e9097f5267b705acf8e"
+
+testScriptHash :: Chain.ScriptHash
+testScriptHash = "45da42055944c69f7b1c7840fc15bd0d05ff5e9097f5267b705acf8e"
+
+marloweVersions :: [(ScriptHash, SomeMarloweVersion)]
+marloweVersions = [(testScriptHash, SomeMarloweVersion MarloweV1)]
+
+createTxId :: TxId
+createTxId = txId $ unContractId testContractId
+
+createTx :: Chain.Transaction
+createTx =
+  let
+    txId = createTxId
+    validityRange = Chain.Unbounded
+    metadata = Nothing
+    inputs = mempty
+    outputs = [createOutput]
+    mintedTokens = Chain.Tokens mempty
+  in
+    Chain.Transaction{..}
+
+createOutput :: Chain.TransactionOutput
+createOutput =
+  let
+    address = testScriptAddress
+    assets = Chain.Assets
+      { ada = 0
+      , tokens = Chain.Tokens mempty
+      }
+    datumHash = Nothing
+    datum = Nothing
+  in
+    Chain.TransactionOutput{..}
+
+point1 :: ChainPoint
+point1 = Chain.At $ Chain.BlockHeader 0 "" 0
+
+checkHandshakeRejected :: Expectation
+checkHandshakeRejected = do
+  FollowerTestResult{..} <- runFollowerTest marloweVersions
+    $ RejectHandshake [] ()
+  followerError `shouldBe` Just HansdshakeFailed
+  followerChanges `shouldBe` Nothing
+
+checkFindTxFailed :: Expectation
+checkFindTxFailed = do
+  FollowerTestResult{..} <- runFollowerTest marloweVersions
+    $ ConfirmHandshake
+    $ ExpectQuery (FindTx (txId $ unContractId testContractId))
+    $ RejectQuery TxNotFound Genesis
+    $ ExpectDone ()
+  followerError `shouldBe` Just (FindTxFailed TxNotFound)
+  followerChanges `shouldBe` Nothing
+
+checkTxIxNotFound :: Expectation
+checkTxIxNotFound = do
+  FollowerTestResult{..} <- runFollowerTest marloweVersions
+    $ ConfirmHandshake
+    $ ExpectQuery (FindTx createTxId)
+    $ RollForward createTx { Chain.outputs = [] } point1 point1
+    $ ExpectDone ()
+  followerError `shouldBe` Just (ExtractContractFailed TxIxNotFound)
+  followerChanges `shouldBe` Nothing
+
+checkByronAddress :: Expectation
+checkByronAddress = do
+  FollowerTestResult{..} <- runFollowerTest marloweVersions
+    $ ConfirmHandshake
+    $ ExpectQuery (FindTx createTxId)
+    $ RollForward createTx { Chain.outputs = [createOutput { address = "" }] } point1 point1
+    $ ExpectDone ()
+  followerError `shouldBe` Just (ExtractContractFailed ByronAddress)
+  followerChanges `shouldBe` Nothing
+
+checkNonScriptAddress :: Expectation
+checkNonScriptAddress = do
+  FollowerTestResult{..} <- runFollowerTest marloweVersions
+    $ ConfirmHandshake
+    $ ExpectQuery (FindTx createTxId)
+    $ RollForward createTx { Chain.outputs = [createOutput { address = "6022c79fed0291c432b62f585d3f1074bf3a5f1df86f61fcca14a5d6d6" }] } point1 point1
+    $ ExpectDone ()
+  followerError `shouldBe` Just (ExtractContractFailed NonScriptAddress)
+  followerChanges `shouldBe` Nothing
+
+checkInvalidScriptHash :: Expectation
+checkInvalidScriptHash = do
+  FollowerTestResult{..} <- runFollowerTest []
+    $ ConfirmHandshake
+    $ ExpectQuery (FindTx createTxId)
+    $ RollForward createTx { Chain.outputs = [createOutput] } point1 point1
+    $ ExpectDone ()
+  followerError `shouldBe` Just (ExtractContractFailed InvalidScriptHash)
+  followerChanges `shouldBe` Nothing
+
+checkNoDatum :: Expectation
+checkNoDatum = do
+  FollowerTestResult{..} <- runFollowerTest marloweVersions
+    $ ConfirmHandshake
+    $ ExpectQuery (FindTx createTxId)
+    $ RollForward createTx { Chain.outputs = [createOutput { Chain.datum = Nothing }] } point1 point1
+    $ ExpectDone ()
+  followerError `shouldBe` Just (ExtractContractFailed NoDatum)
+  followerChanges `shouldBe` Nothing
+
+checkInvalidDatum :: Expectation
+checkInvalidDatum = do
+  FollowerTestResult{..} <- runFollowerTest marloweVersions
+    $ ConfirmHandshake
+    $ ExpectQuery (FindTx createTxId)
+    $ RollForward createTx { Chain.outputs = [createOutput { Chain.datum = Just $ Chain.I 0 }] } point1 point1
+    $ ExpectDone ()
+  followerError `shouldBe` Just (ExtractContractFailed InvalidDatum)
+  followerChanges `shouldBe` Nothing
+
+checkNotCreationTransaction :: Expectation
+checkNotCreationTransaction = do
+  let txId = ""
+  let txIx = 0
+  let address = testScriptAddress
+  let redeemer = Nothing
+  let txIn = Chain.TransactionInput {..}
+  FollowerTestResult{..} <- runFollowerTest marloweVersions
+    $ ConfirmHandshake
+    $ ExpectQuery (FindTx createTxId)
+    $ RollForward createTx { Chain.inputs = Set.singleton txIn } point1 point1
+    $ ExpectDone ()
+  -- Not a creation transaction because there is a txIn from the script
+  -- address, implying that this is an apply-inputs transaction.
+  followerError `shouldBe` Just (ExtractContractFailed NotCreationTransaction)
+  followerChanges `shouldBe` Nothing
+
+-- TODO move to a test module in marlowe-protocols and generalize Move -> query
+data FollowerTestResult a = FollowerTestResult
+  { followerError   :: Maybe ContractHistoryError
+  , followerChanges :: Maybe SomeContractChanges
+  , testResult      :: a
+  }
+
+runFollowerTest
+  :: [(ScriptHash, SomeMarloweVersion)]
+  -> ChainSeekServerScript Move ChainPoint ChainPoint IO a
+  -> IO (FollowerTestResult a)
+runFollowerTest marloweVersions' script = do
+  (resultVar, Follower{..}) <- atomically do
+    resultVar <- newEmptyTMVar
+    let
+      connectToChainSeek :: ChainSeekClient Move ChainPoint ChainPoint IO b -> IO b
+      connectToChainSeek client = do
+        (a, b) <- runClientWithScript show shouldBe script client
+        atomically $ putTMVar resultVar a
+        pure b
+    let contractId = testContractId
+    let getMarloweVersion scriptHash = lookup scriptHash marloweVersions'
+    (resultVar,) <$> mkFollower FollowerDependencies{..}
+  (followerResult, testResult) <- concurrently runFollower $ atomically $ takeTMVar resultVar
+  let followerError = either Just (const Nothing) followerResult
+  followerChanges <- atomically changes
+  pure FollowerTestResult{..}

--- a/marlowe-runtime/test/Spec.hs
+++ b/marlowe-runtime/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -52,7 +52,6 @@ library
     aeson <2,
     base16-aeson,
     base -any,
-    binary -any,
     bytestring,
     containers -any,
     deriving-aeson -any,

--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -52,6 +52,7 @@ library
     aeson <2,
     base16-aeson,
     base -any,
+    binary -any,
     bytestring,
     containers -any,
     deriving-aeson -any,

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -104,7 +104,7 @@ import Text.PrettyPrint.Leijen (comma, hang, lbrace, line, rbrace, space, text, 
     when positive balances are payed out on contract closure.
 -}
 data Payment = Payment AccountId Payee Money
-  deriving stock (Haskell.Show, Haskell.Eq)
+  deriving stock (Haskell.Show)
 
 
 -- | Effect of 'reduceContractStep' computation

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -104,7 +104,7 @@ import Text.PrettyPrint.Leijen (comma, hang, lbrace, line, rbrace, space, text, 
     when positive balances are payed out on contract closure.
 -}
 data Payment = Payment AccountId Payee Money
-  deriving stock (Haskell.Show)
+  deriving stock (Haskell.Show, Haskell.Eq)
 
 
 -- | Effect of 'reduceContractStep' computation

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics/Types.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics/Types.hs
@@ -235,7 +235,6 @@ data State = State { accounts    :: Accounts
 newtype Environment = Environment { timeInterval :: TimeInterval }
   deriving stock (Haskell.Show,Haskell.Eq,Haskell.Ord)
 
-
 {-| Input for a Marlowe contract. Correspond to expected 'Action's.
 -}
 data InputContent = IDeposit AccountId Party Token Integer

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
@@ -77,6 +77,7 @@
           "Language/Marlowe/Runtime/ChainSync/Genesis"
           "Language/Marlowe/Runtime/ChainSync/NodeClient"
           "Language/Marlowe/Runtime/ChainSync/Server"
+          "Language/Marlowe/Runtime/ChainSync/QueryServer"
           "Language/Marlowe/Runtime/ChainSync/Store"
           "Language/Marlowe/Runtime/ChainSync/Api"
           ];
@@ -103,6 +104,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             ];
           buildable = true;
           modules = [ "Options" "Paths_marlowe_chain_sync" ];

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-protocols-test.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-protocols-test.nix
@@ -1,0 +1,45 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "marlowe-protocols-test"; version = "0.0.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jamie.bertram@iohk.io";
+      author = "Jamie Bertram";
+      homepage = "";
+      url = "";
+      synopsis = "Testing library for Marlowe protocols";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+          (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+          ];
+        buildable = true;
+        modules = [ "Test/Network/Protocol/ChainSeek" ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../marlowe-protocols-test; }

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-protocols.nix
@@ -54,6 +54,8 @@
           "Network/Protocol/Job/Server"
           "Network/Protocol/Job/Types"
           "Network/Protocol/Query/Client"
+          "Network/Protocol/Query/Codec"
+          "Network/Protocol/Query/Server"
           "Network/Protocol/Query/Types"
           "Network/Protocol/Codec"
           ];

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-protocols.nix
@@ -34,6 +34,7 @@
       "library" = {
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."network" or (errorHandler.buildDepError "network"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -32,13 +32,33 @@
       };
     components = {
       "library" = {
-        depends = [ (hsPkgs."base" or (errorHandler.buildDepError "base")) ];
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+          (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+          (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+          (hsPkgs."split" or (errorHandler.buildDepError "split"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+          (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
+          ];
         buildable = true;
-        modules = [ "MyLib" ];
+        modules = [
+          "Language/Marlowe/Runtime/Core/Api"
+          "Language/Marlowe/Runtime/History/Follower"
+          ];
         hsSourceDirs = [ "src" ];
         };
       exes = {
-        "marlowe-runtime" = {
+        "marlowed" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
@@ -49,6 +69,52 @@
           mainPath = [
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-follower" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-follower" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        };
+      tests = {
+        "marlowe-runtime-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-protocols-test" or (errorHandler.buildDepError "marlowe-protocols-test"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [
+            "Language/Marlowe/Runtime/History/FollowerSpec"
+            "Paths_marlowe_runtime"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
           };
         };
       };

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -47,6 +47,9 @@
           (hsPkgs."split" or (errorHandler.buildDepError "split"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."these" or (errorHandler.buildDepError "these"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
           ];
@@ -73,8 +76,11 @@
         "marlowe-follower" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
@@ -82,6 +88,8 @@
             (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
             ];
           buildable = true;
           modules = [ "Paths_marlowe_runtime" ];
@@ -96,6 +104,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
@@ -103,7 +112,11 @@
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-protocols-test" or (errorHandler.buildDepError "marlowe-protocols-test"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -759,6 +759,7 @@
         cardano-addresses-cli = ./.plan.nix/cardano-addresses-cli.nix;
         small-steps = ./.plan.nix/small-steps.nix;
         plutus-script-utils = ./.plan.nix/plutus-script-utils.nix;
+        marlowe-protocols-test = ./.plan.nix/marlowe-protocols-test.nix;
         ouroboros-network-framework = ./.plan.nix/ouroboros-network-framework.nix;
         orphans-deriving-via = ./.plan.nix/orphans-deriving-via.nix;
         marlowe-chain-sync = ./.plan.nix/marlowe-chain-sync.nix;
@@ -922,6 +923,7 @@
           "plutus-script-utils" = {
             flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
             };
+          "marlowe-protocols-test" = { flags = {}; };
           "ouroboros-network-framework" = { flags = {}; };
           "orphans-deriving-via" = {
             flags = { "development" = lib.mkOverride 900 false; };
@@ -1201,6 +1203,7 @@
           "lobemo-backend-trace-forwarder".components.library.planned = lib.mkOverride 900 true;
           "dependent-sum-template".components.library.planned = lib.mkOverride 900 true;
           "plutus-ghc-stub".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowed".planned = lib.mkOverride 900 true;
           "validation-selective".components.library.planned = lib.mkOverride 900 true;
           "generic-data".components.library.planned = lib.mkOverride 900 true;
           "small-steps".components.library.planned = lib.mkOverride 900 true;
@@ -1266,6 +1269,7 @@
           "adjunctions".components.library.planned = lib.mkOverride 900 true;
           "tree-diff".components.library.planned = lib.mkOverride 900 true;
           "marlowe-actus".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.tests."marlowe-runtime-test".planned = lib.mkOverride 900 true;
           "vector-binary-instances".components.library.planned = lib.mkOverride 900 true;
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "cryptonite".components.library.planned = lib.mkOverride 900 true;
@@ -1372,6 +1376,7 @@
           "Stream".components.library.planned = lib.mkOverride 900 true;
           "criterion".components.library.planned = lib.mkOverride 900 true;
           "katip".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-protocols-test".components.library.planned = lib.mkOverride 900 true;
           "hasql".components.library.planned = lib.mkOverride 900 true;
           "cardano-submit-api".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.setup.planned = lib.mkOverride 900 true;
@@ -1480,6 +1485,7 @@
           "servant-client".components.library.planned = lib.mkOverride 900 true;
           "natural-transformation".components.library.planned = lib.mkOverride 900 true;
           "wl-pprint-annotated".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-follower".planned = lib.mkOverride 900 true;
           "marlowe-cli".components.library.planned = lib.mkOverride 900 true;
           "hasql-pool".components.library.planned = lib.mkOverride 900 true;
           "writer-cps-mtl".components.library.planned = lib.mkOverride 900 true;
@@ -1488,7 +1494,6 @@
           "cardano-crypto".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
           "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
-          "marlowe-runtime".components.exes."marlowe-runtime".planned = lib.mkOverride 900 true;
           "hpc".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "websockets-snap".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
@@ -77,6 +77,7 @@
           "Language/Marlowe/Runtime/ChainSync/Genesis"
           "Language/Marlowe/Runtime/ChainSync/NodeClient"
           "Language/Marlowe/Runtime/ChainSync/Server"
+          "Language/Marlowe/Runtime/ChainSync/QueryServer"
           "Language/Marlowe/Runtime/ChainSync/Store"
           "Language/Marlowe/Runtime/ChainSync/Api"
           ];
@@ -103,6 +104,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             ];
           buildable = true;
           modules = [ "Options" "Paths_marlowe_chain_sync" ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-protocols-test.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-protocols-test.nix
@@ -1,0 +1,45 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "marlowe-protocols-test"; version = "0.0.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jamie.bertram@iohk.io";
+      author = "Jamie Bertram";
+      homepage = "";
+      url = "";
+      synopsis = "Testing library for Marlowe protocols";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+          (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+          ];
+        buildable = true;
+        modules = [ "Test/Network/Protocol/ChainSeek" ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../marlowe-protocols-test; }

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-protocols.nix
@@ -54,6 +54,8 @@
           "Network/Protocol/Job/Server"
           "Network/Protocol/Job/Types"
           "Network/Protocol/Query/Client"
+          "Network/Protocol/Query/Codec"
+          "Network/Protocol/Query/Server"
           "Network/Protocol/Query/Types"
           "Network/Protocol/Codec"
           ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-protocols.nix
@@ -34,6 +34,7 @@
       "library" = {
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."network" or (errorHandler.buildDepError "network"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -32,13 +32,33 @@
       };
     components = {
       "library" = {
-        depends = [ (hsPkgs."base" or (errorHandler.buildDepError "base")) ];
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+          (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+          (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+          (hsPkgs."split" or (errorHandler.buildDepError "split"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+          (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
+          ];
         buildable = true;
-        modules = [ "MyLib" ];
+        modules = [
+          "Language/Marlowe/Runtime/Core/Api"
+          "Language/Marlowe/Runtime/History/Follower"
+          ];
         hsSourceDirs = [ "src" ];
         };
       exes = {
-        "marlowe-runtime" = {
+        "marlowed" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
@@ -49,6 +69,52 @@
           mainPath = [
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-follower" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-follower" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        };
+      tests = {
+        "marlowe-runtime-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-protocols-test" or (errorHandler.buildDepError "marlowe-protocols-test"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [
+            "Language/Marlowe/Runtime/History/FollowerSpec"
+            "Paths_marlowe_runtime"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
           };
         };
       };

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -47,6 +47,9 @@
           (hsPkgs."split" or (errorHandler.buildDepError "split"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."these" or (errorHandler.buildDepError "these"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
           ];
@@ -73,8 +76,11 @@
         "marlowe-follower" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
@@ -82,6 +88,8 @@
             (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
             ];
           buildable = true;
           modules = [ "Paths_marlowe_runtime" ];
@@ -96,6 +104,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
@@ -103,7 +112,11 @@
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-protocols-test" or (errorHandler.buildDepError "marlowe-protocols-test"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -764,6 +764,7 @@
         cardano-addresses-cli = ./.plan.nix/cardano-addresses-cli.nix;
         small-steps = ./.plan.nix/small-steps.nix;
         plutus-script-utils = ./.plan.nix/plutus-script-utils.nix;
+        marlowe-protocols-test = ./.plan.nix/marlowe-protocols-test.nix;
         ouroboros-network-framework = ./.plan.nix/ouroboros-network-framework.nix;
         orphans-deriving-via = ./.plan.nix/orphans-deriving-via.nix;
         marlowe-chain-sync = ./.plan.nix/marlowe-chain-sync.nix;
@@ -927,6 +928,7 @@
           "plutus-script-utils" = {
             flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
             };
+          "marlowe-protocols-test" = { flags = {}; };
           "ouroboros-network-framework" = { flags = {}; };
           "orphans-deriving-via" = {
             flags = { "development" = lib.mkOverride 900 false; };
@@ -1208,6 +1210,7 @@
           "lobemo-backend-trace-forwarder".components.library.planned = lib.mkOverride 900 true;
           "dependent-sum-template".components.library.planned = lib.mkOverride 900 true;
           "plutus-ghc-stub".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowed".planned = lib.mkOverride 900 true;
           "validation-selective".components.library.planned = lib.mkOverride 900 true;
           "generic-data".components.library.planned = lib.mkOverride 900 true;
           "small-steps".components.library.planned = lib.mkOverride 900 true;
@@ -1273,6 +1276,7 @@
           "adjunctions".components.library.planned = lib.mkOverride 900 true;
           "tree-diff".components.library.planned = lib.mkOverride 900 true;
           "marlowe-actus".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.tests."marlowe-runtime-test".planned = lib.mkOverride 900 true;
           "vector-binary-instances".components.library.planned = lib.mkOverride 900 true;
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "cryptonite".components.library.planned = lib.mkOverride 900 true;
@@ -1379,6 +1383,7 @@
           "Stream".components.library.planned = lib.mkOverride 900 true;
           "criterion".components.library.planned = lib.mkOverride 900 true;
           "katip".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-protocols-test".components.library.planned = lib.mkOverride 900 true;
           "hasql".components.library.planned = lib.mkOverride 900 true;
           "cardano-submit-api".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.setup.planned = lib.mkOverride 900 true;
@@ -1488,6 +1493,7 @@
           "servant-client".components.library.planned = lib.mkOverride 900 true;
           "natural-transformation".components.library.planned = lib.mkOverride 900 true;
           "wl-pprint-annotated".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-follower".planned = lib.mkOverride 900 true;
           "marlowe-cli".components.library.planned = lib.mkOverride 900 true;
           "hasql-pool".components.library.planned = lib.mkOverride 900 true;
           "writer-cps-mtl".components.library.planned = lib.mkOverride 900 true;
@@ -1496,7 +1502,6 @@
           "cardano-crypto".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
           "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
-          "marlowe-runtime".components.exes."marlowe-runtime".planned = lib.mkOverride 900 true;
           "hpc".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "websockets-snap".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-chain-sync.nix
@@ -77,6 +77,7 @@
           "Language/Marlowe/Runtime/ChainSync/Genesis"
           "Language/Marlowe/Runtime/ChainSync/NodeClient"
           "Language/Marlowe/Runtime/ChainSync/Server"
+          "Language/Marlowe/Runtime/ChainSync/QueryServer"
           "Language/Marlowe/Runtime/ChainSync/Store"
           "Language/Marlowe/Runtime/ChainSync/Api"
           ];
@@ -103,6 +104,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             ];
           buildable = true;
           modules = [ "Options" "Paths_marlowe_chain_sync" ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-protocols-test.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-protocols-test.nix
@@ -1,0 +1,45 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "marlowe-protocols-test"; version = "0.0.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jamie.bertram@iohk.io";
+      author = "Jamie Bertram";
+      homepage = "";
+      url = "";
+      synopsis = "Testing library for Marlowe protocols";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+          (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+          ];
+        buildable = true;
+        modules = [ "Test/Network/Protocol/ChainSeek" ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../marlowe-protocols-test; }

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-protocols.nix
@@ -54,6 +54,8 @@
           "Network/Protocol/Job/Server"
           "Network/Protocol/Job/Types"
           "Network/Protocol/Query/Client"
+          "Network/Protocol/Query/Codec"
+          "Network/Protocol/Query/Server"
           "Network/Protocol/Query/Types"
           "Network/Protocol/Codec"
           ];

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-protocols.nix
@@ -34,6 +34,7 @@
       "library" = {
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."network" or (errorHandler.buildDepError "network"))

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-runtime.nix
@@ -32,13 +32,33 @@
       };
     components = {
       "library" = {
-        depends = [ (hsPkgs."base" or (errorHandler.buildDepError "base")) ];
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+          (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+          (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+          (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+          (hsPkgs."split" or (errorHandler.buildDepError "split"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+          (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
+          ];
         buildable = true;
-        modules = [ "MyLib" ];
+        modules = [
+          "Language/Marlowe/Runtime/Core/Api"
+          "Language/Marlowe/Runtime/History/Follower"
+          ];
         hsSourceDirs = [ "src" ];
         };
       exes = {
-        "marlowe-runtime" = {
+        "marlowed" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
@@ -49,6 +69,52 @@
           mainPath = [
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-follower" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-follower" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        };
+      tests = {
+        "marlowe-runtime-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-protocols-test" or (errorHandler.buildDepError "marlowe-protocols-test"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))
+            ];
+          buildable = true;
+          modules = [
+            "Language/Marlowe/Runtime/History/FollowerSpec"
+            "Paths_marlowe_runtime"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
           };
         };
       };

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-runtime.nix
@@ -47,6 +47,9 @@
           (hsPkgs."split" or (errorHandler.buildDepError "split"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."these" or (errorHandler.buildDepError "these"))
+          (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
           ];
@@ -73,8 +76,11 @@
         "marlowe-follower" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
@@ -82,6 +88,8 @@
             (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
             ];
           buildable = true;
           modules = [ "Paths_marlowe_runtime" ];
@@ -96,6 +104,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
@@ -103,7 +112,11 @@
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-protocols-test" or (errorHandler.buildDepError "marlowe-protocols-test"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover.components.exes.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover:hspec-discover")))

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -762,6 +762,7 @@
         cardano-addresses-cli = ./.plan.nix/cardano-addresses-cli.nix;
         small-steps = ./.plan.nix/small-steps.nix;
         plutus-script-utils = ./.plan.nix/plutus-script-utils.nix;
+        marlowe-protocols-test = ./.plan.nix/marlowe-protocols-test.nix;
         ouroboros-network-framework = ./.plan.nix/ouroboros-network-framework.nix;
         orphans-deriving-via = ./.plan.nix/orphans-deriving-via.nix;
         marlowe-chain-sync = ./.plan.nix/marlowe-chain-sync.nix;
@@ -925,6 +926,7 @@
           "plutus-script-utils" = {
             flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
             };
+          "marlowe-protocols-test" = { flags = {}; };
           "ouroboros-network-framework" = { flags = {}; };
           "orphans-deriving-via" = {
             flags = { "development" = lib.mkOverride 900 false; };
@@ -1204,6 +1206,7 @@
           "lobemo-backend-trace-forwarder".components.library.planned = lib.mkOverride 900 true;
           "dependent-sum-template".components.library.planned = lib.mkOverride 900 true;
           "plutus-ghc-stub".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowed".planned = lib.mkOverride 900 true;
           "validation-selective".components.library.planned = lib.mkOverride 900 true;
           "generic-data".components.library.planned = lib.mkOverride 900 true;
           "small-steps".components.library.planned = lib.mkOverride 900 true;
@@ -1269,6 +1272,7 @@
           "adjunctions".components.library.planned = lib.mkOverride 900 true;
           "tree-diff".components.library.planned = lib.mkOverride 900 true;
           "marlowe-actus".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.tests."marlowe-runtime-test".planned = lib.mkOverride 900 true;
           "vector-binary-instances".components.library.planned = lib.mkOverride 900 true;
           "parallel".components.library.planned = lib.mkOverride 900 true;
           "cryptonite".components.library.planned = lib.mkOverride 900 true;
@@ -1375,6 +1379,7 @@
           "Stream".components.library.planned = lib.mkOverride 900 true;
           "criterion".components.library.planned = lib.mkOverride 900 true;
           "katip".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-protocols-test".components.library.planned = lib.mkOverride 900 true;
           "hasql".components.library.planned = lib.mkOverride 900 true;
           "cardano-submit-api".components.library.planned = lib.mkOverride 900 true;
           "wai-logger".components.setup.planned = lib.mkOverride 900 true;
@@ -1483,6 +1488,7 @@
           "servant-client".components.library.planned = lib.mkOverride 900 true;
           "natural-transformation".components.library.planned = lib.mkOverride 900 true;
           "wl-pprint-annotated".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-follower".planned = lib.mkOverride 900 true;
           "marlowe-cli".components.library.planned = lib.mkOverride 900 true;
           "hasql-pool".components.library.planned = lib.mkOverride 900 true;
           "writer-cps-mtl".components.library.planned = lib.mkOverride 900 true;
@@ -1491,7 +1497,6 @@
           "cardano-crypto".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
           "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
-          "marlowe-runtime".components.exes."marlowe-runtime".planned = lib.mkOverride 900 true;
           "hpc".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "websockets-snap".components.library.planned = lib.mkOverride 900 true;

--- a/shell.nix
+++ b/shell.nix
@@ -119,6 +119,9 @@ let
       run-chainseekd
       start-cardano-node
       sphinxTools
+      pkgs.docker-compose
+      pkgs.postgresql
+      pkgs.sqitchPg
       # FIXME: I'm not sure why I'm not able to grap rPackages here
     ]); # ++ (lib.optionals (!stdenv.isDarwin) [ rPackages.plotly R ]));
 


### PR DESCRIPTION
Changes include:

- Adding a `Follower` component with a dedicated CLI executable to the runtime that follows a single contract
- Extending `chainseekd` with a new query API for direct access. Currently supports querying some data from the Genesis parameters.
- Refactoring protocols that pass query GADTs (e.g. chain seek, job, query) to associate them with a `Tag` GADT. This helps a lot serialization a lot by separating the questions "which query are we decoding" and "how do I decode the query / result / error?"