### PR TITLE
SCP-4277 Contract ID management

### DIFF
--- a/marlowe-chain-sync/app/Options.hs
+++ b/marlowe-chain-sync/app/Options.hs
@@ -165,19 +165,17 @@ parseOptions defaultNetworkId defaultSocketPath defaultDatabaseUri defaultHost d
         portOption :: O.Parser PortNumber
         portOption = O.option O.auto $ mconcat
           [ O.long "port-number"
-          , O.short 'p'
           , defaultPort
           , O.metavar "PORT_NUMBER"
-          , O.help "The port number to serve the chain seek protocol on"
+          , O.help "The port number to serve the chain seek protocol on. Default value: 3715"
           ]
 
         queryPortOption :: O.Parser PortNumber
         queryPortOption = O.option O.auto $ mconcat
           [ O.long "query-port-number"
-          , O.short 'p'
           , defaultQueryPort
           , O.metavar "PORT_NUMBER"
-          , O.help "The port number to serve the query protocol on"
+          , O.help "The port number to serve the query protocol on. Default value: 3716"
           ]
 
         hostOption :: O.Parser HostName
@@ -186,7 +184,7 @@ parseOptions defaultNetworkId defaultSocketPath defaultDatabaseUri defaultHost d
           , O.short 'h'
           , defaultHost
           , O.metavar "HOST_NAME"
-          , O.help "The hostname to serve the chain seek protocol on"
+          , O.help "The hostname to serve the chain seek protocol on. Default value: 127.0.0.1"
           ]
 
         costModelParser :: O.Parser CostModel

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -105,7 +105,7 @@ data WithGenesis a = Genesis | At a
   deriving anyclass (Binary)
 
 -- | A point in the chain, identified by a slot number, block header hash, and
--- block numner.
+-- block number.
 type ChainPoint = WithGenesis BlockHeader
 
 -- | A block header, consisting of a slot number, a hash, and a block number.
@@ -141,7 +141,7 @@ data ValidityRange
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (Binary)
 
--- TODO invlude validator versions
+-- TODO add content
 data Metadata
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (Binary)
@@ -152,7 +152,7 @@ data TransactionInput = TransactionInput
   , txIx       :: !TxIx             -- ^ The txIx of the TransactionOutput this input consumes.
   , address    :: !Address          -- ^ The address of the TransactionOutput this input consumes.
   , datumBytes :: !(Maybe Datum)    -- ^ The script datum for this input
-  , redeemer   :: !(Maybe Redeemer) -- ^ The script redeemer dataum for this input (if one was provided).
+  , redeemer   :: !(Maybe Redeemer) -- ^ The script redeemer datum for this input (if one was provided).
   }
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (Binary)
@@ -160,7 +160,7 @@ data TransactionInput = TransactionInput
 -- | An output of a transaction.
 data TransactionOutput = TransactionOutput
   { address   :: !Address           -- ^ The address that receives the assets of this output.
-  , assets    :: !Assets            -- ^ The assets this ouptut produces.
+  , assets    :: !Assets            -- ^ The assets this output produces.
   , datumHash :: !(Maybe DatumHash) -- ^ The hash of the script datum associated with this output.
   , datum     :: !(Maybe Datum)     -- ^ The script datum associated with this output.
   }
@@ -196,21 +196,21 @@ toRedeemer = Redeemer . toDatum
 
 -- | Convert from Plutus.V1.Ledger.Api.Data to Datum
 fromPlutusData :: Plutus.Data -> Datum
-fromPlutusData (Plutus.Constr i dats) = Constr i $ fromPlutusData <$> dats
-fromPlutusData (Plutus.Map m)         = Map $ bimap fromPlutusData fromPlutusData <$> m
-fromPlutusData (Plutus.List dats)     = List $ fromPlutusData <$> dats
-fromPlutusData (Plutus.I i)           = I i
-fromPlutusData (Plutus.B b)           = B b
+fromPlutusData (Plutus.Constr i ds) = Constr i $ fromPlutusData <$> ds
+fromPlutusData (Plutus.Map m)       = Map $ bimap fromPlutusData fromPlutusData <$> m
+fromPlutusData (Plutus.List ds)     = List $ fromPlutusData <$> ds
+fromPlutusData (Plutus.I i)         = I i
+fromPlutusData (Plutus.B b)         = B b
 
 -- | Convert to Plutus.V1.Ledger.Api.Data to Datum
 toPlutusData :: Datum -> Plutus.Data
-toPlutusData (Constr i dats) = Plutus.Constr i $ toPlutusData <$> dats
-toPlutusData (Map m)         = Plutus.Map $ bimap toPlutusData toPlutusData <$> m
-toPlutusData (List dats)     = Plutus.List $ toPlutusData <$> dats
-toPlutusData (I i)           = Plutus.I i
-toPlutusData (B b)           = Plutus.B b
+toPlutusData (Constr i ds) = Plutus.Constr i $ toPlutusData <$> ds
+toPlutusData (Map m)       = Plutus.Map $ bimap toPlutusData toPlutusData <$> m
+toPlutusData (List ds)     = Plutus.List $ toPlutusData <$> ds
+toPlutusData (I i)         = Plutus.I i
+toPlutusData (B b)         = Plutus.B b
 
--- | A collection of assets transferred by a trasaction output.
+-- | A collection of assets transferred by a transaction output.
 data Assets = Assets
   { ada    :: !Lovelace -- ^ The ADA sent by the tx output.
   , tokens :: !Tokens   -- ^ Additional tokens sent by the tx output.
@@ -395,7 +395,7 @@ data Move err result where
   -- | Advance a fixed number of blocks without collecting any results..
   AdvanceBlocks :: Natural -> Move Void ()
 
-  -- | Jump to the lastest intersection from a list of known block headers
+  -- | Jump to the latest intersection from a list of known block headers
   -- without collecting any results.
   Intersect :: [BlockHeader] -> Move IntersectError ()
 

--- a/marlowe-runtime/marlowe-follower/Main.hs
+++ b/marlowe-runtime/marlowe-follower/Main.hs
@@ -22,9 +22,8 @@ import Language.Marlowe.Runtime.Core.Api (ContractId (..), MarloweVersion (..), 
                                           TransactionOutput (..), TransactionScriptOutput (..), parseContractId,
                                           renderContractId)
 import qualified Language.Marlowe.Runtime.Core.Api as Core
-import Language.Marlowe.Runtime.History.Follower (ContractChanges (..), ContractStep (..), CreateStep (..),
-                                                  Follower (..), FollowerDependencies (..), RedeemStep (..),
-                                                  SomeContractChanges (..), mkFollower)
+import Language.Marlowe.Runtime.History.Api
+import Language.Marlowe.Runtime.History.Follower
 import Network.Channel (socketAsChannel)
 import Network.Protocol.ChainSeek.Client (chainSeekClientPeer)
 import Network.Protocol.Driver (mkDriver)

--- a/marlowe-runtime/marlowe-follower/Main.hs
+++ b/marlowe-runtime/marlowe-follower/Main.hs
@@ -32,8 +32,8 @@ import Network.Protocol.Query.Codec (codecQuery)
 import Network.Socket (AddrInfo (..), HostName, PortNumber, SocketType (..), close, connect, defaultHints, getAddrInfo,
                        openSocket, withSocketsDo)
 import Network.TypedProtocol (runPeerWithDriver, startDState)
-import Options.Applicative (argument, auto, execParser, fullDesc, header, help, info, long, maybeReader, metavar,
-                            option, progDesc, short, strOption, value)
+import Options.Applicative (argument, auto, execParser, fullDesc, header, help, helper, info, long, maybeReader,
+                            metavar, option, progDesc, short, strOption, value)
 import System.Console.ANSI (Color (..), ColorIntensity (..), ConsoleLayer (..), SGR (..), setSGR)
 import System.IO (hPrint, stderr)
 import Text.PrettyPrint.Leijen (Doc, indent, putDoc)
@@ -158,32 +158,30 @@ data Options = Options
   }
 
 getOptions :: IO Options
-getOptions = execParser $ info parser infoMod
+getOptions = execParser $ info (helper <*> parser) infoMod
   where
     parser = Options <$> portParser <*> queryPortParser <*> hostParser <*> contractIdParser
 
     portParser = option auto $ mconcat
       [ long "port-number"
-      , short 'p'
       , value 3715
       , metavar "PORT_NUMBER"
-      , help "The port number of the chain seek server"
+      , help "The port number of the chain seek server. Default value: 3715"
       ]
 
     queryPortParser = option auto $ mconcat
       [ long "query-port-number"
-      , short 'p'
       , value 3716
       , metavar "PORT_NUMBER"
-      , help "The query port number of the chain seek server"
+      , help "The query port number of the chain seek server. Default value: 3716"
       ]
 
     hostParser = strOption $ mconcat
       [ long "host"
-      , short 'p'
+      , short 'h'
       , value "127.0.0.1"
       , metavar "HOST_NAME"
-      , help "The host name of the chain seek server"
+      , help "The host name of the chain seek server. Default value: 127.0.0.1"
       ]
 
     contractIdParser = argument (maybeReader parseContractId) $ mconcat

--- a/marlowe-runtime/marlowe-history-cli/Main.hs
+++ b/marlowe-runtime/marlowe-history-cli/Main.hs
@@ -2,15 +2,19 @@ module Main where
 
 import Control.Category ((>>>))
 import Control.Exception (bracket, bracketOnError, throwIO)
-import Control.Monad
-import Data.Foldable (fold)
+import Data.Foldable (asum, fold)
+import Data.Functor (void)
+import qualified Data.Map as Map
 import qualified Data.Text.IO as T
 import Data.Void (Void, absurd)
+import GHC.Base (when)
 import Language.Marlowe.Runtime.Core.Api (ContractId, parseContractId, renderContractId)
 import Language.Marlowe.Runtime.History.Api
 import Network.Channel (socketAsChannel)
 import Network.Protocol.Driver (mkDriver)
 import Network.Protocol.Job.Client (jobClientPeer, liftCommand)
+import Network.Protocol.Query.Client (ClientStInit (..), ClientStNext (..), ClientStNextCanReject (..),
+                                      ClientStPage (..), QueryClient (..), queryClientPeer)
 import Network.Socket (AddrInfo (..), HostName, PortNumber, Socket, SocketType (..), close, connect, defaultHints,
                        getAddrInfo, openSocket)
 import Network.TypedProtocol (Driver (..), runPeerWithDriver)
@@ -23,36 +27,65 @@ main = run =<< getOptions
 
 run :: Options -> IO ()
 run Options{..} = do
-  let hints = defaultHints { addrSocketType = Stream }
-  commandAddr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show commandPort)
-  bracket (open commandAddr) close (runCommand command)
+  case command of
+    Add contractId -> runHistoryCommand (FollowContract contractId) >>= \case
+      Left err -> failWith $ "Failed to follow contract: " <> show err
+      Right hadEffect -> do
+        when hadEffect $ T.putStrLn $ renderContractId contractId
+
+    Rm contractId -> runHistoryCommand (StopFollowingContract contractId) >>= \case
+      Right hadEffect -> do
+        when hadEffect $ T.putStrLn $ renderContractId contractId
+      Left err -> absurd err
+
+    Ls lsCommand -> do
+      queryAddr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show queryPort)
+      bracket (open queryAddr) close $ runLsCommand lsCommand
   where
+    hints = defaultHints { addrSocketType = Stream }
+
     open addr = bracketOnError (openSocket addr) close \sock -> do
       connect sock $ addrAddress addr
       pure sock
 
-runCommand :: Command -> Socket -> IO ()
-runCommand command commandSocket = case command of
-
-  Add contractId -> runHistoryCommand (FollowContract contractId) >>= \case
-    Left err -> failWith $ "Failed to follow contract: " <> show err
-    Right hadEffect -> do
-      when hadEffect $ T.putStrLn $ renderContractId contractId
-
-  Rm contractId -> runHistoryCommand (StopFollowingContract contractId) >>= \case
-    Right hadEffect -> do
-      when hadEffect $ T.putStrLn $ renderContractId contractId
-    Left err -> absurd err
-
-  where
     runHistoryCommand :: HistoryCommand Void err result -> IO (Either err result)
-    runHistoryCommand cmd =
-      fst <$> runPeerWithDriver commandDriver (peer cmd) (startDState commandDriver)
+    runHistoryCommand cmd = do
+      commandAddr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show commandPort)
+      bracket (open commandAddr) close \commandSocket -> do
+        let channel = socketAsChannel commandSocket
+        let driver = mkDriver throwIO historyJobCodec channel
+        let peer = jobClientPeer $ liftCommand cmd
+        fst <$> runPeerWithDriver driver peer (startDState driver)
 
-    peer = jobClientPeer . liftCommand
-
-    commandDriver = mkDriver throwIO historyJobCodec commandChannel
-    commandChannel = socketAsChannel commandSocket
+runLsCommand :: LsCommand -> Socket -> IO ()
+runLsCommand LsCommand{..} socket = void $ runPeerWithDriver driver peer (startDState driver)
+  where
+    driver = mkDriver throwIO historyQueryCodec $ socketAsChannel socket
+    peer = queryClientPeer client
+    client = QueryClient $ pure $ SendMsgRequest GetFollowedContracts ClientStNextCanReject
+      { recvMsgReject = absurd
+      , recvMsgNextPage = nextPage
+      }
+    nextPage results mNextPageDelimiter = do
+      void $ Map.traverseWithKey printResult $ Map.filter filterResult results
+      pure case mNextPageDelimiter of
+        Nothing -> SendMsgDone ()
+        Just nextPageDelimiter -> SendMsgRequestNext nextPageDelimiter ClientStNext
+          { recvMsgNextPage = nextPage
+          }
+    filterResult = case failedFlag of
+      LsShowFailed -> const True
+      LsHideFailed -> \case
+        Failed _ -> False
+        _        -> True
+    printResult = case statusFlag of
+      LsHideStatus -> const . printContractId
+      LsShowStatus -> printStatus
+    printContractId = T.putStrLn . renderContractId
+    printStatus contractId status = do
+      T.putStr $ renderContractId contractId
+      putStr " Status: "
+      print status
 
 failWith :: String -> IO a
 failWith msg = do
@@ -61,6 +94,7 @@ failWith msg = do
 
 data Options = Options
   { commandPort :: !PortNumber
+  , queryPort   :: !PortNumber
   , host        :: !HostName
   , command     :: !Command
   }
@@ -68,17 +102,38 @@ data Options = Options
 data Command
   = Add ContractId
   | Rm ContractId
+  | Ls LsCommand
+
+data LsStatusFlag
+  = LsShowStatus
+  | LsHideStatus
+
+data LsFailedFlag
+  = LsShowFailed
+  | LsHideFailed
+
+data LsCommand = LsCommand
+  { statusFlag:: LsStatusFlag
+  , failedFlag :: LsFailedFlag
+  }
 
 getOptions :: IO Options
 getOptions = O.execParser $ O.info parser infoMod
   where
-    parser = O.helper <*> (Options <$> portParser <*> hostParser <*> exampleParser)
-    portParser = O.option O.auto $ mconcat
+    parser = O.helper <*> (Options <$> commandPortParser <*> queryPortParser <*> hostParser <*> commandParser)
+    commandPortParser = O.option O.auto $ mconcat
       [ O.long "command-port"
       , O.short 'p'
       , O.value 3717
       , O.metavar "PORT_NUMBER"
       , O.help "The port number for issuing commands to the history server"
+      ]
+    queryPortParser = O.option O.auto $ mconcat
+      [ O.long "query-port"
+      , O.short 'p'
+      , O.value 3718
+      , O.metavar "PORT_NUMBER"
+      , O.help "The port number for issuing queries to the history server"
       ]
     hostParser = O.strOption $ mconcat
       [ O.long "host"
@@ -87,12 +142,34 @@ getOptions = O.execParser $ O.info parser infoMod
       , O.metavar "HOST_NAME"
       , O.help "The hostname of the history server to connect to"
       ]
-    exampleParser = O.subparser $ fold
-      [ O.command "add" $ Add <$> addParser
-      , O.command "rm" $ Rm <$> rmParser
+
+    commandParser = asum
+      [ O.hsubparser $ fold
+          [ O.commandGroup "Commands:"
+          , O.command "add" $ Add <$> addParser
+          , O.command "rm" $ Rm <$> rmParser
+          ]
+      , O.hsubparser $ fold
+          [ O.commandGroup "Queries:"
+          , O.command "ls" $ Ls <$> lsParser
+          ]
       ]
+
     addParser = O.info (contractIdParser "follow") $ O.progDesc "Start following a contract by its ID."
     rmParser = O.info (contractIdParser "stop following") $ O.progDesc "Stop following a contract by its ID."
+    lsParser = O.info (LsCommand <$> showStatusParser <*> showFailedParser) $ O.progDesc "List followed contracts"
+      where
+        showStatusParser = O.flag LsHideStatus LsShowStatus $ fold
+          [ O.long "show-status"
+          , O.short 's'
+          , O.help "Show the status of the contract as well as its ID"
+          ]
+        showFailedParser = O.flag LsHideFailed LsShowFailed $ fold
+          [ O.long "show-failed"
+          , O.short 'f'
+          , O.help "Include contracts whose follower encountered an error"
+          ]
+
     contractIdParser verb = O.argument parser' info
       where
         parser' = O.eitherReader $ parseContractId >>> \case

--- a/marlowe-runtime/marlowe-history-cli/Main.hs
+++ b/marlowe-runtime/marlowe-history-cli/Main.hs
@@ -117,24 +117,22 @@ getOptions = O.execParser $ O.info parser infoMod
     parser = O.helper <*> (Options <$> commandPortParser <*> queryPortParser <*> hostParser <*> commandParser)
     commandPortParser = O.option O.auto $ mconcat
       [ O.long "command-port"
-      , O.short 'p'
       , O.value 3717
       , O.metavar "PORT_NUMBER"
-      , O.help "The port number for issuing commands to the history server"
+      , O.help "The port number for issuing commands to the history server. Default: 3717"
       ]
     queryPortParser = O.option O.auto $ mconcat
       [ O.long "query-port"
-      , O.short 'p'
       , O.value 3718
       , O.metavar "PORT_NUMBER"
-      , O.help "The port number for issuing queries to the history server"
+      , O.help "The port number for issuing queries to the history server. Default: 3718"
       ]
     hostParser = O.strOption $ mconcat
       [ O.long "host"
       , O.short 'h'
       , O.value "127.0.0.1"
       , O.metavar "HOST_NAME"
-      , O.help "The hostname of the history server to connect to"
+      , O.help "The hostname of the history server to connect to. Default value: 127.0.0.1"
       ]
 
     commandParser = asum

--- a/marlowe-runtime/marlowe-history-cli/Main.hs
+++ b/marlowe-runtime/marlowe-history-cli/Main.hs
@@ -19,8 +19,7 @@ import Network.Socket (AddrInfo (..), HostName, PortNumber, Socket, SocketType (
                        getAddrInfo, openSocket)
 import Network.TypedProtocol (Driver (..), runPeerWithDriver)
 import qualified Options.Applicative as O
-import System.Exit (exitFailure)
-import System.IO (hPutStrLn, stderr)
+import System.Exit (die)
 
 main :: IO ()
 main = run =<< getOptions
@@ -29,7 +28,7 @@ run :: Options -> IO ()
 run Options{..} = do
   case command of
     Add contractId -> runHistoryCommand (FollowContract contractId) >>= \case
-      Left err -> failWith $ "Failed to follow contract: " <> show err
+      Left err -> die $ "Failed to follow contract: " <> show err
       Right hadEffect -> do
         when hadEffect $ T.putStrLn $ renderContractId contractId
 
@@ -86,11 +85,6 @@ runLsCommand LsCommand{..} socket = void $ runPeerWithDriver driver peer (startD
       T.putStr $ renderContractId contractId
       putStr " Status: "
       print status
-
-failWith :: String -> IO a
-failWith msg = do
-  hPutStrLn stderr msg
-  exitFailure
 
 data Options = Options
   { commandPort :: !PortNumber

--- a/marlowe-runtime/marlowe-history-cli/Main.hs
+++ b/marlowe-runtime/marlowe-history-cli/Main.hs
@@ -1,0 +1,108 @@
+module Main where
+
+import Control.Category ((>>>))
+import Control.Exception (bracket, bracketOnError, throwIO)
+import Control.Monad
+import Data.Foldable (fold)
+import qualified Data.Text.IO as T
+import Data.Void (Void, absurd)
+import Language.Marlowe.Runtime.Core.Api (ContractId, parseContractId, renderContractId)
+import Language.Marlowe.Runtime.History.Api
+import Network.Channel (socketAsChannel)
+import Network.Protocol.Driver (mkDriver)
+import Network.Protocol.Job.Client (jobClientPeer, liftCommand)
+import Network.Socket (AddrInfo (..), HostName, PortNumber, Socket, SocketType (..), close, connect, defaultHints,
+                       getAddrInfo, openSocket)
+import Network.TypedProtocol (Driver (..), runPeerWithDriver)
+import qualified Options.Applicative as O
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+
+main :: IO ()
+main = run =<< getOptions
+
+run :: Options -> IO ()
+run Options{..} = do
+  let hints = defaultHints { addrSocketType = Stream }
+  commandAddr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show commandPort)
+  bracket (open commandAddr) close (runCommand command)
+  where
+    open addr = bracketOnError (openSocket addr) close \sock -> do
+      connect sock $ addrAddress addr
+      pure sock
+
+runCommand :: Command -> Socket -> IO ()
+runCommand command commandSocket = case command of
+
+  Add contractId -> runHistoryCommand (FollowContract contractId) >>= \case
+    Left err -> failWith $ "Failed to follow contract: " <> show err
+    Right hadEffect -> do
+      when hadEffect $ T.putStrLn $ renderContractId contractId
+
+  Rm contractId -> runHistoryCommand (StopFollowingContract contractId) >>= \case
+    Right hadEffect -> do
+      when hadEffect $ T.putStrLn $ renderContractId contractId
+    Left err -> absurd err
+
+  where
+    runHistoryCommand :: HistoryCommand Void err result -> IO (Either err result)
+    runHistoryCommand cmd =
+      fst <$> runPeerWithDriver commandDriver (peer cmd) (startDState commandDriver)
+
+    peer = jobClientPeer . liftCommand
+
+    commandDriver = mkDriver throwIO historyJobCodec commandChannel
+    commandChannel = socketAsChannel commandSocket
+
+failWith :: String -> IO a
+failWith msg = do
+  hPutStrLn stderr msg
+  exitFailure
+
+data Options = Options
+  { commandPort :: !PortNumber
+  , host        :: !HostName
+  , command     :: !Command
+  }
+
+data Command
+  = Add ContractId
+  | Rm ContractId
+
+getOptions :: IO Options
+getOptions = O.execParser $ O.info parser infoMod
+  where
+    parser = O.helper <*> (Options <$> portParser <*> hostParser <*> exampleParser)
+    portParser = O.option O.auto $ mconcat
+      [ O.long "command-port"
+      , O.short 'p'
+      , O.value 3717
+      , O.metavar "PORT_NUMBER"
+      , O.help "The port number for issuing commands to the history server"
+      ]
+    hostParser = O.strOption $ mconcat
+      [ O.long "host"
+      , O.short 'h'
+      , O.value "127.0.0.1"
+      , O.metavar "HOST_NAME"
+      , O.help "The hostname of the history server to connect to"
+      ]
+    exampleParser = O.subparser $ fold
+      [ O.command "add" $ Add <$> addParser
+      , O.command "rm" $ Rm <$> rmParser
+      ]
+    addParser = O.info (contractIdParser "follow") $ O.progDesc "Start following a contract by its ID."
+    rmParser = O.info (contractIdParser "stop following") $ O.progDesc "Stop following a contract by its ID."
+    contractIdParser verb = O.argument parser' info
+      where
+        parser' = O.eitherReader $ parseContractId >>> \case
+          Nothing  -> Left "Invalid contract ID - expected format: <hex-tx-id>#<tx-out-ix>"
+          Just cid -> Right cid
+        info = fold
+          [ O.metavar "CONTRACT_ID"
+          , O.help $ "The ID of the contract to " <> verb
+          ]
+    infoMod = mconcat
+      [ O.fullDesc
+      , O.progDesc "Example Chain Seek client for the Marlowe Chain Sync"
+      ]

--- a/marlowe-runtime/marlowe-history/Main.hs
+++ b/marlowe-runtime/marlowe-history/Main.hs
@@ -24,8 +24,8 @@ import Network.Socket (AddrInfo (..), AddrInfoFlag (..), HostName, PortNumber, S
                        SocketType (..), accept, bind, close, connect, defaultHints, getAddrInfo, listen, openSocket,
                        setCloseOnExecIfNeeded, setSocketOption, withFdSocket, withSocketsDo)
 import Network.TypedProtocol (runPeerWithDriver, startDState)
-import Options.Applicative (auto, execParser, fullDesc, header, help, info, long, metavar, option, progDesc, short,
-                            strOption, value)
+import Options.Applicative (auto, execParser, fullDesc, header, help, helper, info, long, metavar, option, progDesc,
+                            short, strOption, value)
 
 main :: IO ()
 main = run =<< getOptions
@@ -105,7 +105,7 @@ data Options = Options
   }
 
 getOptions :: IO Options
-getOptions = execParser $ info parser infoMod
+getOptions = execParser $ info (helper <*> parser) infoMod
   where
     parser = Options
       <$> chainSeekPortParser
@@ -119,37 +119,35 @@ getOptions = execParser $ info parser infoMod
       [ long "chain-seek-port-number"
       , value 3715
       , metavar "PORT_NUMBER"
-      , help "The port number of the chain seek server"
+      , help "The port number of the chain seek server. Default value: 3715"
       ]
 
     chainSeekQueryPortParser = option auto $ mconcat
       [ long "chain-seek-query-port-number"
       , value 3716
       , metavar "PORT_NUMBER"
-      , help "The port number of the chain sync query server"
+      , help "The port number of the chain sync query server. Default value: 3716"
       ]
 
     commandPortParser = option auto $ mconcat
       [ long "command-port"
-      , short 'c'
       , value 3717
       , metavar "PORT_NUMBER"
-      , help "The port number to run the job server on"
+      , help "The port number to run the job server on. Default value: 3717"
       ]
 
     queryPortParser = option auto $ mconcat
       [ long "query-port"
-      , short 'c'
       , value 3718
       , metavar "PORT_NUMBER"
-      , help "The port number to run the query server on"
+      , help "The port number to run the query server on. Default value: 3718"
       ]
 
     chainSeekHostParser = strOption $ mconcat
       [ long "chain-seek-host"
       , value "127.0.0.1"
       , metavar "HOST_NAME"
-      , help "The host name of the chain seek server"
+      , help "The host name of the chain seek server. Default value: 127.0.0.1"
       ]
 
     hostParser = strOption $ mconcat
@@ -157,7 +155,7 @@ getOptions = execParser $ info parser infoMod
       , short 'h'
       , value "127.0.0.1"
       , metavar "HOST_NAME"
-      , help "The host name to run the history server on"
+      , help "The host name to run the history server on. Default value: 127.0.0.1"
       ]
 
     infoMod = mconcat

--- a/marlowe-runtime/marlowe-history/Main.hs
+++ b/marlowe-runtime/marlowe-history/Main.hs
@@ -10,13 +10,17 @@ import Language.Marlowe.Runtime.ChainSync.Api (ChainSyncQuery (..), RuntimeChain
                                                runtimeChainSeekCodec)
 import qualified Language.Marlowe.Runtime.Core.Api as Core
 import Language.Marlowe.Runtime.History (History (..), HistoryDependencies (..), mkHistory)
+import Language.Marlowe.Runtime.History.Api (historyJobCodec)
+import Language.Marlowe.Runtime.History.JobServer (RunJobServer (RunJobServer))
 import Network.Channel (socketAsChannel)
 import Network.Protocol.ChainSeek.Client (chainSeekClientPeer)
 import Network.Protocol.Driver (mkDriver)
+import Network.Protocol.Job.Server (jobServerPeer)
 import Network.Protocol.Query.Client (liftQuery, queryClientPeer)
 import Network.Protocol.Query.Codec (codecQuery)
-import Network.Socket (AddrInfo (..), HostName, PortNumber, SocketType (..), close, connect, defaultHints, getAddrInfo,
-                       openSocket, withSocketsDo)
+import Network.Socket (AddrInfo (..), AddrInfoFlag (..), HostName, PortNumber, SockAddr, SocketOption (..),
+                       SocketType (..), accept, bind, close, connect, defaultHints, getAddrInfo, listen, openSocket,
+                       setCloseOnExecIfNeeded, setSocketOption, withFdSocket, withSocketsDo)
 import Network.TypedProtocol (runPeerWithDriver, startDState)
 import Options.Applicative (auto, execParser, fullDesc, header, help, info, long, metavar, option, progDesc, short,
                             strOption, value)
@@ -24,33 +28,55 @@ import Options.Applicative (auto, execParser, fullDesc, header, help, info, long
 main :: IO ()
 main = run =<< getOptions
 
-hints :: AddrInfo
-hints = defaultHints { addrSocketType = Stream }
+clientHints :: AddrInfo
+clientHints = defaultHints { addrSocketType = Stream }
 
 run :: Options -> IO ()
 run Options{..} = withSocketsDo do
-  slotConfig <- queryChainSync GetSlotConfig
-  securityParameter <- queryChainSync GetSecurityParameter
-  let
-    connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
-    connectToChainSeek client = do
-      chainSeekAddr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show port)
-      bracket (open chainSeekAddr) close \chainSeekSocket -> do
-        let driver = mkDriver throwIO runtimeChainSeekCodec $ socketAsChannel chainSeekSocket
-        let peer = chainSeekClientPeer Genesis client
-        fst <$> runPeerWithDriver driver peer (startDState driver)
-  let getMarloweVersion = Core.getMarloweVersion
-  History{..} <- atomically $ mkHistory HistoryDependencies{..}
-  runHistory
+  jobAddr <- resolve commandPort
+  bracket (openServer jobAddr) close \jobSocket -> do
+    slotConfig <- queryChainSync GetSlotConfig
+    securityParameter <- queryChainSync GetSecurityParameter
+    let
+
+      connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
+      connectToChainSeek client = do
+        chainSeekAddr <- head <$> getAddrInfo (Just clientHints) (Just chainSeekHost) (Just $ show chainSeekPort)
+        bracket (openClient chainSeekAddr) close \chainSeekSocket -> do
+          let driver = mkDriver throwIO runtimeChainSeekCodec $ socketAsChannel chainSeekSocket
+          let peer = chainSeekClientPeer Genesis client
+          fst <$> runPeerWithDriver driver peer (startDState driver)
+
+      acceptRunJobServer = do
+        (conn, _ :: SockAddr) <- accept jobSocket
+        let driver = mkDriver throwIO historyJobCodec $ socketAsChannel conn
+        pure $ RunJobServer \server -> do
+          let peer = jobServerPeer server
+          fst <$> runPeerWithDriver driver peer (startDState driver)
+
+    let getMarloweVersion = Core.getMarloweVersion
+    History{..} <- atomically $ mkHistory HistoryDependencies{..}
+    runHistory
   where
-    open addr = bracketOnError (openSocket addr) close \sock -> do
+    openClient addr = bracketOnError (openSocket addr) close \sock -> do
       connect sock $ addrAddress addr
       pure sock
 
+    openServer addr = bracketOnError (openSocket addr) close \socket -> do
+      setSocketOption socket ReuseAddr 1
+      withFdSocket socket setCloseOnExecIfNeeded
+      bind socket $ addrAddress addr
+      listen socket 2048
+      return socket
+
+    resolve p = do
+      let hints = defaultHints { addrFlags = [AI_PASSIVE], addrSocketType = Stream }
+      head <$> getAddrInfo (Just hints) (Just host) (Just $ show p)
+
     queryChainSync :: ChainSyncQuery Void e a -> IO a
     queryChainSync query = do
-      addr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show queryPort)
-      bracket (open addr) close \socket -> do
+      addr <- head <$> getAddrInfo (Just clientHints) (Just chainSeekHost) (Just $ show chainSeekQueryPort)
+      bracket (openClient addr) close \socket -> do
         let driver = mkDriver throwIO codecQuery $ socketAsChannel socket
         let client = liftQuery query
         let peer = queryClientPeer client
@@ -58,38 +84,53 @@ run Options{..} = withSocketsDo do
         pure $ fromRight (error "failed to query chain seek server") result
 
 data Options = Options
-  { port      :: PortNumber
-  , queryPort :: PortNumber
-  , host      :: HostName
+  { chainSeekPort      :: PortNumber
+  , chainSeekQueryPort :: PortNumber
+  , commandPort        :: PortNumber
+  , chainSeekHost      :: HostName
+  , host               :: HostName
   }
 
 getOptions :: IO Options
 getOptions = execParser $ info parser infoMod
   where
-    parser = Options <$> portParser <*> queryPortParser <*> hostParser
+    parser = Options <$> chainSeekPortParser <*> chainSeekQueryPortParser <*> commandPortParser <*> chainSeekHostParser <*> hostParser
 
-    portParser = option auto $ mconcat
-      [ long "port-number"
-      , short 'p'
+    chainSeekPortParser = option auto $ mconcat
+      [ long "chain-seek-port-number"
       , value 3715
       , metavar "PORT_NUMBER"
       , help "The port number of the chain seek server"
       ]
 
-    queryPortParser = option auto $ mconcat
-      [ long "query-port-number"
-      , short 'p'
+    chainSeekQueryPortParser = option auto $ mconcat
+      [ long "chain-seek-query-port-number"
       , value 3716
       , metavar "PORT_NUMBER"
-      , help "The query port number of the chain seek server"
+      , help "The port number of the chain sync query server"
+      ]
+
+    commandPortParser = option auto $ mconcat
+      [ long "command-port"
+      , short 'c'
+      , value 3717
+      , metavar "PORT_NUMBER"
+      , help "The port number to run the job server on"
+      ]
+
+    chainSeekHostParser = strOption $ mconcat
+      [ long "chain-seek-host"
+      , value "127.0.0.1"
+      , metavar "HOST_NAME"
+      , help "The host name of the chain seek server"
       ]
 
     hostParser = strOption $ mconcat
       [ long "host"
-      , short 'p'
+      , short 'h'
       , value "127.0.0.1"
       , metavar "HOST_NAME"
-      , help "The host name of the chain seek server"
+      , help "The host name to run the history server on"
       ]
 
     infoMod = mconcat

--- a/marlowe-runtime/marlowe-history/Main.hs
+++ b/marlowe-runtime/marlowe-history/Main.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE GADTs #-}
+
+module Main where
+
+import Control.Concurrent.STM (atomically)
+import Control.Exception (bracket, bracketOnError, throwIO)
+import Data.Either (fromRight)
+import Data.Void (Void)
+import Language.Marlowe.Runtime.ChainSync.Api (ChainSyncQuery (..), RuntimeChainSeekClient, WithGenesis (..),
+                                               runtimeChainSeekCodec)
+import qualified Language.Marlowe.Runtime.Core.Api as Core
+import Language.Marlowe.Runtime.History (History (..), HistoryDependencies (..), mkHistory)
+import Network.Channel (socketAsChannel)
+import Network.Protocol.ChainSeek.Client (chainSeekClientPeer)
+import Network.Protocol.Driver (mkDriver)
+import Network.Protocol.Query.Client (liftQuery, queryClientPeer)
+import Network.Protocol.Query.Codec (codecQuery)
+import Network.Socket (AddrInfo (..), HostName, PortNumber, SocketType (..), close, connect, defaultHints, getAddrInfo,
+                       openSocket, withSocketsDo)
+import Network.TypedProtocol (runPeerWithDriver, startDState)
+import Options.Applicative (auto, execParser, fullDesc, header, help, info, long, metavar, option, progDesc, short,
+                            strOption, value)
+
+main :: IO ()
+main = run =<< getOptions
+
+hints :: AddrInfo
+hints = defaultHints { addrSocketType = Stream }
+
+run :: Options -> IO ()
+run Options{..} = withSocketsDo do
+  slotConfig <- queryChainSync GetSlotConfig
+  securityParameter <- queryChainSync GetSecurityParameter
+  let
+    connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
+    connectToChainSeek client = do
+      chainSeekAddr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show port)
+      bracket (open chainSeekAddr) close \chainSeekSocket -> do
+        let driver = mkDriver throwIO runtimeChainSeekCodec $ socketAsChannel chainSeekSocket
+        let peer = chainSeekClientPeer Genesis client
+        fst <$> runPeerWithDriver driver peer (startDState driver)
+  let getMarloweVersion = Core.getMarloweVersion
+  History{..} <- atomically $ mkHistory HistoryDependencies{..}
+  runHistory
+  where
+    open addr = bracketOnError (openSocket addr) close \sock -> do
+      connect sock $ addrAddress addr
+      pure sock
+
+    queryChainSync :: ChainSyncQuery Void e a -> IO a
+    queryChainSync query = do
+      addr <- head <$> getAddrInfo (Just hints) (Just host) (Just $ show queryPort)
+      bracket (open addr) close \socket -> do
+        let driver = mkDriver throwIO codecQuery $ socketAsChannel socket
+        let client = liftQuery query
+        let peer = queryClientPeer client
+        result <- fst <$> runPeerWithDriver driver peer (startDState driver)
+        pure $ fromRight (error "failed to query chain seek server") result
+
+data Options = Options
+  { port      :: PortNumber
+  , queryPort :: PortNumber
+  , host      :: HostName
+  }
+
+getOptions :: IO Options
+getOptions = execParser $ info parser infoMod
+  where
+    parser = Options <$> portParser <*> queryPortParser <*> hostParser
+
+    portParser = option auto $ mconcat
+      [ long "port-number"
+      , short 'p'
+      , value 3715
+      , metavar "PORT_NUMBER"
+      , help "The port number of the chain seek server"
+      ]
+
+    queryPortParser = option auto $ mconcat
+      [ long "query-port-number"
+      , short 'p'
+      , value 3716
+      , metavar "PORT_NUMBER"
+      , help "The query port number of the chain seek server"
+      ]
+
+    hostParser = strOption $ mconcat
+      [ long "host"
+      , short 'p'
+      , value "127.0.0.1"
+      , metavar "HOST_NAME"
+      , help "The host name of the chain seek server"
+      ]
+
+    infoMod = mconcat
+      [ fullDesc
+      , progDesc "Contract follower for Marlowe Runtime"
+      , header "marlowe-follower : a contract follower for the Marlowe Runtime."
+      ]

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -128,6 +128,30 @@ executable marlowe-history
     , text
     , wl-pprint
 
+executable marlowe-history-cli
+  import: lang
+  hs-source-dirs:   marlowe-history-cli
+  main-is: Main.hs
+  other-modules:
+    Paths_marlowe_runtime
+  autogen-modules:
+    Paths_marlowe_runtime
+  build-depends:
+      base >= 4.9 && < 5
+    , ansi-terminal
+    , async
+    , base16
+    , containers
+    , marlowe
+    , marlowe-protocols
+    , marlowe-runtime
+    , network
+    , typed-protocols
+    , optparse-applicative
+    , stm
+    , text
+    , wl-pprint
+
 executable marlowe-follower
   import: lang
   hs-source-dirs:   marlowe-follower

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -66,6 +66,7 @@ library
   exposed-modules:
     Language.Marlowe.Runtime.Core.Api
     Language.Marlowe.Runtime.History.Follower
+    Language.Marlowe.Runtime.History.FollowerSupervisor
   build-depends:
       base >= 4.9 && < 5
     , aeson

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -65,6 +65,7 @@ library
   hs-source-dirs:   src
   exposed-modules:
     Language.Marlowe.Runtime.Core.Api
+    Language.Marlowe.Runtime.History
     Language.Marlowe.Runtime.History.Follower
     Language.Marlowe.Runtime.History.FollowerSupervisor
   build-depends:
@@ -99,6 +100,31 @@ executable marlowed
   build-depends:
       base >= 4.9 && < 5
     , marlowe-runtime
+
+executable marlowe-history
+  import: lang
+  hs-source-dirs:   marlowe-history
+  main-is: Main.hs
+  other-modules:
+    Paths_marlowe_runtime
+  autogen-modules:
+    Paths_marlowe_runtime
+  build-depends:
+      base >= 4.9 && < 5
+    , ansi-terminal
+    , async
+    , base16
+    , containers
+    , marlowe
+    , marlowe-protocols
+    , marlowe-runtime
+    , marlowe-chain-sync
+    , network
+    , typed-protocols
+    , optparse-applicative
+    , stm
+    , text
+    , wl-pprint
 
 executable marlowe-follower
   import: lang

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -70,6 +70,7 @@ library
     Language.Marlowe.Runtime.History.Follower
     Language.Marlowe.Runtime.History.FollowerSupervisor
     Language.Marlowe.Runtime.History.JobServer
+    Language.Marlowe.Runtime.History.QueryServer
   build-depends:
       base >= 4.9 && < 5
     , aeson

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -66,8 +66,10 @@ library
   exposed-modules:
     Language.Marlowe.Runtime.Core.Api
     Language.Marlowe.Runtime.History
+    Language.Marlowe.Runtime.History.Api
     Language.Marlowe.Runtime.History.Follower
     Language.Marlowe.Runtime.History.FollowerSupervisor
+    Language.Marlowe.Runtime.History.JobServer
   build-depends:
       base >= 4.9 && < 5
     , aeson

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -120,6 +120,13 @@ deriving instance Eq (TransactionScriptOutput 'V1)
 
 data SomeMarloweVersion = forall v. SomeMarloweVersion (MarloweVersion v)
 
+instance Eq SomeMarloweVersion where
+  SomeMarloweVersion MarloweV1 == SomeMarloweVersion MarloweV1 = True
+
+instance Show SomeMarloweVersion where
+  showsPrec p (SomeMarloweVersion version) = showParen (p >= 11)
+    $ showString "SomeMarloweVersion " . showsPrec 11 version
+
 data ContractInVersion v = ContractInVersion (MarloweVersion v) (Contract v)
 data SomeContractInVersion = forall v. SomeContractInVersion (ContractInVersion v)
 

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -123,6 +123,9 @@ data SomeMarloweVersion = forall v. SomeMarloweVersion (MarloweVersion v)
 instance Eq SomeMarloweVersion where
   SomeMarloweVersion MarloweV1 == SomeMarloweVersion MarloweV1 = True
 
+instance Ord SomeMarloweVersion where
+  compare (SomeMarloweVersion MarloweV1) (SomeMarloweVersion MarloweV1) = EQ
+
 instance Show SomeMarloweVersion where
   showsPrec p (SomeMarloweVersion version) = showParen (p >= 11)
     $ showString "SomeMarloweVersion " . showsPrec 11 version

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE RankNTypes  #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE StrictData  #-}
+
+module Language.Marlowe.Runtime.History where
+
+import Control.Concurrent.Async (race_)
+import Control.Concurrent.STM (STM, atomically)
+import Control.Monad (when)
+import Language.Marlowe.Runtime.ChainSync.Api (RuntimeChainSeekClient, ScriptHash, SlotConfig)
+import Language.Marlowe.Runtime.Core.Api (SomeMarloweVersion, parseContractId)
+import Language.Marlowe.Runtime.History.FollowerSupervisor
+
+data HistoryDependencies = HistoryDependencies
+  { getMarloweVersion  :: ScriptHash -> Maybe (SomeMarloweVersion, ScriptHash)
+  , connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
+  , slotConfig         :: SlotConfig
+  , securityParameter  :: Int
+  }
+
+newtype History = History
+  { runHistory :: IO ()
+  }
+
+
+mkHistory :: HistoryDependencies -> STM History
+mkHistory HistoryDependencies{..} = do
+  FollowerSupervisor{..} <- mkFollowerSupervisor FollowerSupervisorDependencies{..}
+  let
+    go = do
+      line <- getLine
+      loop <- case words line of
+
+        ["add", cidRaw] -> True <$ case parseContractId cidRaw of
+          Nothing  -> putStrLn "invalid cid"
+          Just cid -> print =<< atomically (followContract cid)
+
+        ["rm", cidRaw] -> True <$ case parseContractId cidRaw of
+          Nothing  -> putStrLn "invalid cid"
+          Just cid -> print =<< atomically (stopFollowingContract cid)
+
+        ["status"] -> do
+          print =<< atomically followerStatuses
+          pure True
+
+        ["changes"] -> do
+          print =<< atomically changes
+          pure True
+
+        ["quit"] -> pure False
+
+        _ -> True <$ putStrLn "invalid command"
+      when loop go
+  pure History
+    { runHistory = race_ runFollowerSupervisor $ putStrLn "enter a command" *> go
+    }

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Api.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE GADTs        #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Language.Marlowe.Runtime.History.Api where
+
+import Data.Binary (Binary, get, getWord8, put, putWord8)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Map (Map)
+import Data.Void (Void, absurd)
+import GHC.Generics (Generic)
+import Language.Marlowe.Runtime.ChainSync.Api (TxError, TxOutRef, UTxOError)
+import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
+import Language.Marlowe.Runtime.Core.Api (ContractId, SomeMarloweVersion)
+import Network.Protocol.ChainSeek.Codec (DeserializeError)
+import Network.Protocol.Job.Client
+import Network.Protocol.Job.Codec
+import Network.Protocol.Job.Server
+import Network.Protocol.Job.Types
+import Network.TypedProtocol.Codec
+
+data ContractHistoryError
+  = HansdshakeFailed
+  | FindTxFailed TxError
+  | ExtractContractFailed ExtractCreationError
+  | FollowScriptUTxOFailed UTxOError
+  | FollowPayoutUTxOsFailed (Map Chain.TxOutRef UTxOError)
+  | ExtractMarloweTransactionFailed ExtractMarloweTransactionError
+  | PayoutUTxONotFound Chain.TxOutRef
+  | CreateTxRolledBack
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass Binary
+
+data ExtractCreationError
+  = TxIxNotFound
+  | ByronAddress
+  | NonScriptAddress
+  | InvalidScriptHash
+  | NoCreateDatum
+  | InvalidCreateDatum
+  | NotCreationTransaction
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass Binary
+
+data ExtractMarloweTransactionError
+  = TxInNotFound
+  | NoRedeemer
+  | InvalidRedeemer
+  | NoTransactionDatum
+  | InvalidTransactionDatum
+  | NoPayoutDatum TxOutRef
+  | InvalidPayoutDatum TxOutRef
+  | InvalidValidityRange
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass Binary
+
+data FollowerStatus
+  = Pending
+  | Following SomeMarloweVersion
+  | Failed ContractHistoryError
+  deriving (Eq, Ord, Show, Generic)
+  deriving anyclass Binary
+
+data HistoryCommand status err result where
+  FollowContract :: ContractId -> HistoryCommand Void ContractHistoryError Bool
+  StopFollowingContract :: ContractId -> HistoryCommand Void Void Bool
+
+instance Command HistoryCommand where
+  data JobId HistoryCommand status err result where
+
+  data Tag HistoryCommand status err result where
+    TagFollowContract :: Tag HistoryCommand Void ContractHistoryError Bool
+    TagStopFollowingContract :: Tag HistoryCommand Void Void Bool
+
+  tagFromCommand = \case
+    FollowContract _        -> TagFollowContract
+    StopFollowingContract _ -> TagStopFollowingContract
+
+  tagFromJobId = \case
+
+  tagEq = curry \case
+    (TagFollowContract, TagFollowContract)               -> Just Refl
+    (TagFollowContract, _)                               -> Nothing
+    (TagStopFollowingContract, TagStopFollowingContract) -> Just Refl
+    (TagStopFollowingContract, _)                        -> Nothing
+
+  putTag = \case
+    TagFollowContract        -> putWord8 0x01
+    TagStopFollowingContract -> putWord8 0x02
+
+  getTag = do
+    tag <- getWord8
+    case tag of
+      0x01 -> pure $ SomeTag TagFollowContract
+      0x02 -> pure $ SomeTag TagStopFollowingContract
+      _    -> fail $ "Invalid HistoryCommand tag: " <> show tag
+
+  putCommand = \case
+    FollowContract contractId        -> put contractId
+
+    StopFollowingContract contractId -> put contractId
+
+  getCommand = \case
+    TagFollowContract        -> FollowContract <$> get
+    TagStopFollowingContract -> StopFollowingContract <$> get
+
+  putJobId = \case
+
+  getJobId _ = fail "History commands have no job IDs"
+
+  putStatus = \case
+    TagFollowContract        -> absurd
+    TagStopFollowingContract -> absurd
+
+  getStatus _ = fail "History commands have no statuses"
+
+  putErr = \case
+    TagFollowContract        -> put
+    TagStopFollowingContract -> absurd
+
+  getErr = \case
+    TagFollowContract        -> get
+    TagStopFollowingContract -> fail "StopFollowingContract has no error"
+
+  putResult = \case
+    TagFollowContract        -> put
+    TagStopFollowingContract -> put
+
+  getResult = \case
+    TagFollowContract        -> get
+    TagStopFollowingContract -> get
+
+type RuntimeHistoryJob = Job HistoryCommand
+
+type RuntimeHistoryJobClient = JobClient HistoryCommand
+
+type RuntimeHistoryJobServer = JobServer HistoryCommand
+
+type RuntimeHistoryJobCodec m = Codec RuntimeHistoryJob DeserializeError m LBS.ByteString
+
+historyJobCodec :: Applicative m => RuntimeHistoryJobCodec m
+historyJobCodec = codecJob

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
@@ -110,6 +110,10 @@ instance Semigroup (ContractChanges v) where
 instance Monoid (ContractChanges v) where
   mempty = ContractChanges Map.empty Nothing
 
+isEmptyChanges :: SomeContractChanges -> Bool
+isEmptyChanges (SomeContractChanges _ (ContractChanges steps Nothing)) = Map.null steps
+isEmptyChanges _                                                       = False
+
 applyRollback :: WithGenesis SlotNo -> ContractChanges v -> ContractChanges v
 applyRollback Genesis _ = ContractChanges mempty $ Just Genesis
 applyRollback (At slotNo) ContractChanges{..} = ContractChanges
@@ -126,6 +130,7 @@ data FollowerStatus
   = Pending
   | Following SomeMarloweVersion
   | Failed ContractHistoryError
+  deriving (Eq, Show)
 
 data FollowerDependencies = FollowerDependencies
   { contractId         :: ContractId

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/FollowerSupervisor.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/FollowerSupervisor.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Language.Marlowe.Runtime.History.FollowerSupervisor where
+
+import Control.Concurrent.Async (Concurrently (Concurrently, runConcurrently))
+import Control.Concurrent.STM (STM, atomically, modifyTVar, newTVar, readTVar, writeTVar)
+import Control.Monad (guard, (<=<))
+import Data.Foldable (sequenceA_)
+import Data.Functor (void)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Language.Marlowe.Runtime.ChainSync.Api (RuntimeChainSeekClient, ScriptHash, SlotConfig)
+import Language.Marlowe.Runtime.Core.Api (ContractId, SomeMarloweVersion)
+import Language.Marlowe.Runtime.History.Follower (Follower (..), FollowerDependencies (..), FollowerStatus (..),
+                                                  SomeContractChanges, mkFollower)
+import qualified Language.Marlowe.Runtime.History.Follower as Follower
+import Witherable (Witherable (wither))
+
+data FollowerActivation
+  = Deactivate
+  | Activate
+
+data FollowerSupervisorDependencies = FollowerSupervisorDependencies
+  { getMarloweVersion  :: ScriptHash -> Maybe (SomeMarloweVersion, ScriptHash)
+  , connectToChainSeek :: forall a. RuntimeChainSeekClient IO a -> IO a
+  , slotConfig         :: SlotConfig
+  , securityParameter  :: Int
+  }
+
+data FollowerSupervisor = FollowerSupervisor
+  { followContract        :: ContractId -> STM Bool
+  , stopFollowingContract :: ContractId -> STM Bool
+  , followerStatuses      :: STM (Map ContractId FollowerStatus)
+  , changes               :: STM (Map ContractId SomeContractChanges)
+  , runFollowerSupervisor :: IO ()
+  }
+
+mkFollowerSupervisor :: FollowerSupervisorDependencies -> STM FollowerSupervisor
+mkFollowerSupervisor FollowerSupervisorDependencies{..} = do
+  followersVar <- newTVar Map.empty
+  followerActivationsVar <- newTVar Map.empty
+
+  let
+    followContract contractId = do
+      followers <- readTVar followersVar
+      followerActivations <- readTVar followerActivationsVar
+      mStatus <- traverse (status <=< readTVar) $ Map.lookup contractId followers
+      let
+        doActivate = do
+          modifyTVar followerActivationsVar $ Map.insert contractId Activate
+          pure True
+        cancelDeactivate = do
+          modifyTVar followerActivationsVar $ Map.delete contractId
+          pure True
+      let activation = Map.lookup contractId followerActivations
+      case (mStatus, activation) of
+        -- Follower has never run and there is a pending activation
+        (Nothing, Just Activate)         -> pure False
+        -- Follower has never run and there is no pending activation
+        (Nothing, _)                     -> doActivate
+        -- Follower failed previously and there is a pending activation
+        (Just (Failed _), Just Activate) -> pure False
+        -- Follower failed previously and there is no pending activation
+        (Just (Failed _), _)             -> doActivate
+        -- Follower is running and there is a pending deactivation
+        (_, Just Deactivate)             -> cancelDeactivate
+        -- Follower is running and there is no pending deactivation
+        (_, _)                           -> pure False
+
+    stopFollowingContract contractId = do
+      followers <- readTVar followersVar
+      followerActivations <- readTVar followerActivationsVar
+      mStatus <- traverse (status <=< readTVar) $ Map.lookup contractId followers
+      let
+        doDeactivate = do
+          modifyTVar followerActivationsVar $ Map.insert contractId Deactivate
+          pure True
+        cancelActivate = do
+          modifyTVar followerActivationsVar $ Map.delete contractId
+          pure True
+      let activation = Map.lookup contractId followerActivations
+      case (mStatus, activation) of
+        -- Follower has never run and there is a pending activation
+        (Nothing, Just Activate)         -> cancelActivate
+        -- Follower has never run and there is no pending activation
+        (Nothing, _)                     -> pure False
+        -- Follower failed previously and there is a pending activation
+        (Just (Failed _), Just Activate) -> cancelActivate
+        -- Follower failed previously and there is no pending activation
+        (Just (Failed _), _)             -> pure False
+        -- Follower is running and there is a pending deactivation
+        (_, Just Deactivate)             -> pure False
+        -- Follower is running and there is no pending deactivation
+        (_, _)                           -> doDeactivate
+
+    followerStatuses = traverse (status <=< readTVar) =<< readTVar followersVar
+
+    changes = wither (Follower.changes <=< readTVar) =<< readTVar followersVar
+
+    awaitActivations = do
+      activations <- readTVar followerActivationsVar
+      guard $ not $ Map.null activations
+      writeTVar followerActivationsVar Map.empty
+      pure $ Map.toList activations
+
+    runFollowerSupervisor = do
+      newFollowers <- atomically do
+        activations <- awaitActivations
+        flip wither activations \(contractId, activation) -> do
+          followers <- readTVar followersVar
+          case (activation, Map.lookup contractId followers) of
+            (Activate, Nothing) -> do
+              follower <- mkFollower FollowerDependencies{..}
+              followerVar <- newTVar follower
+              writeTVar followersVar $ Map.insert contractId followerVar followers
+              pure $ Just follower
+            (Activate, Just followerVar) -> do
+              follower <- mkFollower FollowerDependencies{..}
+              writeTVar followerVar follower
+              pure $ Just follower
+            (Deactivate, Nothing) -> pure Nothing
+            (Deactivate, Just followerVar) -> do
+              writeTVar followersVar $ Map.delete contractId followers
+              Follower{cancelFollower} <- readTVar followerVar
+              cancelFollower
+              pure Nothing
+      runConcurrently
+        $ sequenceA_
+        $ Concurrently <$> (runFollowerSupervisor : (void . runFollower <$> newFollowers))
+
+  pure FollowerSupervisor {..}

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/FollowerSupervisor.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/FollowerSupervisor.hs
@@ -12,8 +12,9 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Language.Marlowe.Runtime.ChainSync.Api (RuntimeChainSeekClient, ScriptHash, SlotConfig)
 import Language.Marlowe.Runtime.Core.Api (ContractId, SomeMarloweVersion)
-import Language.Marlowe.Runtime.History.Follower (Follower (..), FollowerDependencies (..), FollowerStatus (..),
-                                                  SomeContractChanges, mkFollower)
+import Language.Marlowe.Runtime.History.Api (FollowerStatus (..))
+import Language.Marlowe.Runtime.History.Follower (Follower (..), FollowerDependencies (..), SomeContractChanges,
+                                                  mkFollower)
 import qualified Language.Marlowe.Runtime.History.Follower as Follower
 import Witherable (Witherable (wither))
 

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/JobServer.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/JobServer.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE StrictData            #-}
+
+module Language.Marlowe.Runtime.History.JobServer where
+
+import Control.Concurrent.Async (Concurrently (Concurrently, runConcurrently))
+import Control.Concurrent.STM (STM, atomically, retry)
+import Control.Exception (SomeException, catch)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Language.Marlowe.Runtime.Core.Api
+import Language.Marlowe.Runtime.History.Api
+import Network.Protocol.Job.Server (liftCommandHandler)
+import System.IO (hPutStrLn, stderr)
+
+newtype RunJobServer m = RunJobServer (forall a. RuntimeHistoryJobServer m a -> IO a)
+
+data HistoryJobServerDependencies = HistoryJobServerDependencies
+  { acceptRunJobServer    :: IO (RunJobServer IO)
+  , followContract        :: ContractId -> STM Bool
+  , stopFollowingContract :: ContractId -> STM Bool
+  , followerStatuses      :: STM (Map ContractId FollowerStatus)
+  }
+
+newtype HistoryJobServer = HistoryJobServer
+  { runHistoryJobServer :: IO ()
+  }
+
+mkHistoryJobServer :: HistoryJobServerDependencies -> STM HistoryJobServer
+mkHistoryJobServer HistoryJobServerDependencies{..} = do
+  let
+    runHistoryJobServer = do
+      runJobServer <- acceptRunJobServer
+      Worker{..} <- atomically $ mkWorker WorkerDependencies {..}
+      runConcurrently $
+        Concurrently (runWorker `catch` catchWorker) *> Concurrently runHistoryJobServer
+  pure $ HistoryJobServer { runHistoryJobServer }
+
+catchWorker :: SomeException -> IO ()
+catchWorker = hPutStrLn stderr . ("Query worker crashed with exception: " <>) . show
+
+data WorkerDependencies = WorkerDependencies
+  { runJobServer          :: RunJobServer IO
+  , followContract        :: ContractId -> STM Bool
+  , stopFollowingContract :: ContractId -> STM Bool
+  , followerStatuses      :: STM (Map ContractId FollowerStatus)
+  }
+
+newtype Worker = Worker
+  { runWorker :: IO ()
+  }
+
+mkWorker :: WorkerDependencies -> STM Worker
+mkWorker WorkerDependencies{..} =
+  let
+    RunJobServer run = runJobServer
+  in
+    pure Worker { runWorker = run server }
+
+  where
+    server :: RuntimeHistoryJobServer IO ()
+    server = liftCommandHandler $ fmap ((),) . \case
+      Left (FollowContract contractId) -> do
+        followed <- atomically $ followContract contractId
+        if followed
+          then atomically do
+            statuses <- followerStatuses
+            case Map.lookup contractId statuses of
+              Nothing            -> retry
+              Just Pending       -> retry
+              Just (Following _) -> pure $ Right True
+              Just (Failed err)  -> pure $ Left err
+          else pure $ Right False
+      Left (StopFollowingContract contractId) -> atomically $ Right <$> stopFollowingContract contractId
+      Right jobId -> case jobId of

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/JobServer.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/JobServer.hs
@@ -41,7 +41,7 @@ mkHistoryJobServer HistoryJobServerDependencies{..} = do
   pure $ HistoryJobServer { runHistoryJobServer }
 
 catchWorker :: SomeException -> IO ()
-catchWorker = hPutStrLn stderr . ("Query worker crashed with exception: " <>) . show
+catchWorker = hPutStrLn stderr . ("Job worker crashed with exception: " <>) . show
 
 data WorkerDependencies = WorkerDependencies
   { runJobServer          :: RunJobServer IO

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/QueryServer.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/QueryServer.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE StrictData            #-}
+
+module Language.Marlowe.Runtime.History.QueryServer where
+
+import Control.Concurrent.Async (Concurrently (Concurrently, runConcurrently))
+import Control.Concurrent.STM (STM, atomically)
+import Control.Exception (SomeException, catch)
+import Data.Bifunctor (bimap)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (listToMaybe)
+import Data.Void (Void)
+import Language.Marlowe.Runtime.Core.Api
+import Language.Marlowe.Runtime.History.Api
+import Network.Protocol.Query.Server
+import Network.Protocol.Query.Types
+import Numeric.Natural (Natural)
+import System.IO (hPutStrLn, stderr)
+
+newtype RunQueryServer m = RunQueryServer (forall a. RuntimeHistoryQueryServer m a -> IO a)
+
+data HistoryQueryServerDependencies = HistoryQueryServerDependencies
+  { acceptRunQueryServer :: IO (RunQueryServer IO)
+  , followerStatuses     :: STM (Map ContractId FollowerStatus)
+  , followerPageSize     :: Natural
+  }
+
+newtype HistoryQueryServer = HistoryQueryServer
+  { runHistoryQueryServer :: IO ()
+  }
+
+mkHistoryQueryServer :: HistoryQueryServerDependencies -> STM HistoryQueryServer
+mkHistoryQueryServer HistoryQueryServerDependencies{..} = do
+  let
+    runHistoryQueryServer = do
+      runQueryServer <- acceptRunQueryServer
+      Worker{..} <- atomically $ mkWorker WorkerDependencies {..}
+      runConcurrently $
+        Concurrently (runWorker `catch` catchWorker) *> Concurrently runHistoryQueryServer
+  pure $ HistoryQueryServer { runHistoryQueryServer }
+
+catchWorker :: SomeException -> IO ()
+catchWorker = hPutStrLn stderr . ("Query worker crashed with exception: " <>) . show
+
+data WorkerDependencies = WorkerDependencies
+  { runQueryServer   :: RunQueryServer IO
+  , followerStatuses :: STM (Map ContractId FollowerStatus)
+  , followerPageSize :: Natural
+  }
+
+newtype Worker = Worker
+  { runWorker :: IO ()
+  }
+
+mkWorker :: WorkerDependencies -> STM Worker
+mkWorker WorkerDependencies{..} =
+  let
+    RunQueryServer run = runQueryServer
+  in
+    pure Worker { runWorker = run server }
+
+  where
+    server :: RuntimeHistoryQueryServer IO ()
+    server = QueryServer $ pure $ ServerStInit \case
+      GetFollowedContracts -> getFollowedContractsServer followerPageSize followerStatuses
+
+getFollowedContractsServer
+  :: Natural
+  -> STM (Map ContractId FollowerStatus)
+  -> IO (ServerStNext HistoryQuery 'CanReject ContractId Void (Map ContractId FollowerStatus) IO ())
+getFollowedContractsServer followerPageSize followerStatuses = do
+  followers <- atomically followerStatuses
+  next followers
+  where
+  next
+    :: Map ContractId FollowerStatus
+    -> IO (ServerStNext HistoryQuery k ContractId Void (Map ContractId FollowerStatus) IO ())
+  next followers =  do
+    let
+      (results, remaining) = bimap (Map.fromDistinctAscList . fmap snd) (fmap snd)
+        $ break ((== followerPageSize) . fst)
+        $ zip [0..]
+        $ Map.toAscList followers
+      nextPageDelimiter = fst <$> listToMaybe remaining
+    pure $ SendMsgNextPage results nextPageDelimiter ServerStPage
+      { recvMsgDone = pure ()
+      , recvMsgRequestNext = \delimiter -> next
+          $ Map.fromDistinctAscList
+          $ dropWhile ((/= delimiter) . fst) remaining
+      }

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
@@ -28,11 +28,8 @@ import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
 import Language.Marlowe.Runtime.Core.Api (ContractId (..), MarloweVersion (..), MarloweVersionTag (..), Payout (..),
                                           SomeMarloweVersion (..), Transaction (..), TransactionOutput (..),
                                           TransactionScriptOutput (..), parseContractId)
-import Language.Marlowe.Runtime.History.Follower (ContractChanges (..), ContractHistoryError (..), ContractStep (..),
-                                                  CreateStep (..), ExtractCreationError (..),
-                                                  ExtractMarloweTransactionError (..), Follower (..),
-                                                  FollowerDependencies (..), RedeemStep (..), SomeContractChanges (..),
-                                                  mkFollower)
+import Language.Marlowe.Runtime.History.Api
+import Language.Marlowe.Runtime.History.Follower
 import qualified Plutus.V1.Ledger.Api as Plutus
 import qualified PlutusTx.AssocMap as AMap
 import Test.Hspec (Expectation, Spec, it, shouldBe)

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -56,7 +56,12 @@
         buildable = true;
         modules = [
           "Language/Marlowe/Runtime/Core/Api"
+          "Language/Marlowe/Runtime/History"
+          "Language/Marlowe/Runtime/History/Api"
           "Language/Marlowe/Runtime/History/Follower"
+          "Language/Marlowe/Runtime/History/FollowerSupervisor"
+          "Language/Marlowe/Runtime/History/JobServer"
+          "Language/Marlowe/Runtime/History/QueryServer"
           ];
         hsSourceDirs = [ "src" ];
         };
@@ -69,6 +74,55 @@
           buildable = true;
           modules = [ "Paths_marlowe_runtime" ];
           hsSourceDirs = [ "app" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-history" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-history" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-history-cli" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-history-cli" ];
           mainPath = [
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -1095,6 +1095,7 @@
           "cardano-binary-test".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-wrapper".components.library.planned = lib.mkOverride 900 true;
           "pretty-simple".components.setup.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-history".planned = lib.mkOverride 900 true;
           "sort".components.library.planned = lib.mkOverride 900 true;
           "cereal".components.library.planned = lib.mkOverride 900 true;
           "deferred-folds".components.library.planned = lib.mkOverride 900 true;
@@ -1150,6 +1151,7 @@
           "tasty-golden".components.library.planned = lib.mkOverride 900 true;
           "composition-prelude".components.library.planned = lib.mkOverride 900 true;
           "mwc-random".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-history-cli".planned = lib.mkOverride 900 true;
           "mono-traversable".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-core".components.library.planned = lib.mkOverride 900 true;
           "zlib".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -56,7 +56,12 @@
         buildable = true;
         modules = [
           "Language/Marlowe/Runtime/Core/Api"
+          "Language/Marlowe/Runtime/History"
+          "Language/Marlowe/Runtime/History/Api"
           "Language/Marlowe/Runtime/History/Follower"
+          "Language/Marlowe/Runtime/History/FollowerSupervisor"
+          "Language/Marlowe/Runtime/History/JobServer"
+          "Language/Marlowe/Runtime/History/QueryServer"
           ];
         hsSourceDirs = [ "src" ];
         };
@@ -69,6 +74,55 @@
           buildable = true;
           modules = [ "Paths_marlowe_runtime" ];
           hsSourceDirs = [ "app" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-history" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-history" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-history-cli" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-history-cli" ];
           mainPath = [
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -1101,6 +1101,7 @@
           "cardano-binary-test".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-wrapper".components.library.planned = lib.mkOverride 900 true;
           "pretty-simple".components.setup.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-history".planned = lib.mkOverride 900 true;
           "sort".components.library.planned = lib.mkOverride 900 true;
           "cereal".components.library.planned = lib.mkOverride 900 true;
           "deferred-folds".components.library.planned = lib.mkOverride 900 true;
@@ -1157,6 +1158,7 @@
           "tasty-golden".components.library.planned = lib.mkOverride 900 true;
           "composition-prelude".components.library.planned = lib.mkOverride 900 true;
           "mwc-random".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-history-cli".planned = lib.mkOverride 900 true;
           "mono-traversable".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-core".components.library.planned = lib.mkOverride 900 true;
           "zlib".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-runtime.nix
@@ -56,7 +56,12 @@
         buildable = true;
         modules = [
           "Language/Marlowe/Runtime/Core/Api"
+          "Language/Marlowe/Runtime/History"
+          "Language/Marlowe/Runtime/History/Api"
           "Language/Marlowe/Runtime/History/Follower"
+          "Language/Marlowe/Runtime/History/FollowerSupervisor"
+          "Language/Marlowe/Runtime/History/JobServer"
+          "Language/Marlowe/Runtime/History/QueryServer"
           ];
         hsSourceDirs = [ "src" ];
         };
@@ -69,6 +74,55 @@
           buildable = true;
           modules = [ "Paths_marlowe_runtime" ];
           hsSourceDirs = [ "app" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-history" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-history" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";
+          };
+        "marlowe-history-cli" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."network" or (errorHandler.buildDepError "network"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."wl-pprint" or (errorHandler.buildDepError "wl-pprint"))
+            ];
+          buildable = true;
+          modules = [ "Paths_marlowe_runtime" ];
+          hsSourceDirs = [ "marlowe-history-cli" ];
           mainPath = [
             "Main.hs"
             ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "";

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -1098,6 +1098,7 @@
           "cardano-binary-test".components.library.planned = lib.mkOverride 900 true;
           "cardano-crypto-wrapper".components.library.planned = lib.mkOverride 900 true;
           "pretty-simple".components.setup.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-history".planned = lib.mkOverride 900 true;
           "sort".components.library.planned = lib.mkOverride 900 true;
           "cereal".components.library.planned = lib.mkOverride 900 true;
           "deferred-folds".components.library.planned = lib.mkOverride 900 true;
@@ -1153,6 +1154,7 @@
           "tasty-golden".components.library.planned = lib.mkOverride 900 true;
           "composition-prelude".components.library.planned = lib.mkOverride 900 true;
           "mwc-random".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.exes."marlowe-history-cli".planned = lib.mkOverride 900 true;
           "mono-traversable".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-core".components.library.planned = lib.mkOverride 900 true;
           "mintty".components.library.planned = lib.mkOverride 900 true;


### PR DESCRIPTION
Changes included:

- Adds a new `marlowe-history` server process which manages multiple follower threads and exposes a query API and a command API (as well as a temporary repl)
- Adds a new `marlowe-history-cli` which can be used to communicate with a `marlowe-history` server. supported commands:
  - `marlowe-history-cli add CONTRACT_ID` starts following a contract by its ID
  - `marlowe-history-cli rm CONTRACT_ID` stops following a contract by its ID
  - `marlowe-history-cli ls -[sf]` lists all followed contracts. `-s` shows the status of the follower and `-f` also shows failed contracts (e.g. if you use `add` and it fails to follow the contract, the failure message will be shown next to the contract ID with `-sf`)