### PR TITLE
SCP-4364 non-pab tests run again

### DIFF
--- a/marlowe-cli/examples/actus/run-actus.sh
+++ b/marlowe-cli/examples/actus/run-actus.sh
@@ -22,12 +22,12 @@ echo "Signing and verification keys must be provided below for the two parties, 
 
 echo "## Preliminaries"
 
+: "${FAUCET_ADDRESS:?FAUCET_ADDRESS not set}"
+: "${FAUCET_SKEY_FILE:?FAUCET_SKEY_FILE not set}"
+
 echo "### Select Network"
 
-if [[ -z "$MAGIC" ]]
-then
-  MAGIC=1567
-fi
+: "${MAGIC:=2}"
 echo "MAGIC=$MAGIC"
 
 SLOT_LENGTH=$(marlowe-cli util slotting --testnet-magic "$MAGIC" --socket-path "$CARDANO_NODE_SOCKET_PATH" | jq .scSlotLength)
@@ -67,6 +67,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 150000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$LENDER_ADDRESS"
 
 echo "#### The Borrower"
@@ -93,6 +95,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 250000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$BORROWER_ADDRESS"
 
 echo "### Role Tokens"
@@ -269,13 +273,13 @@ marlowe-cli run initialize --testnet-magic "$MAGIC"                  \
 
 echo "In particular, we can extract the contract's address from the "'`'".marlowe"'`'" file."
 
-CONTRACT_ADDRESS=$(jq -r '.marloweValidator.address' tx-1.marlowe)
+CONTRACT_ADDRESS=$(jq -r '.tx.marloweValidator.address' tx-1.marlowe)
 
 echo "The Marlowe contract resides at address "'`'"$CONTRACT_ADDRESS"'`.'
 
 echo "Because this is a role-based contract, we compute the address of the script for roles."
 
-ROLE_ADDRESS=$(jq -r '.rolesValidator.address' tx-1.marlowe)
+ROLE_ADDRESS=$(jq -r '.tx.rolesValidator.address' tx-1.marlowe)
 
 echo "The role address is "'`'"$ROLE_ADDRESS"'`.'
 
@@ -489,8 +493,6 @@ echo "Here are the UTxOs at the borrower $BORROWER_NAME's address:"
 cardano-cli query utxo --testnet-magic "$MAGIC" --address "$BORROWER_ADDRESS" | sed -n -e "1p;2p;/$TX_1/p;/$TX_2/p;/$TX_3/p;/$TX_4/p;/$TX_5/p;/$TX_6/p"
 
 echo "## Clean Up"
-
-FAUCET_ADDRESS=addr_test1wr2yzgn42ws0r2t9lmnavzs0wf9ndrw3hhduyzrnplxwhncaya5f8
 
 TX_7=$(
 marlowe-cli util select --testnet-magic "$MAGIC"                  \

--- a/marlowe-cli/examples/cfd/run-cfd.sh
+++ b/marlowe-cli/examples/cfd/run-cfd.sh
@@ -27,7 +27,7 @@ echo "## Preliminaries"
 
 echo "### Select Network"
 
-: "${MAGIC:=1097911063}"
+: "${MAGIC:=2}"
 echo "MAGIC=$MAGIC"
 
 SLOT_LENGTH=$(marlowe-cli util slotting --testnet-magic "$MAGIC" --socket-path "$CARDANO_NODE_SOCKET_PATH" | jq .scSlotLength)
@@ -814,8 +814,6 @@ echo "Here are the UTxOs at the oracle $ORACLE_NAME's address:"
 cardano-cli query utxo --testnet-magic "$MAGIC" --address "$ORACLE_ADDRESS" | sed -n -e "1p;2p;/$TX_1/p;/$TX_2/p;/$TX_3/p;/$TX_4/p;/$TX_5/p;/$TX_6/p;/$TX_7/p;/$TX_8/p"
 
 echo "## Clean Up"
-
-FAUCET_ADDRESS=addr_test1wr2yzgn42ws0r2t9lmnavzs0wf9ndrw3hhduyzrnplxwhncaya5f8
 
 marlowe-cli transaction simple --testnet-magic "$MAGIC"                  \
                                --socket-path "$CARDANO_NODE_SOCKET_PATH"         \

--- a/marlowe-cli/examples/escrow/run-confirm-claim.sh
+++ b/marlowe-cli/examples/escrow/run-confirm-claim.sh
@@ -29,7 +29,7 @@ echo "## Preliminaries"
 
 echo "### Select Network"
 
-: "${MAGIC:=1097911063}"
+: "${MAGIC:=2}"
 echo "MAGIC=$MAGIC"
 
 SLOT_LENGTH=$(marlowe-cli util slotting --testnet-magic "$MAGIC" --socket-path "$CARDANO_NODE_SOCKET_PATH" | jq .scSlotLength)
@@ -597,8 +597,6 @@ echo "Here are the UTxOs at the mediator $MEDIATOR_NAME's address:"
 cardano-cli query utxo --testnet-magic "$MAGIC" --address "$MEDIATOR_ADDRESS" | sed -n -e "1p;2p;/$TX_1/p;/$TX_2/p;/$TX_3/p;/$TX_4/p;/$TX_5/p;/$TX_6/p;/$TX_7/p"
 
 echo "## Clean Up"
-
-FAUCET_ADDRESS=addr_test1wr2yzgn42ws0r2t9lmnavzs0wf9ndrw3hhduyzrnplxwhncaya5f8
 
 marlowe-cli transaction simple --testnet-magic "$MAGIC"                             \
                                --socket-path "$CARDANO_NODE_SOCKET_PATH"            \

--- a/marlowe-cli/examples/escrow/run-confirm-problem.sh
+++ b/marlowe-cli/examples/escrow/run-confirm-problem.sh
@@ -24,12 +24,12 @@ echo "Signing and verification keys must be provided below for the bystander and
 
 echo "## Preliminaries"
 
+: "${FAUCET_ADDRESS:?FAUCET_ADDRESS not set}"
+: "${FAUCET_SKEY_FILE:?FAUCET_SKEY_FILE not set}"
+
 echo "### Select Network"
 
-if [[ -z "$MAGIC" ]]
-then
-  MAGIC=1567
-fi
+: "${MAGIC:=2}"
 echo "MAGIC=$MAGIC"
 
 SLOT_LENGTH=$(marlowe-cli util slotting --testnet-magic "$MAGIC" --socket-path "$CARDANO_NODE_SOCKET_PATH" | jq .scSlotLength)
@@ -71,6 +71,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 50000000                       \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$SELLER_ADDRESS"
 
 echo "#### The Buyer"
@@ -97,6 +99,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 350000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$BUYER_ADDRESS"
 
 echo "#### The Mediator"
@@ -123,6 +127,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 120000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$MEDIATOR_ADDRESS"
 
 echo "### Role Tokens"
@@ -331,13 +337,13 @@ marlowe-cli run initialize --testnet-magic "$MAGIC"                  \
 
 echo "In particular, we can extract the contract's address from the "'`'".marlowe"'`'" file."
 
-CONTRACT_ADDRESS=$(jq -r '.marloweValidator.address' tx-1.marlowe)
+CONTRACT_ADDRESS=$(jq -r '.tx.marloweValidator.address' tx-1.marlowe)
 
 echo "The Marlowe contract resides at address "'`'"$CONTRACT_ADDRESS"'`.'
 
 echo "Because this is a role-based contract, we compute the address of the script for roles."
 
-ROLE_ADDRESS=$(jq -r '.rolesValidator.address' tx-1.marlowe)
+ROLE_ADDRESS=$(jq -r '.tx.rolesValidator.address' tx-1.marlowe)
 
 echo "The role address is "'`'"$ROLE_ADDRESS"'`.'
 
@@ -550,8 +556,6 @@ echo "Here are the UTxOs at the mediator $MEDIATOR_NAME's address:"
 cardano-cli query utxo --testnet-magic "$MAGIC" --address "$MEDIATOR_ADDRESS" | sed -n -e "1p;2p;/$TX_1/p;/$TX_2/p;/$TX_3/p;/$TX_4/p;/$TX_5/p;/$TX_6/p"
 
 echo "## Clean Up"
-
-FAUCET_ADDRESS=addr_test1wr2yzgn42ws0r2t9lmnavzs0wf9ndrw3hhduyzrnplxwhncaya5f8
 
 marlowe-cli transaction simple --testnet-magic "$MAGIC"                             \
                                --socket-path "$CARDANO_NODE_SOCKET_PATH"            \

--- a/marlowe-cli/examples/escrow/run-dismiss-claim.sh
+++ b/marlowe-cli/examples/escrow/run-dismiss-claim.sh
@@ -24,12 +24,12 @@ echo "Signing and verification keys must be provided below for the bystander and
 
 echo "## Preliminaries"
 
+: "${FAUCET_ADDRESS:?FAUCET_ADDRESS not set}"
+: "${FAUCET_SKEY_FILE:?FAUCET_SKEY_FILE not set}"
+
 echo "### Select Network"
 
-if [[ -z "$MAGIC" ]]
-then
-  MAGIC=1567
-fi
+: "${MAGIC:=2}"
 echo "MAGIC=$MAGIC"
 
 SLOT_LENGTH=$(marlowe-cli util slotting --testnet-magic "$MAGIC" --socket-path "$CARDANO_NODE_SOCKET_PATH" | jq .scSlotLength)
@@ -71,6 +71,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 50000000                       \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$SELLER_ADDRESS"
 
 echo "#### The Buyer"
@@ -97,6 +99,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 350000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$BUYER_ADDRESS"
 
 echo "#### The Mediator"
@@ -123,6 +127,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 120000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$MEDIATOR_ADDRESS"
 
 echo "### Role Tokens"
@@ -331,13 +337,13 @@ marlowe-cli run initialize --testnet-magic "$MAGIC"                  \
 
 echo "In particular, we can extract the contract's address from the "'`'".marlowe"'`'" file."
 
-CONTRACT_ADDRESS=$(jq -r '.marloweValidator.address' tx-1.marlowe)
+CONTRACT_ADDRESS=$(jq -r '.tx.marloweValidator.address' tx-1.marlowe)
 
 echo "The Marlowe contract resides at address "'`'"$CONTRACT_ADDRESS"'`.'
 
 echo "Because this is a role-based contract, we compute the address of the script for roles."
 
-ROLE_ADDRESS=$(jq -r '.rolesValidator.address' tx-1.marlowe)
+ROLE_ADDRESS=$(jq -r '.tx.rolesValidator.address' tx-1.marlowe)
 
 echo "The role address is "'`'"$ROLE_ADDRESS"'`.'
 
@@ -591,8 +597,6 @@ echo "Here are the UTxOs at the mediator $MEDIATOR_NAME's address:"
 cardano-cli query utxo --testnet-magic "$MAGIC" --address "$MEDIATOR_ADDRESS" | sed -n -e "1p;2p;/$TX_1/p;/$TX_2/p;/$TX_3/p;/$TX_4/p;/$TX_5/p;/$TX_6/p;/$TX_7/p"
 
 echo "## Clean Up"
-
-FAUCET_ADDRESS=addr_test1wr2yzgn42ws0r2t9lmnavzs0wf9ndrw3hhduyzrnplxwhncaya5f8
 
 marlowe-cli transaction simple --testnet-magic "$MAGIC"                             \
                                --socket-path "$CARDANO_NODE_SOCKET_PATH"            \

--- a/marlowe-cli/examples/escrow/run-everything-is-alright.sh
+++ b/marlowe-cli/examples/escrow/run-everything-is-alright.sh
@@ -24,12 +24,12 @@ echo "Signing and verification keys must be provided below for the bystander and
 
 echo "## Preliminaries"
 
+: "${FAUCET_ADDRESS:?FAUCET_ADDRESS not set}"
+: "${FAUCET_SKEY_FILE:?FAUCET_SKEY_FILE not set}"
+
 echo "### Select Network"
 
-if [[ -z "$MAGIC" ]]
-then
-  MAGIC=1567
-fi
+: "${MAGIC:=2}"
 echo "MAGIC=$MAGIC"
 
 SLOT_LENGTH=$(marlowe-cli util slotting --testnet-magic "$MAGIC" --socket-path "$CARDANO_NODE_SOCKET_PATH" | jq .scSlotLength)
@@ -71,6 +71,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 50000000                       \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$SELLER_ADDRESS"
 
 echo "#### The Buyer"
@@ -97,6 +99,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 350000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$BUYER_ADDRESS"
 
 echo "#### The Mediator"
@@ -123,6 +127,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 120000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$MEDIATOR_ADDRESS"
 
 echo "### Role Tokens"
@@ -331,13 +337,13 @@ marlowe-cli run initialize --testnet-magic "$MAGIC"                  \
 
 echo "In particular, we can extract the contract's address from the "'`'".marlowe"'`'" file."
 
-CONTRACT_ADDRESS=$(jq -r '.marloweValidator.address' tx-1.marlowe)
+CONTRACT_ADDRESS=$(jq -r '.tx.marloweValidator.address' tx-1.marlowe)
 
 echo "The Marlowe contract resides at address "'`'"$CONTRACT_ADDRESS"'`.'
 
 echo "Because this is a role-based contract, we compute the address of the script for roles."
 
-ROLE_ADDRESS=$(jq -r '.rolesValidator.address' tx-1.marlowe)
+ROLE_ADDRESS=$(jq -r '.tx.rolesValidator.address' tx-1.marlowe)
 
 echo "The role address is "'`'"$ROLE_ADDRESS"'`.'
 
@@ -509,8 +515,6 @@ echo "Here are the UTxOs at the mediator $MEDIATOR_NAME's address:"
 cardano-cli query utxo --testnet-magic "$MAGIC" --address "$MEDIATOR_ADDRESS" | sed -n -e "1p;2p;/$TX_1/p;/$TX_2/p;/$TX_3/p;/$TX_4/p;/$TX_5/p"
 
 echo "## Clean Up"
-
-FAUCET_ADDRESS=addr_test1wr2yzgn42ws0r2t9lmnavzs0wf9ndrw3hhduyzrnplxwhncaya5f8
 
 marlowe-cli transaction simple --testnet-magic "$MAGIC"                             \
                                --socket-path "$CARDANO_NODE_SOCKET_PATH"            \

--- a/marlowe-cli/examples/zcb/run-zcb.sh
+++ b/marlowe-cli/examples/zcb/run-zcb.sh
@@ -22,12 +22,12 @@ echo "Signing and verification keys must be provided below for the two parties, 
 
 echo "## Preliminaries"
 
+: "${FAUCET_ADDRESS:?FAUCET_ADDRESS not set}"
+: "${FAUCET_SKEY_FILE:?FAUCET_SKEY_FILE not set}"
+
 echo "### Select Network"
 
-if [[ -z "$MAGIC" ]]
-then
-  MAGIC=1567
-fi
+: "${MAGIC:=2}"
 echo "MAGIC=$MAGIC"
 
 SLOT_LENGTH=$(marlowe-cli util slotting --testnet-magic "$MAGIC" --socket-path "$CARDANO_NODE_SOCKET_PATH" | jq .scSlotLength)
@@ -67,6 +67,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 150000000                      \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$LENDER_ADDRESS"
 
 echo "#### The Borrower"
@@ -93,6 +95,8 @@ marlowe-cli util faucet --testnet-magic "$MAGIC"                  \
                         --out-file /dev/null                      \
                         --submit 600                              \
                         --lovelace 50000000                       \
+                        --faucet-address "$FAUCET_ADDRESS"        \
+                        --required-signer "$FAUCET_SKEY_FILE"     \
                         "$BORROWER_ADDRESS"
 
 echo "### Role Tokens"
@@ -236,13 +240,13 @@ marlowe-cli run initialize --testnet-magic "$MAGIC"                  \
 
 echo "In particular, we can extract the contract's address from the "'`'".marlowe"'`'" file."
 
-CONTRACT_ADDRESS=$(jq -r '.marloweValidator.address' tx-1.marlowe)
+CONTRACT_ADDRESS=$(jq -r '.tx.marloweValidator.address' tx-1.marlowe)
 
 echo "The Marlowe contract resides at address "'`'"$CONTRACT_ADDRESS"'`.'
 
 echo "Because this is a role-based contract, we compute the address of the script for roles."
 
-ROLE_ADDRESS=$(jq -r '.rolesValidator.address' tx-1.marlowe)
+ROLE_ADDRESS=$(jq -r '.tx.rolesValidator.address' tx-1.marlowe)
 
 echo "The role address is "'`'"$ROLE_ADDRESS"'`.'
 
@@ -423,8 +427,6 @@ echo "Here are the UTxOs at the borrower $BORROWER_NAME's address:"
 cardano-cli query utxo --testnet-magic "$MAGIC" --address "$BORROWER_ADDRESS" | sed -n -e "1p;2p;/$TX_1/p;/$TX_2/p;/$TX_3/p;/$TX_4/p;/$TX_5/p"
 
 echo "## Clean Up"
-
-FAUCET_ADDRESS=addr_test1wr2yzgn42ws0r2t9lmnavzs0wf9ndrw3hhduyzrnplxwhncaya5f8
 
 marlowe-cli transaction simple --testnet-magic "$MAGIC"                             \
                                --socket-path "$CARDANO_NODE_SOCKET_PATH"            \

--- a/marlowe-cli/run-nonpab-tests.sh
+++ b/marlowe-cli/run-nonpab-tests.sh
@@ -79,10 +79,7 @@ export TREASURY
 export FAUCET_ADDRESS
 export FAUCET_SKEY_FILE
 
-# for t in {test/double-satisfaction.sh,examples/*/run-*.sh}
-# shellcheck disable=SC2043
-for t in test/double-satisfaction.sh
-# for t in examples/cfd/run-*.sh
+for t in {test/double-satisfaction.sh,examples/*/run-*.sh}
 do
   if bash -ve "$t" >& "${t%%.sh}.log"
     then echo "PASS: $t"

--- a/marlowe-cli/test/double-satisfaction.sh
+++ b/marlowe-cli/test/double-satisfaction.sh
@@ -25,7 +25,7 @@
 set -ev
 
 
-: "${MAGIC:="1097911063"}"
+: "${MAGIC:="2"}"
 echo "MAGIC=$MAGIC"
 
 


### PR DESCRIPTION
This work exposed an obscure bug in the way payee pkhs are used for
sorting, which has an effect on their tx index. bash code was added to
protect against this but tickets were created for further work in this
area at a later time.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
