### PR TITLE
SCP-4453 Validator now forbids close and creation in same tx.

### DIFF
--- a/marlowe/debugging-cookbook.md
+++ b/marlowe/debugging-cookbook.md
@@ -112,6 +112,7 @@ Transaction failures occur in either phase 1 validation (ledger rules) or phase 
     *   `"I0"`: The input datum was not provided to the script.
     *   `"I1"`: Inputting from two Marlowe scripts with the same address in the same transaction is forbidden.
     *   `"L1+"`: The datum or value at the script output does not match the contract's transition.
+    *   `"L2"`: A transaction containing a contract that closes may not also include the creation of a new contract.
     *   `"O0"`: Outputing to two Marlowe scripts with the same address in the same transaction is forbidden.
     *   `"P"`: Insufficient value is paid to a public-key address.
     *   `"R"`: Insufficient value is paid in a role payout. This may occur because the role payout was adjusted to satisfy the minimum-ADA ledger rule, despite that adjustment violating the terms of the contract.

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -150,7 +150,7 @@ mkMarloweValidator
                 payoutsByParty = AssocMap.toList $ foldMap payoutByParty txOutPayments
                 payoutsOk = payoutConstraints payoutsByParty
                 checkContinuation = case txOutContract of
-                    Close -> True
+                    Close -> traceIfFalse "L2" checkScriptOutputAny
                     _ -> let
                         totalIncome = foldMap (collectDeposits . getInputContent) inputs
                         totalPayouts = foldMap snd payoutsByParty
@@ -209,6 +209,8 @@ mkMarloweValidator
     checkScriptOutputRelaxed addr hsh value TxOut{txOutAddress, txOutValue, txOutDatum=OutputDatumHash svh} =
                     txOutValue `Val.geq` value && hsh == Just svh && txOutAddress == addr
     checkScriptOutputRelaxed _ _ _ _ = False
+
+    checkScriptOutputAny = all ((/= ownAddress) . txOutAddress) allOutputs
 
     allOutputs :: [TxOut]
     allOutputs = txInfoOutputs scriptContextTxInfo

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -126,7 +126,7 @@ smallMarloweValidatorSize :: IO ()
 smallMarloweValidatorSize = do
     let validator = Scripts.validatorScript smallMarloweValidator
     let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 12650)
+    assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 12700)
 
 
 -- | Test `extractNonMerkleizedContractRoles`.

--- a/marlowe/test/Spec/Marlowe/Plutus/Specification.hs
+++ b/marlowe/test/Spec/Marlowe/Plutus/Specification.hs
@@ -82,7 +82,7 @@ tests =
             [
               testProperty "Invalid attempt to split Marlowe output" checkMultipleOutput
             ]
-        , testGroup "FAILURE OF Constraint 4. No output to script on close"
+        , testGroup "Constraint 4. No output to script on close"
             [
               testProperty "Invalid attempt to output to Marlowe on close" checkCloseOutput
             ]
@@ -308,9 +308,7 @@ checkCloseOutput =
         infoOutputs <>= (txInInfoResolved <$> inScript)
         shuffle
   in
-    checkSemanticsTransaction noModify modifyAfter doesClose
-      True  -- FIXME: According to the specification, this test should fail.
-      False
+    checkSemanticsTransaction noModify modifyAfter doesClose False False
 
 
 -- | Check that value input to a script matches its input state.


### PR DESCRIPTION
Changed the Marlowe semantics validator to forbid the creation of a new Marlowe contract in the same transaction as when another Marlowe contract closes.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested