### PR TITLE
SCP-4267 SCP-4268 SCP-4269 Corrections to property-based tests

### DIFF
--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -84,9 +84,21 @@ library
     Language.Marlowe.Analysis.FSSemantics
     Plutus.Debug
 
+
+flag limit-static-analysis-time
+  description:
+    This flag sets the timeout seconds for static analysis testing of arbitrary
+    contracts, which can take so much time on a complex contract that it exceeds
+    hydra/CI resource limits, see SCP-4267.
+  default: True
+
+
 test-suite marlowe-test
     import: lang
     hs-source-dirs: test
+
+    if flag(limit-static-analysis-time)
+      cpp-options: -DSTATIC_ANALYSIS_TIMEOUT=180
 
     if flag(defer-plugin-errors)
       ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors

--- a/marlowe/test/Spec.hs
+++ b/marlowe/test/Spec.hs
@@ -11,6 +11,7 @@
 -----------------------------------------------------------------------------
 
 
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 
@@ -28,6 +29,16 @@ import qualified Spec.Marlowe.Marlowe (prop_contractJsonLoops, prop_marloweParam
 import qualified Spec.Marlowe.Semantics (tests)
 
 
+-- | Timeout seconds for static analysis, which can take so much time on a complex contract
+--   that it exceeds hydra/CI resource limits, see SCP-4267.
+timeout :: Maybe Int
+#ifdef STATIC_ANALYSIS_TIMEOUT
+timeout = Just $ STATIC_ANALYSIS_TIMEOUT
+#else
+timeout = Nothing
+#endif
+
+
 -- | Entry point for the tests.
 main :: IO ()
 main = defaultMain tests
@@ -41,7 +52,7 @@ tests =
       Spec.Marlowe.Marlowe.tests
     , testGroup "Static Analysis"
       [
-        testProperty "No false positives" Spec.Marlowe.Marlowe.prop_noFalsePositives
+        testProperty "No false positives" $ Spec.Marlowe.Marlowe.prop_noFalsePositives timeout
       ]
     , testGroup "JSON Serialisation"
       [

--- a/marlowe/test/Spec/Marlowe/Semantics/Functions.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics/Functions.hs
@@ -59,11 +59,6 @@ import Test.Tasty.QuickCheck (Arbitrary (..), Gen, Property, Testable (property)
 import qualified PlutusTx.AssocMap as AM (delete, empty, filter, fromList, insert, keys, lookup, member, null, toList)
 
 
--- | FIXME: Turn this off when semantics are fixed, see SCP-4269.
-_ALLOW_ZERO_PAYMENT :: Bool
-_ALLOW_ZERO_PAYMENT = True
-
-
 -- | Run the tests.
 tests :: TestTree
 tests =
@@ -746,7 +741,7 @@ checkReduceContractStepPay =
           && Party payee' == payee
           && case flattenMoney money of
                [(token', amount)] -> token == token' && amount == debit && state' `stateEq` newState
-               []                 -> _ALLOW_ZERO_PAYMENT && state' `stateEq` state
+               []                 -> state' `stateEq` state
                _                  -> False
       checkPayment (Payment account' (Account payee') money) state' =
         let
@@ -757,7 +752,7 @@ checkReduceContractStepPay =
             && Account payee' == payee
             && case flattenMoney money of
                  [(token', amount)] -> token' == token && amount == debit && state' `stateEq` newState'
-                 []                 -> _ALLOW_ZERO_PAYMENT && state' `stateEq` state
+                 []                 -> state' `stateEq` state
                  _                  -> False
     in
       case reduceContractStep environment state (Pay account payee token value contract) of
@@ -772,7 +767,7 @@ checkReduceContractStepPay =
                                                                                                                             && fullAmount
                                                                                                                             && checkPayment payment state'
                                                                                                                             && contract' == contract
-        Reduced (ReducePartialPay account' payee' token' debit' request') (ReduceWithPayment payment) state' contract' -> (positiveAmount || _ALLOW_ZERO_PAYMENT && debit' == 0)
+        Reduced (ReducePartialPay account' payee' token' debit' request') (ReduceWithPayment payment) state' contract' -> (positiveAmount || debit' == 0)
                                                                                                                             && not fullAmount
                                                                                                                             && account' == account
                                                                                                                             && payee' == payee

--- a/marlowe/test/Spec/Marlowe/Semantics/Functions.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics/Functions.hs
@@ -870,12 +870,14 @@ checkGetContinuation =
            action <- arbitrary
            input <- elements [NormalInput content, MerkleizedInput content contractHash' contract']
            case' <- elements [Case action contract, MerkleizedCase action contractHash]
-           pure (input, case', contract, contractHash == contractHash')
-    forAll' gen $ \(input, case', contract, hashesMatch) ->
+           pure (input, case', contract)
+    forAll' gen $ \(input, case', contract) ->
       case (input, case', getContinuation input case') of
-        (NormalInput{}    , Case{}                                       , contract') -> Just contract == contract'
-        (MerkleizedInput _ contractHash _, MerkleizedCase _ contractHash', _        ) -> (contractHash == contractHash') == hashesMatch
-        (_                , _                                            , Nothing  ) -> True
+        (NormalInput{}                   , Case{}                        , contract') -> Just contract == contract'
+        (MerkleizedInput _ contractHash _, MerkleizedCase _ contractHash', Just _   ) -> contractHash == contractHash'
+        (MerkleizedInput _ contractHash _, MerkleizedCase _ contractHash', Nothing  ) -> contractHash /= contractHash'
+        (NormalInput{}                   , MerkleizedCase{}              , Nothing  ) -> True
+        (MerkleizedInput{}               , Case{}                        , Nothing  ) -> True
         _                                                                             -> False
 
 

--- a/marlowe/test/Spec/Marlowe/Semantics/Functions.hs
+++ b/marlowe/test/Spec/Marlowe/Semantics/Functions.hs
@@ -64,11 +64,6 @@ _ALLOW_ZERO_PAYMENT :: Bool
 _ALLOW_ZERO_PAYMENT = True
 
 
--- | FIXME: Turn this off when the `Language.Marlowe.Core.V1.Semantics.getContinuation` test is fixed, see SCP-4268.
-_ALLOW_FAILED_CONTINUATION_ :: Bool
-_ALLOW_FAILED_CONTINUATION_ = True
-
-
 -- | Run the tests.
 tests :: TestTree
 tests =
@@ -882,11 +877,11 @@ checkGetContinuation =
            case' <- elements [Case action contract, MerkleizedCase action contractHash]
            pure (input, case', contract, contractHash == contractHash')
     forAll' gen $ \(input, case', contract, hashesMatch) ->
-      _ALLOW_FAILED_CONTINUATION_ || case (input, case', getContinuation input case') of
-        (NormalInput{}    , Case{}          , contract') -> Just contract == contract'
-        (MerkleizedInput{}, MerkleizedCase{}, contract') -> (Just contract == contract') == hashesMatch
-        (_                , _               , Nothing  ) -> True
-        _                                                -> False
+      case (input, case', getContinuation input case') of
+        (NormalInput{}    , Case{}                                       , contract') -> Just contract == contract'
+        (MerkleizedInput _ contractHash _, MerkleizedCase _ contractHash', _        ) -> (contractHash == contractHash') == hashesMatch
+        (_                , _                                            , Nothing  ) -> True
+        _                                                                             -> False
 
 
 -- | Test `Language.Marlowe.Core.V1.Semantics.applyCases`.

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
@@ -8,7 +8,7 @@
   , config
   , ... }:
   {
-    flags = { defer-plugin-errors = false; };
+    flags = { defer-plugin-errors = false; limit-static-analysis-time = true; };
     package = {
       specVersion = "2.2";
       identifier = { name = "marlowe"; version = "0.1.0.1"; };

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -859,7 +859,10 @@
           "hedgehog-extras" = { flags = {}; };
           "cardano-submit-api" = { flags = {}; };
           "marlowe" = {
-            flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
+            flags = {
+              "limit-static-analysis-time" = lib.mkOverride 900 true;
+              "defer-plugin-errors" = lib.mkOverride 900 false;
+              };
             };
           "cardano-git-rev" = {
             flags = { "systemd" = lib.mkOverride 900 true; };

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
@@ -8,7 +8,7 @@
   , config
   , ... }:
   {
-    flags = { defer-plugin-errors = false; };
+    flags = { defer-plugin-errors = false; limit-static-analysis-time = true; };
     package = {
       specVersion = "2.2";
       identifier = { name = "marlowe"; version = "0.1.0.1"; };

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -864,7 +864,10 @@
           "hedgehog-extras" = { flags = {}; };
           "cardano-submit-api" = { flags = {}; };
           "marlowe" = {
-            flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
+            flags = {
+              "limit-static-analysis-time" = lib.mkOverride 900 true;
+              "defer-plugin-errors" = lib.mkOverride 900 false;
+              };
             };
           "cardano-git-rev" = {
             flags = { "systemd" = lib.mkOverride 900 true; };

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
@@ -8,7 +8,7 @@
   , config
   , ... }:
   {
-    flags = { defer-plugin-errors = false; };
+    flags = { defer-plugin-errors = false; limit-static-analysis-time = true; };
     package = {
       specVersion = "2.2";
       identifier = { name = "marlowe"; version = "0.1.0.1"; };

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -862,7 +862,10 @@
           "hedgehog-extras" = { flags = {}; };
           "cardano-submit-api" = { flags = {}; };
           "marlowe" = {
-            flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
+            flags = {
+              "limit-static-analysis-time" = lib.mkOverride 900 true;
+              "defer-plugin-errors" = lib.mkOverride 900 false;
+              };
             };
           "cardano-git-rev" = {
             flags = { "systemd" = lib.mkOverride 900 true; };


### PR DESCRIPTION
This contains three testing-related changes:
1. SCP-4267 allows the false-positives static-analysis test to timeout without failing.
2. SCP-4269 confirms the warning message for zero payment.
3. SCP-4268 fixes a logical error in the test for `getContinuation`.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
