### PR TITLE
SCP-4451 history tests

### DIFF
--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -198,6 +198,7 @@ test-suite marlowe-runtime-test
   other-modules:
     Language.Marlowe.Runtime.History.FollowerSpec
     Language.Marlowe.Runtime.History.Script
+    Language.Marlowe.Runtime.HistorySpec
     Spec.Marlowe.Semantics.Arbitrary
     Spec.Marlowe.Semantics.Golden
     Spec.Marlowe.Semantics.Golden.Escrow
@@ -222,6 +223,9 @@ test-suite marlowe-runtime-test
     , QuickCheck
     , some
     , stm
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
     , time
     , transformers
   build-tool-depends: hspec-discover:hspec-discover

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -195,6 +195,7 @@ test-suite marlowe-runtime-test
   main-is: Spec.hs
   other-modules:
     Language.Marlowe.Runtime.History.FollowerSpec
+    Language.Marlowe.Runtime.History.Script
     Paths_marlowe_runtime
   build-depends:
       base >= 4.9 && < 5

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -77,6 +77,7 @@ library
     Language.Marlowe.Runtime.History.QueryServer
     Language.Marlowe.Runtime.History.Store
     Language.Marlowe.Runtime.History.Store.Memory
+    Language.Marlowe.Runtime.History.Store.Model
     Language.Marlowe.Runtime.History.SyncServer
   build-depends:
       base >= 4.9 && < 5
@@ -199,6 +200,7 @@ test-suite marlowe-runtime-test
     Language.Marlowe.Runtime.History.FollowerSpec
     Language.Marlowe.Runtime.History.Script
     Language.Marlowe.Runtime.History.StoreSpec
+    Language.Marlowe.Runtime.History.Store.ModelSpec
     Language.Marlowe.Runtime.HistorySpec
     Spec.Marlowe.Semantics.Arbitrary
     Spec.Marlowe.Semantics.Golden

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -190,12 +190,21 @@ executable marlowe-follower
 
 test-suite marlowe-runtime-test
   import: lang
-  hs-source-dirs: test
+  hs-source-dirs:
+    test
+    ../marlowe/test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
     Language.Marlowe.Runtime.History.FollowerSpec
     Language.Marlowe.Runtime.History.Script
+    Spec.Marlowe.Semantics.Arbitrary
+    Spec.Marlowe.Semantics.Golden
+    Spec.Marlowe.Semantics.Golden.Escrow
+    Spec.Marlowe.Semantics.Golden.Pangram
+    Spec.Marlowe.Semantics.Golden.Swap
+    Spec.Marlowe.Semantics.Golden.Trivial
+    Spec.Marlowe.Semantics.Golden.ZeroCouponBond
     Paths_marlowe_runtime
   build-depends:
       base >= 4.9 && < 5
@@ -210,6 +219,8 @@ test-suite marlowe-runtime-test
     , marlowe-runtime
     , plutus-tx
     , plutus-ledger-api
+    , QuickCheck
+    , some
     , stm
     , time
     , transformers

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -198,6 +198,7 @@ test-suite marlowe-runtime-test
   other-modules:
     Language.Marlowe.Runtime.History.FollowerSpec
     Language.Marlowe.Runtime.History.Script
+    Language.Marlowe.Runtime.History.StoreSpec
     Language.Marlowe.Runtime.HistorySpec
     Spec.Marlowe.Semantics.Arbitrary
     Spec.Marlowe.Semantics.Golden

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Api.hs
@@ -81,6 +81,12 @@ deriving instance Eq (CreateStep 'V1)
 
 data SomeCreateStep = forall v. SomeCreateStep (MarloweVersion v) (CreateStep v)
 
+instance Eq SomeCreateStep where
+  SomeCreateStep MarloweV1 a == SomeCreateStep MarloweV1 b = a == b
+
+instance Show SomeCreateStep where
+  show (SomeCreateStep MarloweV1 a) = show a
+
 instance Binary (CreateStep 'V1) where
   put CreateStep{..} = do
     putDatum MarloweV1 datum

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Store/Model.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Store/Model.hs
@@ -1,0 +1,356 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE RankNTypes         #-}
+
+module Language.Marlowe.Runtime.History.Store.Model where
+
+import Control.Monad (guard, (<=<))
+import Data.Bifunctor (first)
+import Data.Foldable (fold)
+import Data.List (intersperse, sort)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Semigroup (Min (..))
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Tuple (swap)
+import Data.Type.Equality (TestEquality (testEquality), type (:~:) (Refl))
+import GHC.Show (showSpace)
+import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, ChainPoint, WithGenesis (..))
+import Language.Marlowe.Runtime.Core.Api (ContractId, IsMarloweVersion (..), MarloweVersion (..))
+import Language.Marlowe.Runtime.History.Api (ContractStep, CreateStep, SomeCreateStep (SomeCreateStep))
+import Language.Marlowe.Runtime.History.Follower (ContractChanges (..), SomeContractChanges (..))
+import Language.Marlowe.Runtime.History.FollowerSupervisor (UpdateContract (..))
+import Language.Marlowe.Runtime.History.Store (FindNextStepsResponse (..), Intersection (Intersection),
+                                               SomeContractSteps (..))
+
+-- | The history store is modelled as a collection of contract history traces.
+-- Keyed by contract ID.
+newtype HistoryStoreModel = HistoryStoreModel
+  { unHistoryStoreModel :: Map ContractId HistoryRoot
+  } deriving (Eq, Show)
+
+-- | The root of a history tree.
+data HistoryRoot where
+  HistoryRoot
+    :: MarloweVersion v
+    -> BlockHeader -- The block associated with this node.
+    -> CreateStep v -- The creation step of the contract
+    -> [ContractStep v] -- Steps that occurred in the same block
+    -> Set BlockHeader -- The blocks that used to grow as branches from this tree.
+    -> Maybe (HistoryTree v) -- The rest of the history tree.
+    -> HistoryRoot
+
+instance Eq HistoryRoot where
+  (==)
+    (HistoryRoot MarloweV1 block1 create1 steps1 rolledBackBlocks1 next1)
+    (HistoryRoot MarloweV1 block2 create2 steps2 rolledBackBlocks2 next2) =
+      block1 == block2
+      && create1 == create2
+      && steps1 == steps2
+      && rolledBackBlocks1 == rolledBackBlocks2
+      && next1 == next2
+
+instance Show HistoryRoot where
+  showsPrec p (HistoryRoot version block create steps rolledBackBlocks next) =
+    showParen (p >= 11) $ fold $ intersperse showSpace
+      [ showString "HistoryRoot"
+      , showsPrec 11 version
+      , showsPrec 11 block
+      , case version of
+          MarloweV1 -> showsPrec 11 create
+      , case version of
+          MarloweV1 -> showsPrec 11 steps
+      , showsPrec 11 rolledBackBlocks
+      , case version of
+          MarloweV1 -> showsPrec 11 next
+      ]
+
+-- | A tree of contract history branches.
+data HistoryTree v where
+  HistoryTree
+    :: BlockHeader -- The block associated with this node.
+    -> [ContractStep v] -- Steps that occurred at this block
+    -> Set BlockHeader -- The blocks that used to grow as branches from this tree.
+    -> Maybe (HistoryTree v) -- The rest of the history tree.
+    -> HistoryTree v
+
+instance IsMarloweVersion v => Eq (HistoryTree v) where
+  (==)
+    (HistoryTree block1 steps1 rolledBackBlocks1 next1)
+    (HistoryTree block2 steps2 rolledBackBlocks2 next2) =
+      block1 == block2
+      && case marloweVersion @v of
+          MarloweV1 -> steps1 == steps2
+      && rolledBackBlocks1 == rolledBackBlocks2
+      && next1 == next2
+
+instance IsMarloweVersion v => Show (HistoryTree v) where
+  showsPrec p (HistoryTree block steps rolledBackBlocks next) =
+    showParen (p >= 11) $ fold $ intersperse showSpace
+      [ showString "HistoryTree"
+      , showsPrec 11 block
+      , case marloweVersion @v of
+          MarloweV1 -> showsPrec 11 steps
+      , showsPrec 11 rolledBackBlocks
+      , showsPrec 11 next
+      ]
+
+-- | Initialize an empty store model
+emptyHistoryStore :: HistoryStoreModel
+emptyHistoryStore = HistoryStoreModel mempty
+
+-- | Add a new contract to the store. Returns 'Nothing' if the given
+-- 'ContractId' is already present in the store.
+addContract
+  :: ContractId
+  -> MarloweVersion v
+  -> BlockHeader
+  -> CreateStep v
+  -> HistoryStoreModel
+  -> Either String HistoryStoreModel
+addContract contractId version block create (HistoryStoreModel store) = do
+  guard $ not $ Map.member contractId store
+  pure
+    $ HistoryStoreModel
+    $ flip (Map.insert contractId) store
+    $ HistoryRoot version block create [] mempty Nothing
+
+-- | Remove a contract from the store. Returns 'Nothing' if the store does not
+-- contain the given 'ContractId'.
+removeContract
+  :: ContractId
+  -> HistoryStoreModel
+  -> Either String HistoryStoreModel
+removeContract contractId (HistoryStoreModel store) = do
+  guard $ Map.member contractId store
+  pure $ HistoryStoreModel $ Map.delete contractId store
+
+-- | Add new steps to a contract in the store. Returns 'Nothing' if the given
+-- 'BlockHeader' is earlier than the current tip of the contract.
+addSteps
+  :: forall v
+   . ContractId
+  -> MarloweVersion v
+  -> BlockHeader
+  -> [ContractStep v]
+  -> HistoryStoreModel
+  -> Either String HistoryStoreModel
+addSteps contractId version block steps (HistoryStoreModel store) = do
+  root <- note "addSteps: Contract not found" $ Map.lookup contractId store
+  root' <- addStepsToRoot version block steps root
+  pure $ HistoryStoreModel $ Map.insert contractId root' store
+
+-- | Add new steps to a 'HistoryRoot'. Returns 'Nothing' if the given
+-- 'BlockHeader' is earlier than the current tip of the contract.
+
+note :: String -> Maybe a -> Either String a
+note msg = maybe (Left msg) Right
+
+addStepsToRoot
+  :: forall v
+   . MarloweVersion v
+  -> BlockHeader
+  -> [ContractStep v]
+  -> HistoryRoot
+  -> Either String HistoryRoot
+addStepsToRoot version block steps (HistoryRoot version' rootBlock create rootSteps rolledBackBlocks next) = first ("addStepsToRoot: " <>) do
+  Refl <- note "version mismatch" $ testEquality version version'
+  result <- extendTree rootBlock next
+  pure case result of
+    Left rootSteps' -> HistoryRoot version' rootBlock create (rootSteps <> rootSteps') rolledBackBlocks Nothing
+    Right next'     -> HistoryRoot version' rootBlock create rootSteps rolledBackBlocks $ Just next'
+  where
+    extendTree :: BlockHeader -> Maybe (HistoryTree v) -> Either String (Either [ContractStep v] (HistoryTree v))
+    extendTree fromBlock = \case
+      Nothing -> case compare block fromBlock of
+        LT -> Left "adding steps to previous block"
+        EQ -> Right $ Left steps
+        GT -> Right $ Right $ HistoryTree block steps mempty Nothing
+      Just (HistoryTree fromBlock' steps' rolledBackBlocks' next') -> case extendTree fromBlock' next' of
+        Left msg -> Left msg
+        Right (Left steps'') ->
+          Right $ Right $ HistoryTree fromBlock' (steps' <> steps'') rolledBackBlocks' Nothing
+        Right (Right next'') ->
+          Right $ Right $ HistoryTree fromBlock' steps' rolledBackBlocks' $ Just next''
+
+-- | Roll back all contracts in the store to the given point.
+rollback :: ChainPoint -> HistoryStoreModel -> HistoryStoreModel
+rollback = \case
+  Genesis    -> const emptyHistoryStore
+  At toBlock -> HistoryStoreModel . Map.mapMaybe (rollbackRoot toBlock) . unHistoryStoreModel
+
+-- | Roll back a 'HistoryRoot' to the given point.
+rollbackRoot :: BlockHeader -> HistoryRoot -> Maybe HistoryRoot
+rollbackRoot toBlock (HistoryRoot version block create steps rolledBackBlocks next) = do
+  guard $ toBlock >= block
+  pure case rollbackTree toBlock <$> next of
+    Nothing -> HistoryRoot version block create steps rolledBackBlocks Nothing
+    Just (Left rolledBackBlocks') -> HistoryRoot version block create steps (rolledBackBlocks <> rolledBackBlocks') Nothing
+    Just (Right next') -> HistoryRoot version block create steps rolledBackBlocks $ Just next'
+
+-- | Roll back a 'HistoryTree' to a given point. If the rollback point is after
+-- this tree, returns the set of 'BlockHeaders' referenced by the tree and its
+-- descendants.
+rollbackTree :: BlockHeader -> HistoryTree v -> Either (Set BlockHeader) (HistoryTree v)
+rollbackTree toBlock (HistoryTree block steps rolledBackBlocks next) = case nextRolledBack of
+  Left rolledBackBlocks'
+    | toBlock >= block -> Right $ HistoryTree block steps rolledBackBlocks' Nothing
+    | otherwise -> Left rolledBackBlocks'
+  Right next' -> Right $ HistoryTree block steps rolledBackBlocks $ Just next'
+  where
+    nextRolledBack = first (rolledBackBlocks <>) case rollbackTree toBlock <$> next of
+      Nothing                       -> Left mempty
+      Just (Left rolledBackBlocks') -> Left rolledBackBlocks'
+      Just (Right next')            -> Right next'
+
+newtype EndoKleisli m a = EndoKleisli { runEndoKleisli :: a -> m a }
+
+instance Monad m => Semigroup (EndoKleisli m a) where
+  a <> b = EndoKleisli $ runEndoKleisli b <=< runEndoKleisli a
+
+instance Monad m => Monoid (EndoKleisli m a) where
+  mempty = EndoKleisli pure
+
+commitChanges :: Map ContractId UpdateContract -> HistoryStoreModel -> Either String HistoryStoreModel
+commitChanges updates = runEndoKleisli $ fold
+  [ foldMap (uncurry handleUpdate . swap) $ Map.toList updates
+  , EndoKleisli $ Right . handleRollbacks updates
+  ]
+
+handleUpdate :: UpdateContract -> ContractId -> EndoKleisli (Either String) HistoryStoreModel
+handleUpdate = \case
+  RemoveContract -> EndoKleisli . removeContract
+  UpdateContract (SomeContractChanges version ContractChanges{..}) -> \contractId ->
+    fold
+      [ fold $ uncurry (handleCreate contractId version) <$> create
+      , fold $ uncurry (handleSteps contractId version) <$> Map.toAscList steps
+      ]
+
+handleRollbacks :: Map ContractId UpdateContract -> HistoryStoreModel -> HistoryStoreModel
+handleRollbacks updates =
+  let
+    rollbackPoint = getMin <$> foldMap getRollback updates
+  in
+    maybe id rollback rollbackPoint
+
+getRollback :: UpdateContract -> Maybe (Min ChainPoint)
+getRollback = \case
+  RemoveContract                                             -> Nothing
+  UpdateContract (SomeContractChanges _ ContractChanges{..}) -> Min <$> rollbackTo
+
+-- TODO hoist rollback handling to be done over all contracts instead of
+-- per-contract
+rollbackContract
+  :: ContractId
+  -> BlockHeader
+  -> Map ContractId HistoryRoot
+  -> Either String (Map ContractId HistoryRoot)
+rollbackContract contractId toBlock store = do
+  root <- note "rollbackContract: contract not found" $ Map.lookup contractId store
+  pure case rollbackRoot toBlock root of
+    Nothing    -> Map.delete contractId store
+    Just root' -> Map.insert contractId root' store
+
+handleCreate
+  :: ContractId
+  -> MarloweVersion v
+  -> BlockHeader
+  -> CreateStep v
+  -> EndoKleisli (Either String) HistoryStoreModel
+handleCreate contractId version createBlock createStep =
+  EndoKleisli $ addContract contractId version createBlock createStep
+
+handleSteps
+  :: ContractId
+  -> MarloweVersion v
+  -> BlockHeader
+  -> [ContractStep v]
+  -> EndoKleisli (Either String) HistoryStoreModel
+handleSteps contractId version block steps = EndoKleisli
+  $ addSteps contractId version block steps
+
+findCreateStep
+  :: ContractId
+  -> HistoryStoreModel
+  -> Maybe (BlockHeader, SomeCreateStep)
+findCreateStep contractId (HistoryStoreModel store) = do
+  HistoryRoot version block create _ _ _ <- Map.lookup contractId store
+  pure (block, SomeCreateStep version create)
+
+findIntersection
+  :: ContractId
+  -> [BlockHeader]
+  -> HistoryStoreModel
+  -> Maybe Intersection
+findIntersection contractId blocks (HistoryStoreModel store) = do
+  HistoryRoot version block _ _ _ next <- Map.lookup contractId store
+  case sort blocks of
+    [] -> Nothing
+    block' : blocks'
+      | block == block -> intersect version block' blocks' next
+      | otherwise -> Nothing
+  where
+    intersect version candidate blocks' = \case
+      Nothing -> Just $ Intersection version candidate
+      Just (HistoryTree block _ _ next') -> case blocks' of
+        [] -> Just $ Intersection version candidate
+        candidate' : blocks''
+          | block == candidate' -> intersect version candidate' blocks'' next'
+          | otherwise -> Just $ Intersection version candidate
+
+findNextSteps
+  :: ContractId
+  -> ChainPoint
+  -> HistoryStoreModel
+  -> FindNextStepsResponse
+findNextSteps contractId afterPoint (HistoryStoreModel store) = case Map.lookup contractId store of
+  Nothing -> FindRollback Genesis
+  Just (HistoryRoot version block _ steps rolledBackBlocks next) -> case (trimPoint block afterPoint, steps) of
+    (Genesis, [])      -> findNextSteps' block version $ HistoryTree block steps rolledBackBlocks next
+    (Genesis, _)       -> FindNext block (SomeContractSteps version steps)
+    (At afterBlock, _) -> findNextSteps' afterBlock version $ HistoryTree block steps rolledBackBlocks next
+  where
+    trimPoint block point
+      | point < At block = Genesis
+      | otherwise = point
+    findNextSteps' afterBlock version (HistoryTree block steps rolledBackBlocks next)
+      | afterBlock < block = FindNext block (SomeContractSteps version steps)
+      | Set.member afterBlock rolledBackBlocks = FindRollback $ At block
+      | otherwise = maybe (FindWait block) (findNextSteps' afterBlock version) next
+
+getRoots :: HistoryStoreModel -> [(ContractId, HistoryRoot)]
+getRoots = Map.toList . unHistoryStoreModel
+
+getAllBlocks :: HistoryStoreModel -> [BlockHeader]
+getAllBlocks = Set.toAscList . foldMap getAllRootBlocks . unHistoryStoreModel
+
+getBlocks :: HistoryStoreModel -> [BlockHeader]
+getBlocks = Set.toAscList . foldMap getRootBlocks . unHistoryStoreModel
+
+getAllRootBlocks :: HistoryRoot -> Set BlockHeader
+getAllRootBlocks (HistoryRoot _ block _ _ rolledBackBlocks next) =
+  Set.insert block $ rolledBackBlocks <> foldMap getAllTreeBlocks next
+
+getRootBlocks :: HistoryRoot -> Set BlockHeader
+getRootBlocks (HistoryRoot _ block _ _ _ next) = Set.insert block $ foldMap getTreeBlocks next
+
+getAllTreeBlocks :: HistoryTree v -> Set BlockHeader
+getAllTreeBlocks (HistoryTree block _ rolledBackBlocks next) =
+  Set.insert block $ rolledBackBlocks <> foldMap getTreeBlocks next
+
+getTreeBlocks :: HistoryTree v -> Set BlockHeader
+getTreeBlocks (HistoryTree block _ _ next) = Set.insert block $ foldMap getTreeBlocks next
+
+getTip :: HistoryStoreModel -> ChainPoint
+getTip = foldr (max . getRootTip) Genesis . unHistoryStoreModel
+
+getRootTip :: HistoryRoot -> ChainPoint
+getRootTip (HistoryRoot _ block _ _ _ Nothing) = At block
+getRootTip (HistoryRoot _ _ _ _ _ (Just next)) = getTreeTip next
+
+getTreeTip :: HistoryTree v -> ChainPoint
+getTreeTip (HistoryTree block _ _ Nothing) = At block
+getTreeTip (HistoryTree _ _ _ (Just next)) = getTreeTip next

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
@@ -1,41 +1,63 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE GADTs              #-}
 
 module Language.Marlowe.Runtime.History.Script where
 
-import Control.Monad (foldM, (<=<))
+import Control.Monad (foldM, replicateM, (<=<))
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State (StateT (..), get, put)
 import Data.Bifunctor (Bifunctor (bimap))
+import qualified Data.ByteString as BS
 import Data.Data (type (:~:) (Refl))
+import Data.Foldable (fold)
+import Data.GADT.Show (GShow (..))
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (mapMaybe)
+import Data.Maybe (mapMaybe, maybeToList)
+import Data.Some (Some (Some), withSome)
 import Data.Type.Equality (testEquality)
 import qualified Language.Marlowe.Core.V1.Semantics as V1
 import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
 import Language.Marlowe.Runtime.ChainSync.Api (AssetId (..), Assets (..), BlockHeader (..), BlockHeaderHash (..),
-                                               Lovelace (..), PolicyId (..), SlotNo, TokenName (..), Tokens (..), TxId,
-                                               TxOutRef (..))
+                                               Lovelace (..), PolicyId (..), SlotNo (..), TokenName (..), Tokens (..),
+                                               TxId (..), TxOutRef (..))
 import Language.Marlowe.Runtime.Core.Api
 import Language.Marlowe.Runtime.History.Api
 import Numeric.Natural (Natural)
 import qualified Plutus.V1.Ledger.Api as P
 import qualified PlutusTx.AssocMap as AM
+import Spec.Marlowe.Semantics.Arbitrary (arbitraryValidStep)
+import Test.QuickCheck (Gen, arbitrary, frequency, getSize, resize)
+import Test.QuickCheck.Gen (chooseWord64)
 
 -- An event in a history test script
-data HistoryScriptEvent
+data HistoryScriptEvent v
   -- Extend the chain with a new block
   = RollForward SlotNo BlockHeaderHash
   -- Retract the given number of blocks from the chain.
   | RollBackward Natural
   -- Create a new contract in the current block
-  | forall v. CreateContract ContractId (MarloweVersion v) (CreateStep v)
+  | CreateContract ContractId (MarloweVersion v) (CreateStep v)
   -- Apply Inputs to a contract in the current block
-  | forall v. ApplyInputs ContractId TxId (MarloweVersion v) (Redeemer v)
+  | ApplyInputs ContractId TxId (MarloweVersion v) P.POSIXTime P.POSIXTime (Redeemer v)
   -- Withdraw funds from a contract in the current block
-  | forall v. Withdraw ContractId (MarloweVersion v) (RedeemStep v)
+  | Withdraw ContractId (MarloweVersion v) (RedeemStep v)
 
-newtype HistoryScript = HistoryScript { unHistoryScript :: [HistoryScriptEvent] }
+deriving instance Show (HistoryScriptEvent 'V1)
+deriving instance Eq (HistoryScriptEvent 'V1)
+
+instance GShow HistoryScriptEvent where
+  gshowsPrec p = \case
+    RollForward s b                             -> showsPrec p (RollForward s b :: HistoryScriptEvent 'V1)
+    RollBackward n                              -> showsPrec p (RollBackward n :: HistoryScriptEvent 'V1)
+    CreateContract cid MarloweV1 cs             -> showsPrec p $ CreateContract cid MarloweV1 cs
+    ApplyInputs cid txId MarloweV1 vLow vHigh r -> showsPrec p $ ApplyInputs cid txId MarloweV1 vLow vHigh r
+    Withdraw cid MarloweV1 rs                   -> showsPrec p $ Withdraw cid MarloweV1 rs
+
+newtype HistoryScript = HistoryScript { unHistoryScript :: [Some HistoryScriptEvent] }
+  deriving (Show)
 
 -- A list of state snapshots in descending block order
 type HistoryScriptState = [HistoryScriptBlockState]
@@ -63,9 +85,9 @@ data ReductionError
   | V1TransactionError V1.TransactionError
 
 foldScript :: HistoryScript -> Either ReductionError HistoryScriptState
-foldScript = foldM (flip reduceScriptEvent) [] . unHistoryScript
+foldScript = foldM (\state (Some event) -> reduceScriptEvent event state) [] . unHistoryScript
 
-reduceScriptEvent :: HistoryScriptEvent -> HistoryScriptState -> Either ReductionError HistoryScriptState
+reduceScriptEvent :: HistoryScriptEvent v -> HistoryScriptState -> Either ReductionError HistoryScriptState
 reduceScriptEvent = \case
   RollForward slotOffset headerHash -> \case
     states@(HistoryScriptBlockState{..} : _) ->
@@ -101,7 +123,7 @@ reduceScriptEvent = \case
               state' = state { contractStates = Map.insert contractId contractState contractStates }
             in
               Right $ state' : states
-  ApplyInputs contractId txId version redeemer ->
+  ApplyInputs contractId txId version vLow vHigh redeemer ->
     \case
       []                              -> Left EmptyChain
       state@HistoryScriptBlockState{..} : states -> case Map.lookup contractId contractStates of
@@ -112,8 +134,7 @@ reduceScriptEvent = \case
             datum <- case stateScriptOutput of
               Nothing                          -> Left $ ContractClosed contractId
               Just TransactionScriptOutput{..} -> Right datum
-            let BlockHeader{slotNo} = block
-            TransactionOutput{..} <- applyInputs version slotNo txId redeemer datum
+            TransactionOutput{..} <- applyInputs version vLow vHigh txId redeemer datum
             let
               state' = state
                 { contractStates = Map.insert
@@ -147,12 +168,12 @@ reduceScriptEvent = \case
                 in
                   Right $ state' : states
 
-applyInputs :: MarloweVersion v -> SlotNo -> TxId -> Redeemer v -> Datum v -> Either ReductionError (TransactionOutput v)
+applyInputs :: MarloweVersion v -> P.POSIXTime -> P.POSIXTime -> TxId -> Redeemer v -> Datum v -> Either ReductionError (TransactionOutput v)
 applyInputs = \case
   MarloweV1 -> applyInputsV1
 
-applyInputsV1 :: SlotNo -> TxId -> [V1.Input] -> V1.MarloweData -> Either ReductionError (TransactionOutput 'V1)
-applyInputsV1 slot txId txInputs V1.MarloweData{..} =
+applyInputsV1 :: P.POSIXTime -> P.POSIXTime -> TxId -> [V1.Input] -> V1.MarloweData -> Either ReductionError (TransactionOutput 'V1)
+applyInputsV1 vLow vHigh txId txInputs V1.MarloweData{..} =
   case V1.computeTransaction V1.TransactionInput{..} marloweState marloweContract of
     V1.Error err -> Left $V1TransactionError err
     V1.TransactionOutput{..} -> Right $ TransactionOutput
@@ -165,17 +186,7 @@ applyInputsV1 slot txId txInputs V1.MarloweData{..} =
             }
       }
   where
-    intervalMax = \case
-      V1.Close         -> P.POSIXTime 9999999999
-      V1.Pay _ _ _ _ c -> intervalMax c
-      V1.If _ c1 c2    -> min (intervalMax c1) (intervalMax c2)
-      V1.When _ t c
-        | t <= fromIntegral slot -> intervalMax c
-        | otherwise -> t
-      V1.Let _ _ c     -> intervalMax c
-      V1.Assert _ c    -> intervalMax c
-    txInterval = (fromIntegral slot, intervalMax marloweContract)
-
+    txInterval = (vLow, vHigh)
     paymentToPayout :: V1.Payment -> Maybe (Payout 'V1)
     paymentToPayout (V1.Payment _ (V1.Party (V1.Role role)) money) = Just $ Payout
       { assets = moneyToAssets money
@@ -202,9 +213,84 @@ applyInputsV1 slot txId txInputs V1.MarloweData{..} =
 
     assocLeft (a, (b, c)) = ((a, b), c)
 
-
     fromPlutusTokenName :: P.TokenName -> TokenName
     fromPlutusTokenName = TokenName . P.fromBuiltin . P.unTokenName
 
     fromPlutusCurrencySymbol :: P.CurrencySymbol -> PolicyId
     fromPlutusCurrencySymbol = PolicyId . P.fromBuiltin . P.unCurrencySymbol
+
+genHistoryScript :: StateT HistoryScriptState Gen [Some HistoryScriptEvent]
+genHistoryScript = do
+  states <- get
+  event <- lift case states of
+    []        -> genRollForward
+    state : _ -> genHistoryScriptEvent state
+  put case withSome event $ flip reduceScriptEvent states of
+    Left _        -> error "Failed to reduce script event while generating script"
+    Right states' -> states'
+  (event :) <$> StateT \state -> do
+    size <- getSize
+    resize (size - 1) $ runStateT genHistoryScript state
+
+genHistoryScriptEvent :: HistoryScriptBlockState -> Gen (Some HistoryScriptEvent)
+genHistoryScriptEvent HistoryScriptBlockState{..} = frequency $ fold
+  [ blockEvents
+  , (fmap (2,) . uncurry contractEvents) =<< Map.toList contractStates
+  , [(5, genCreateContract slotNo)]
+  ]
+  where
+    BlockHeader{..} = block
+    blockEvents = [(5, genRollForward), (1, genRollBackward)]
+    contractEvents contractId HistoryScriptContractState{..} = (fmap . fmap) Some $ fold
+      [ maybeToList $ genApplyInputs contractVersion slotNo contractId <$> stateScriptOutput
+      , uncurry (genWithdraw contractVersion contractId) <$> Map.toList statePayouts
+      ]
+
+genRollForward :: Gen (Some HistoryScriptEvent)
+genRollForward = do
+  slots <- SlotNo <$> chooseWord64 (1, 120)
+  header <- BlockHeaderHash . BS.pack <$> replicateM 64 arbitrary
+  pure $ Some $ RollForward slots header
+
+genRollBackward :: Gen (Some HistoryScriptEvent)
+genRollBackward = Some . RollBackward <$> frequency
+  [ (1, pure 7)
+  , (1, pure 6)
+  , (2, pure 5)
+  , (3, pure 4)
+  , (5, pure 3)
+  , (8, pure 2)
+  , (13, pure 1)
+  ]
+
+genCreateContract :: SlotNo -> Gen (Some HistoryScriptEvent)
+genCreateContract slot = do
+  contractId <- ContractId . flip TxOutRef 0 <$> genTxId
+  datum <- V1.MarloweData (V1.emptyState $ fromIntegral slot) <$> arbitrary
+  let scriptAddress = "7062c56ccfc6217aff5692e1d3ebe89c21053d31fc11882cb21bfdd307"
+  let payoutValidatorHash = "a2c56ccfc6217aff5692e1d3ebe89c21053d31fc11882cb21bfdd307"
+  pure $ Some $ CreateContract contractId MarloweV1 CreateStep{..}
+
+genTxId :: Gen TxId
+genTxId = TxId . BS.pack <$> replicateM 64 arbitrary
+
+genApplyInputs :: MarloweVersion v -> SlotNo -> ContractId -> TransactionScriptOutput v -> Gen (HistoryScriptEvent v)
+genApplyInputs = \case
+  MarloweV1 -> genApplyInputsV1
+
+genApplyInputsV1 :: SlotNo -> ContractId -> TransactionScriptOutput 'V1 -> Gen (HistoryScriptEvent 'V1)
+genApplyInputsV1 slot contractId TransactionScriptOutput{..} = do
+  let V1.MarloweData{..} = datum
+  let minTime = fromIntegral slot
+  V1.TransactionInput (vLow, vHigh) inputs <- arbitraryValidStep marloweState {V1.minTime=minTime} marloweContract
+  txId <- genTxId
+  pure $ ApplyInputs contractId txId MarloweV1 vLow vHigh inputs
+
+genWithdraw :: MarloweVersion v -> ContractId -> TxOutRef -> Payout v -> Gen (HistoryScriptEvent v)
+genWithdraw = \case
+  MarloweV1 -> genWithdrawV1
+
+genWithdrawV1 :: ContractId -> TxOutRef -> Payout 'V1 -> Gen (HistoryScriptEvent 'V1)
+genWithdrawV1 contractId utxo Payout{..} = do
+  redeemingTx <- genTxId
+  pure $ Withdraw contractId MarloweV1 RedeemStep{..}

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE GADTs              #-}
+
+module Language.Marlowe.Runtime.History.Script where
+
+import Control.Monad (foldM, (<=<))
+import Data.Bifunctor (Bifunctor (bimap))
+import Data.Data (type (:~:) (Refl))
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (mapMaybe)
+import Data.Type.Equality (testEquality)
+import qualified Language.Marlowe.Core.V1.Semantics as V1
+import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
+import Language.Marlowe.Runtime.ChainSync.Api (AssetId (..), Assets (..), BlockHeader (..), BlockHeaderHash (..),
+                                               Lovelace (..), PolicyId (..), SlotNo, TokenName (..), Tokens (..), TxId,
+                                               TxOutRef (..))
+import Language.Marlowe.Runtime.Core.Api
+import Language.Marlowe.Runtime.History.Api
+import Numeric.Natural (Natural)
+import qualified Plutus.V1.Ledger.Api as P
+import qualified PlutusTx.AssocMap as AM
+
+-- An event in a history test script
+data HistoryScriptEvent
+  -- Extend the chain with a new block
+  = RollForward SlotNo BlockHeaderHash
+  -- Retract the given number of blocks from the chain.
+  | RollBackward Natural
+  -- Create a new contract in the current block
+  | forall v. CreateContract ContractId (MarloweVersion v) (CreateStep v)
+  -- Apply Inputs to a contract in the current block
+  | forall v. ApplyInputs ContractId TxId (MarloweVersion v) (Redeemer v)
+  -- Withdraw funds from a contract in the current block
+  | forall v. Withdraw ContractId (MarloweVersion v) (RedeemStep v)
+
+newtype HistoryScript = HistoryScript { unHistoryScript :: [HistoryScriptEvent] }
+
+-- A list of state snapshots in descending block order
+type HistoryScriptState = [HistoryScriptBlockState]
+
+-- An aggregate state snapshot at a particular block
+data HistoryScriptBlockState = HistoryScriptBlockState
+  { contractStates :: Map ContractId HistoryScriptContractState
+  , block          :: BlockHeader
+  }
+
+-- A state snapshot for a particular contract
+data HistoryScriptContractState = forall v. HistoryScriptContractState
+  { contractVersion   :: MarloweVersion v
+  , statePayouts      :: Map TxOutRef (Payout v)
+  , stateScriptOutput :: Maybe (TransactionScriptOutput v)
+  }
+
+data ReductionError
+  = EmptyChain
+  | ContractExists ContractId
+  | ContractNotFound ContractId
+  | ContractClosed ContractId
+  | PayoutNotFound ContractId TxOutRef
+  | forall v1 v2. VersionMismatch ContractId (MarloweVersion v1) (MarloweVersion v2)
+  | V1TransactionError V1.TransactionError
+
+foldScript :: HistoryScript -> Either ReductionError HistoryScriptState
+foldScript = foldM (flip reduceScriptEvent) [] . unHistoryScript
+
+reduceScriptEvent :: HistoryScriptEvent -> HistoryScriptState -> Either ReductionError HistoryScriptState
+reduceScriptEvent = \case
+  RollForward slotOffset headerHash -> \case
+    states@(HistoryScriptBlockState{..} : _) ->
+      let
+        BlockHeader{slotNo,blockNo} = block
+        blockState = HistoryScriptBlockState
+          { contractStates
+          , block = BlockHeader
+            { slotNo = slotOffset + slotNo
+            , headerHash
+            , blockNo = blockNo + 1
+            }
+          }
+      in
+        Right $ blockState : states
+    [] -> Right [HistoryScriptBlockState mempty $ BlockHeader slotOffset headerHash 0]
+  RollBackward n -> Right . drop (fromIntegral n)
+  CreateContract contractId version CreateStep{..} ->
+    \case
+      []                              -> Left EmptyChain
+      state@HistoryScriptBlockState{..} : states
+        | Map.member contractId contractStates -> Left $ ContractExists contractId
+        | otherwise ->
+            let
+              contractState = HistoryScriptContractState
+                { contractVersion = version
+                , statePayouts = mempty
+                , stateScriptOutput = Just TransactionScriptOutput
+                    { utxo = unContractId contractId
+                    , datum
+                    }
+                }
+              state' = state { contractStates = Map.insert contractId contractState contractStates }
+            in
+              Right $ state' : states
+  ApplyInputs contractId txId version redeemer ->
+    \case
+      []                              -> Left EmptyChain
+      state@HistoryScriptBlockState{..} : states -> case Map.lookup contractId contractStates of
+        Nothing -> Left $ ContractNotFound contractId
+        Just HistoryScriptContractState{..} -> case testEquality version contractVersion of
+          Nothing   -> Left $ VersionMismatch contractId version contractVersion
+          Just Refl -> do
+            datum <- case stateScriptOutput of
+              Nothing                          -> Left $ ContractClosed contractId
+              Just TransactionScriptOutput{..} -> Right datum
+            let BlockHeader{slotNo} = block
+            TransactionOutput{..} <- applyInputs version slotNo txId redeemer datum
+            let
+              state' = state
+                { contractStates = Map.insert
+                    contractId
+                    HistoryScriptContractState
+                      { contractVersion
+                      , statePayouts = Map.union statePayouts payouts
+                      , stateScriptOutput = scriptOutput
+                      }
+                    contractStates
+                }
+            pure $ state' : states
+  Withdraw contractId version RedeemStep{..} ->
+    \case
+      []                              -> Left EmptyChain
+      state@HistoryScriptBlockState{..} : states -> case Map.lookup contractId contractStates of
+        Nothing -> Left $ ContractNotFound contractId
+        Just HistoryScriptContractState{..} -> case testEquality version contractVersion of
+          Nothing   -> Left $ VersionMismatch contractId version contractVersion
+          Just Refl -> do
+            case Map.lookup utxo statePayouts of
+              Nothing -> Left $ PayoutNotFound contractId utxo
+              Just _ ->
+                let
+                  contractState' = HistoryScriptContractState
+                    { contractVersion
+                    , stateScriptOutput
+                    , statePayouts = Map.delete utxo statePayouts
+                    }
+                  state' = state { contractStates = Map.insert contractId contractState' contractStates }
+                in
+                  Right $ state' : states
+
+applyInputs :: MarloweVersion v -> SlotNo -> TxId -> Redeemer v -> Datum v -> Either ReductionError (TransactionOutput v)
+applyInputs = \case
+  MarloweV1 -> applyInputsV1
+
+applyInputsV1 :: SlotNo -> TxId -> [V1.Input] -> V1.MarloweData -> Either ReductionError (TransactionOutput 'V1)
+applyInputsV1 slot txId txInputs V1.MarloweData{..} =
+  case V1.computeTransaction V1.TransactionInput{..} marloweState marloweContract of
+    V1.Error err -> Left $V1TransactionError err
+    V1.TransactionOutput{..} -> Right $ TransactionOutput
+      { payouts = Map.fromList $ zip (TxOutRef txId <$> [1..]) $ mapMaybe paymentToPayout txOutPayments
+      , scriptOutput = case txOutContract of
+          V1.Close -> Nothing
+          _ -> Just TransactionScriptOutput
+            { utxo = TxOutRef txId 0
+            , datum = V1.MarloweData txOutState txOutContract
+            }
+      }
+  where
+    intervalMax = \case
+      V1.Close         -> P.POSIXTime 9999999999
+      V1.Pay _ _ _ _ c -> intervalMax c
+      V1.If _ c1 c2    -> min (intervalMax c1) (intervalMax c2)
+      V1.When _ t c
+        | t <= fromIntegral slot -> intervalMax c
+        | otherwise -> t
+      V1.Let _ _ c     -> intervalMax c
+      V1.Assert _ c    -> intervalMax c
+    txInterval = (fromIntegral slot, intervalMax marloweContract)
+
+    paymentToPayout :: V1.Payment -> Maybe (Payout 'V1)
+    paymentToPayout (V1.Payment _ (V1.Party (V1.Role role)) money) = Just $ Payout
+      { assets = moneyToAssets money
+      , datum = fromPlutusTokenName role
+      }
+    paymentToPayout _                                              = Nothing
+
+    moneyToAssets :: V1.Money -> Assets
+    moneyToAssets = Assets <$> moneyToLovelace <*> moneyToTokens
+
+    moneyToLovelace :: V1.Money -> Lovelace
+    moneyToLovelace = Lovelace . maybe 0 fromIntegral . (AM.lookup "" <=< AM.lookup "") . P.getValue
+
+    moneyToTokens :: V1.Money -> Tokens
+    moneyToTokens = Tokens
+      . Map.fromList
+      . fmap
+          ( bimap (uncurry AssetId . bimap fromPlutusCurrencySymbol fromPlutusTokenName) fromIntegral
+          . assocLeft
+          )
+      . (traverse AM.toList <=< AM.toList)
+      . AM.delete ""
+      . P.getValue
+
+    assocLeft (a, (b, c)) = ((a, b), c)
+
+
+    fromPlutusTokenName :: P.TokenName -> TokenName
+    fromPlutusTokenName = TokenName . P.fromBuiltin . P.unTokenName
+
+    fromPlutusCurrencySymbol :: P.CurrencySymbol -> PolicyId
+    fromPlutusCurrencySymbol = PolicyId . P.fromBuiltin . P.unCurrencySymbol

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/Store/ModelSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/Store/ModelSpec.hs
@@ -1,0 +1,138 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE ExistentialQuantification #-}
+
+module Language.Marlowe.Runtime.History.Store.ModelSpec (spec, genFindCreateStepArgs, genFindNextStepArgs, modelFromScript) where
+
+import Data.Bifunctor (Bifunctor (first))
+import Data.List (foldl')
+import qualified Data.Set as Set
+import Data.Some (withSome)
+import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader (..), ChainPoint, TxIx (..), TxOutRef (..), WithGenesis (..))
+import Language.Marlowe.Runtime.Core.Api (ContractId (..), SomeMarloweVersion (..), Transaction (..))
+import Language.Marlowe.Runtime.History.Api (ContractStep (..), SomeCreateStep (..))
+import Language.Marlowe.Runtime.History.Script (HistoryScript (..), HistoryScriptEvent (..), genTxId)
+import Language.Marlowe.Runtime.History.Store (FindNextStepsResponse (..), Intersection (..), SomeContractSteps (..))
+import Language.Marlowe.Runtime.History.Store.Model (HistoryRoot (..), HistoryStoreModel (..), addContract, addSteps,
+                                                     emptyHistoryStore, findCreateStep, findIntersection, findNextSteps,
+                                                     getAllBlocks, getBlocks, getRootBlocks, getRoots, getTip, rollback)
+import Test.Hspec (Spec)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (Arbitrary (..), Gen, chooseInt, discard, elements, frequency, oneof, sublistOf, suchThat, (===))
+import Test.QuickCheck.Property ((==>))
+
+instance Arbitrary HistoryStoreModel where
+  arbitrary = modelFromScript <$> arbitrary
+
+modelFromScript :: HistoryScript -> HistoryStoreModel
+modelFromScript = snd
+  . foldl' (\store event -> withSome event mkStep store) ([], emptyHistoryStore)
+  . unHistoryScript
+
+pickRoot :: HistoryStoreModel -> Gen (ContractId, HistoryRoot)
+pickRoot = elements . getRoots
+
+genIntersectionBlocks :: HistoryStoreModel -> HistoryRoot -> Gen [BlockHeader]
+genIntersectionBlocks store root = oneof
+  [ sublistOf $ getAllBlocks store
+  , do
+      let contractBlocks = Set.toAscList $ getRootBlocks root
+      n <- chooseInt (0, length contractBlocks)
+      pure $ take n contractBlocks
+  ]
+
+genPoint :: HistoryStoreModel -> Gen ChainPoint
+genPoint = elements . (Genesis :) . fmap At . getBlocks
+
+spec :: Spec
+spec = do
+  -- This property specifies that after a rollback, the tip of the store will
+  -- be equal to the rollback point
+  prop "getTip / rollback" \store -> do
+    point <- genPoint store
+    pure $ getTip (rollback point store) === point
+
+  -- This property specifies that performing two rollbacks in a row is
+  -- equivalent to rolling back to the second point directly.
+  prop "rollback composition" \store -> do
+    point1 <- genPoint store
+    point2 <- genPoint store `suchThat` (<= point1)
+    pure $ rollback point2 (rollback point1 store) === rollback point2 store
+
+  -- This property specifies that performing a rollback to a specific block is
+  -- an idempotent operation.
+  prop "rollback idempotent" \store -> do
+    point <- genPoint store
+    pure $ rollback point (rollback point store) === rollback point store
+
+  -- This property specifies that the result of calling findIntersection
+  -- can never return a point bigger than the tip.
+  prop "find intersection constraint" \store -> not (null $ getRoots store) ==> do
+    (contractId, root) <- pickRoot store
+    intersectionPoints <- genIntersectionBlocks store root
+    let intersect = findIntersection contractId intersectionPoints store
+    pure case intersect of
+      Nothing                     -> discard
+      Just (Intersection _ block) -> At block <= getTip store
+
+  -- This property specifies that rolling back to the tip is a no-op.
+  prop "rollback tip" \store ->
+    rollback (getTip store) store === store
+
+  -- This property specifies that finding a contract that exists succeeds.
+  prop "getRoot / findCreateStep" \store -> not (null $ getRoots store) ==> do
+    (contractId, HistoryRoot version block createStep _ _ _) <- pickRoot store
+    pure $ findCreateStep contractId store === Just (block, SomeCreateStep version createStep)
+
+  -- This property specifies that finding the next steps from genesis for a contract that exists succeeds.
+  prop "getRoot / getNextSteps Genesis" \store -> not (null $ getRoots store) ==> do
+    (contractId, HistoryRoot version block _ steps _ _) <- pickRoot store
+    pure case steps of
+      [] -> discard
+      _  -> findNextSteps contractId Genesis store === FindNext block (SomeContractSteps version steps)
+
+  -- This property specifies that when next steps are found, the block must be
+  -- bigger than the block provided.
+  prop "findNextSteps block increasing" \store -> not (null $ getRoots store) ==> do
+    (contractId, _, point) <- genFindNextStepArgs store
+    pure case findNextSteps contractId point store of
+      FindNext block _ -> At block > point
+      _                -> discard
+
+mkStep :: HistoryScriptEvent a -> ([BlockHeader], HistoryStoreModel) -> ([BlockHeader], HistoryStoreModel)
+mkStep = \case
+  RollForward slotOffset hash -> first \case
+    []                            -> [BlockHeader slotOffset hash 0]
+    headers@(BlockHeader{..} : _) -> BlockHeader (slotNo + slotOffset) hash (blockNo + 1) : headers
+  RollBackward n -> \(headers, store) -> case drop (fromIntegral n) headers of
+    []                   -> ([], rollback Genesis store)
+    headers'@(block : _) -> (headers', rollback (At block) store)
+  CreateContract contractId version createStep -> \case
+    ([], _) -> error "Create in empty chain"
+    (headers@(block : _), store) ->
+      case addContract contractId version block createStep store of
+        Left msg     -> error msg
+        Right store' -> (headers, store')
+  ApplyInputs version transaction@Transaction{..} -> \case
+    ([], _) -> error "ApplyInputs in empty chain"
+    (headers@(block : _), store) ->
+      case addSteps contractId version block [ApplyTransaction transaction] store of
+        Left msg     -> error msg
+        Right store' -> (headers, store')
+  Withdraw contractId version redeemStep -> \case
+    ([], _) -> error "ApplyInputs in empty chain"
+    (headers@(block : _), store) ->
+      case addSteps contractId version block [RedeemPayout redeemStep] store of
+        Left msg     -> error msg
+        Right store' -> (headers, store')
+
+genFindCreateStepArgs :: HistoryStoreModel -> Gen ContractId
+genFindCreateStepArgs store = frequency
+  [ (5, fst <$> pickRoot store)
+  , (1, ContractId <$> (TxOutRef <$> genTxId <*> (TxIx . fromIntegral <$> chooseInt (0, 10))))
+  ]
+
+genFindNextStepArgs :: HistoryStoreModel -> Gen (ContractId, SomeMarloweVersion, ChainPoint)
+genFindNextStepArgs store = do
+  (contractId, HistoryRoot version _ _ _ _ _) <- pickRoot store
+  point <- elements $ Genesis : (At <$> getAllBlocks store)
+  pure (contractId, SomeMarloweVersion version, point)

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/StoreSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/StoreSpec.hs
@@ -1,0 +1,203 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE RankNTypes         #-}
+
+module Language.Marlowe.Runtime.History.StoreSpec (spec) where
+
+import Control.Concurrent (forkFinally, killThread)
+import Control.Concurrent.STM (STM, TVar, atomically, modifyTVar, newEmptyTMVarIO, newTVar, putTMVar, readTVar,
+                               tryTakeTMVar, writeTVar)
+import Control.Exception.Base (throwIO)
+import Control.Monad (mfilter)
+import Data.Either (fromRight)
+import Data.Foldable (traverse_)
+import Data.Functor (void)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Some (Some (..), withSome)
+import Data.Time.Clock (secondsToNominalDiffTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Data.Type.Equality (type (:~:) (Refl))
+import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader (..), TxOutRef (TxOutRef), WithGenesis (..))
+import Language.Marlowe.Runtime.Core.Api (ContractId (ContractId), Transaction (..), TransactionScriptOutput (..),
+                                          assertVersionsEqual)
+import Language.Marlowe.Runtime.History.Api (ContractStep (..), SomeCreateStep (..))
+import Language.Marlowe.Runtime.History.Follower (ContractChanges (..), SomeContractChanges (..), applyRollback,
+                                                  isEmptyChanges)
+import Language.Marlowe.Runtime.History.FollowerSupervisor (UpdateContract (..))
+import Language.Marlowe.Runtime.History.Script (HistoryScript (..), HistoryScriptBlockState (..),
+                                                HistoryScriptContractState (..), HistoryScriptEvent (..),
+                                                HistoryScriptState, applyInputs, genCreateContract, genRollForward,
+                                                genTxId, reduceScriptEvent)
+import Language.Marlowe.Runtime.History.Store
+import Language.Marlowe.Runtime.History.Store.Memory (mkHistoryQueriesInMemory)
+import Test.Hspec (Spec)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (Property, (===))
+import Test.QuickCheck.Monadic (PropertyM, monadicIO, pick, run)
+
+spec :: Spec
+spec = do
+  prop "Created contracts are found" $ runHistoryProp propCreatedContractsAreFound
+  prop "Non created contracts are not found" $ runHistoryProp propNonCreatedContractsAreNotFound
+  prop "Rolled back contracts are not found" $ runHistoryProp propRolledBackContractsAreNotFound
+  prop "RollForward, RollBackward is a no-op" $ runHistoryProp propRollForwardRollBackward
+
+propCreatedContractsAreFound :: HistoryProp
+propCreatedContractsAreFound HistoryScriptBlockState{..} _ HistoryStore{..} runEvent = do
+  Some event <- pick $ genCreateContract $ slotNo block
+  run $ runEvent event
+  let (contractId, create) = assertCreate event
+  found <- run $ findContract contractId
+  pure $ found === Just (block, create)
+
+propNonCreatedContractsAreNotFound :: HistoryProp
+propNonCreatedContractsAreNotFound _ _ HistoryStore{..} _ = do
+  contractId <- ContractId . flip TxOutRef 0 <$> pick genTxId
+  found <- run $ findContract contractId
+  pure $ found === Nothing
+
+propRolledBackContractsAreNotFound :: HistoryProp
+propRolledBackContractsAreNotFound HistoryScriptBlockState{..} _ HistoryStore{..} runEvent = do
+  Some event <- pick $ genCreateContract $ slotNo block
+  let (contractId, _) = assertCreate event
+  expected <- run $ findContract contractId
+  run do
+    runEvent event
+    runEvent $ RollBackward 1
+  found <- run $ findContract contractId
+  pure $ found === expected
+
+propRollForwardRollBackward :: HistoryProp
+propRollForwardRollBackward HistoryScriptBlockState{..} _ HistoryStore{..} runEvent = do
+  Some event <- pick $ genCreateContract $ slotNo block
+  Some rollForward <- pick genRollForward
+  run $ runEvent event
+  let (contractId, _) = assertCreate event
+  expected <- run $ findContract contractId
+  run do
+    runEvent rollForward
+    runEvent $ RollBackward 1
+  actual <- run $ findContract contractId
+  pure $ actual === expected
+
+assertCreate :: HistoryScriptEvent v -> (ContractId, SomeCreateStep)
+assertCreate = \case
+    CreateContract contractId version create -> (contractId, SomeCreateStep version create)
+    _                                        -> error "failed to match irrefutable pattern"
+
+type RunScriptEvent = forall v. HistoryScriptEvent v -> IO ()
+
+type HistoryProp = HistoryScriptBlockState -> HistoryScriptState -> HistoryStore -> RunScriptEvent -> PropertyM IO Property
+
+runHistoryProp :: HistoryProp -> HistoryScript -> Property
+runHistoryProp test (HistoryScript script) = monadicIO do
+  (store@HistoryStore{..}, changesVar, stateVar, state) <- run $ atomically do
+    changesVar <- newTVar mempty
+    stateVar <- newTVar []
+    historyQueries <- hoistHistoryQueries atomically <$> mkHistoryQueriesInMemory
+    let
+      changes = do
+        newChanges <- readTVar changesVar
+        writeTVar changesVar $ flip Map.mapMaybe newChanges \case
+          RemoveContract                                 -> Nothing
+          UpdateContract (SomeContractChanges version _) -> Just $ UpdateContract $ SomeContractChanges version mempty
+        pure $ Map.filter notEmptyUpdate newChanges
+      notEmptyUpdate = \case
+        RemoveContract    -> False
+        UpdateContract ch -> not $ isEmptyChanges ch
+    traverse_ (\event -> withSome event $ runScriptEvent stateVar changesVar) script
+    (, changesVar, stateVar,) <$> mkHistoryStore HistoryStoreDependencies{..} <*> readTVar stateVar
+  case state of
+    []                  -> error "Generated empty script"
+    blockState : state' -> do
+      exVar <- run newEmptyTMVarIO
+      threadId <- run $ forkFinally runHistoryStore \case
+        Left ex -> atomically $ putTMVar exVar ex
+        _       -> pure ()
+      result <- test blockState state' store \event -> do
+        -- write the changes
+        atomically $ runScriptEvent stateVar changesVar event
+        -- wait until they are picked up.
+        let
+          isEmptyUpdate = \case
+            RemoveContract    -> False
+            UpdateContract ch -> isEmptyChanges ch
+        void $ atomically $ mfilter (all isEmptyUpdate) $ readTVar changesVar
+      run $ killThread threadId
+      mEx <- run $ atomically $ tryTakeTMVar exVar
+      case mEx of
+        Nothing -> pure result
+        Just ex -> run $ throwIO ex
+
+runScriptEvent :: TVar HistoryScriptState -> TVar (Map ContractId UpdateContract) -> HistoryScriptEvent v -> STM ()
+runScriptEvent stateVar changesVar event = do
+  state <- readTVar stateVar
+  modifyTVar stateVar (fromRight (error "failed to reduce generated script") . reduceScriptEvent event)
+  modifyTVar changesVar case event of
+    RollForward _ _ -> id
+    RollBackward n ->
+      let
+        rollbackPoint = case drop (fromIntegral n) state of
+          []                              -> Genesis
+          HistoryScriptBlockState{..} : _ -> At block
+      in
+        fmap \case
+          RemoveContract -> RemoveContract
+          UpdateContract (SomeContractChanges version changes) ->
+            UpdateContract $ SomeContractChanges version $ applyRollback rollbackPoint changes
+    CreateContract contractId version create -> case state of
+      [] -> error "create at genesis"
+      HistoryScriptBlockState{..} : _ ->
+        Map.insert contractId $ UpdateContract $ SomeContractChanges version $ ContractChanges
+          { steps = mempty
+          , create = Just (block, create)
+          , rollbackTo = Nothing
+          }
+    ApplyInputs contractId transactionId version vLow vHigh redeemer -> case state of
+      [] -> error "create at genesis"
+      HistoryScriptBlockState{..} : _ ->
+        case Map.lookup contractId contractStates of
+          Nothing -> error "contract not found"
+          Just (Some HistoryScriptContractState{..}) -> case stateScriptOutput of
+            Nothing -> error "no script output"
+            Just TransactionScriptOutput{..} ->
+              flip Map.update contractId $ Just . \case
+                RemoveContract -> error "applied inputs after remove"
+                UpdateContract (SomeContractChanges version' changes) -> case assertVersionsEqual version version' of
+                  Refl -> case assertVersionsEqual contractVersion version of
+                    Refl ->
+                      let
+                        step = ApplyTransaction Transaction
+                          { contractId
+                          , transactionId
+                          , blockHeader = block
+                          , validityLowerBound = posixSecondsToUTCTime $ secondsToNominalDiffTime $ fromIntegral vLow
+                          , validityUpperBound = posixSecondsToUTCTime $ secondsToNominalDiffTime $ fromIntegral vLow
+                          , redeemer
+                          , output = case applyInputs contractVersion vLow vHigh transactionId redeemer datum of
+                              Left err     -> error $ "error applying inputs " <> show err
+                              Right output -> output
+                          }
+                        newChanges = ContractChanges
+                          { steps = Map.singleton block [step]
+                          , create = Nothing
+                          , rollbackTo = Nothing
+                          }
+                      in
+                        UpdateContract $ SomeContractChanges version' $ changes <> newChanges
+    Withdraw contractId version step -> case state of
+      [] -> error "create at genesis"
+      HistoryScriptBlockState{..} : _ ->
+        flip Map.update contractId $ Just . \case
+          RemoveContract -> error "applied inputs after remove"
+          UpdateContract (SomeContractChanges version' changes) -> case assertVersionsEqual version version' of
+            Refl ->
+              let
+                newChanges = ContractChanges
+                  { steps = Map.singleton block [RedeemPayout step]
+                  , create = Nothing
+                  , rollbackTo = Nothing
+                  }
+              in
+                UpdateContract $ SomeContractChanges version' $ changes <> newChanges

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/HistorySpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/HistorySpec.hs
@@ -1,0 +1,14 @@
+module Language.Marlowe.Runtime.HistorySpec (spec) where
+
+import Language.Marlowe.Runtime.History.Script (foldHistoryScript)
+import Test.Hspec (Spec, describe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck ((===))
+
+spec :: Spec
+spec = do
+  describe "HistoryScript" historyScriptSpec
+
+historyScriptSpec :: Spec
+historyScriptSpec = prop "It generates only valid scripts" \script ->
+  either Just (const Nothing) (foldHistoryScript script) === Nothing

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -69,6 +69,7 @@
           "Language/Marlowe/Runtime/History/QueryServer"
           "Language/Marlowe/Runtime/History/Store"
           "Language/Marlowe/Runtime/History/Store/Memory"
+          "Language/Marlowe/Runtime/History/Store/Model"
           "Language/Marlowe/Runtime/History/SyncServer"
           ];
         hsSourceDirs = [ "src" ];
@@ -177,7 +178,12 @@
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."some" or (errorHandler.buildDepError "some"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             ];
@@ -187,9 +193,20 @@
           buildable = true;
           modules = [
             "Language/Marlowe/Runtime/History/FollowerSpec"
+            "Language/Marlowe/Runtime/History/Script"
+            "Language/Marlowe/Runtime/History/StoreSpec"
+            "Language/Marlowe/Runtime/History/Store/ModelSpec"
+            "Language/Marlowe/Runtime/HistorySpec"
+            "Spec/Marlowe/Semantics/Arbitrary"
+            "Spec/Marlowe/Semantics/Golden"
+            "Spec/Marlowe/Semantics/Golden/Escrow"
+            "Spec/Marlowe/Semantics/Golden/Pangram"
+            "Spec/Marlowe/Semantics/Golden/Swap"
+            "Spec/Marlowe/Semantics/Golden/Trivial"
+            "Spec/Marlowe/Semantics/Golden/ZeroCouponBond"
             "Paths_marlowe_runtime"
             ];
-          hsSourceDirs = [ "test" ];
+          hsSourceDirs = [ "test" "../marlowe/test" ];
           mainPath = [ "Spec.hs" ];
           };
         };

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -69,6 +69,7 @@
           "Language/Marlowe/Runtime/History/QueryServer"
           "Language/Marlowe/Runtime/History/Store"
           "Language/Marlowe/Runtime/History/Store/Memory"
+          "Language/Marlowe/Runtime/History/Store/Model"
           "Language/Marlowe/Runtime/History/SyncServer"
           ];
         hsSourceDirs = [ "src" ];
@@ -177,7 +178,12 @@
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."some" or (errorHandler.buildDepError "some"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             ];
@@ -187,9 +193,20 @@
           buildable = true;
           modules = [
             "Language/Marlowe/Runtime/History/FollowerSpec"
+            "Language/Marlowe/Runtime/History/Script"
+            "Language/Marlowe/Runtime/History/StoreSpec"
+            "Language/Marlowe/Runtime/History/Store/ModelSpec"
+            "Language/Marlowe/Runtime/HistorySpec"
+            "Spec/Marlowe/Semantics/Arbitrary"
+            "Spec/Marlowe/Semantics/Golden"
+            "Spec/Marlowe/Semantics/Golden/Escrow"
+            "Spec/Marlowe/Semantics/Golden/Pangram"
+            "Spec/Marlowe/Semantics/Golden/Swap"
+            "Spec/Marlowe/Semantics/Golden/Trivial"
+            "Spec/Marlowe/Semantics/Golden/ZeroCouponBond"
             "Paths_marlowe_runtime"
             ];
-          hsSourceDirs = [ "test" ];
+          hsSourceDirs = [ "test" "../marlowe/test" ];
           mainPath = [ "Spec.hs" ];
           };
         };

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-runtime.nix
@@ -69,6 +69,7 @@
           "Language/Marlowe/Runtime/History/QueryServer"
           "Language/Marlowe/Runtime/History/Store"
           "Language/Marlowe/Runtime/History/Store/Memory"
+          "Language/Marlowe/Runtime/History/Store/Model"
           "Language/Marlowe/Runtime/History/SyncServer"
           ];
         hsSourceDirs = [ "src" ];
@@ -177,7 +178,12 @@
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."some" or (errorHandler.buildDepError "some"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             ];
@@ -187,9 +193,20 @@
           buildable = true;
           modules = [
             "Language/Marlowe/Runtime/History/FollowerSpec"
+            "Language/Marlowe/Runtime/History/Script"
+            "Language/Marlowe/Runtime/History/StoreSpec"
+            "Language/Marlowe/Runtime/History/Store/ModelSpec"
+            "Language/Marlowe/Runtime/HistorySpec"
+            "Spec/Marlowe/Semantics/Arbitrary"
+            "Spec/Marlowe/Semantics/Golden"
+            "Spec/Marlowe/Semantics/Golden/Escrow"
+            "Spec/Marlowe/Semantics/Golden/Pangram"
+            "Spec/Marlowe/Semantics/Golden/Swap"
+            "Spec/Marlowe/Semantics/Golden/Trivial"
+            "Spec/Marlowe/Semantics/Golden/ZeroCouponBond"
             "Paths_marlowe_runtime"
             ];
-          hsSourceDirs = [ "test" ];
+          hsSourceDirs = [ "test" "../marlowe/test" ];
           mainPath = [ "Spec.hs" ];
           };
         };


### PR DESCRIPTION
I wrote these tests by writing a pure model of the history store queries, writing property tests for that, then writing equivalence tests between the public API of the HistoryStore and the model.

The `HistoryScript` is a sequence of actions which create and advance contracts in a very simple mock of the blockchain, and which manipulate that mock by rolling it forwards and backwards. It has an `Arbitrary` instance that generates valid scripts. Using the script I can set up both the model store and the real store so that they have equivalent states. Once that is done, I can generate query parameters for the model and check them against both the real and the model implementation to make sure they produce the same result.

This will make it easy to test future implementations of the queries that use, for example, a real database, because we can just plug in a different set of queries and run the same store tests.