### PR TITLE
SCP-4372 Stop stylish-haskell from forcing alignment

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,15 +1,5 @@
 ---
 steps:
-  - simple_align:
-      cases: always
-      top_level_patterns: always
-      records: always
-  - imports:
-      align: none
-      post_qualify: true
-  - language_pragmas:
-      remove_redundant: false
-
   - trailing_whitespace: {}
 columns: 120
 newline: native


### PR DESCRIPTION
This is a preliminary fix to remove the settings from stylish-haskell that were forcing column alignment on us in many parts of Haskell code. It also will not care about existing alignment in source files, which will minimize noisy changes to existing code.

I tested it by changing formatting in a source file of some LANGUAGE pragmas, imports, type signatures, Haddock comments and case statement `->` alignments to confirm it both ignores existing indentation and also allows no alignment.