### PR TITLE
Use template haskell to generate a schema version from the query type

### DIFF
--- a/marlowe-chain-sync/example-client/FollowingUTxOs.hs
+++ b/marlowe-chain-sync/example-client/FollowingUTxOs.hs
@@ -9,7 +9,7 @@ import Language.Marlowe.Runtime.ChainSync.Api
 client :: RuntimeChainSeekClient IO ()
 client = ChainSeekClient stInit
   where
-    stInit = pure $ SendMsgRequestHandshake schemaVersion1_0 stHandshake
+    stInit = pure $ SendMsgRequestHandshake moveSchema stHandshake
 
     stHandshake = ClientStHandshake
       { recvMsgHandshakeRejected = \supportedVersions -> do

--- a/marlowe-chain-sync/example-client/SkippingBlocks.hs
+++ b/marlowe-chain-sync/example-client/SkippingBlocks.hs
@@ -7,7 +7,7 @@ import Language.Marlowe.Runtime.ChainSync.Api
 client :: RuntimeChainSeekClient IO ()
 client = ChainSeekClient stInit
   where
-    stInit = pure $ SendMsgRequestHandshake schemaVersion1_0 stHandshake
+    stInit = pure $ SendMsgRequestHandshake moveSchema stHandshake
 
     stHandshake = ClientStHandshake
       { recvMsgHandshakeRejected = \supportedVersions -> do

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Server.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Server.hs
@@ -17,8 +17,7 @@ import qualified Data.Text as T
 import Data.Text.IO (hPutStrLn)
 import Data.Void (Void, absurd)
 import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader (BlockHeader), BlockHeaderHash (unBlockHeaderHash),
-                                               ChainPoint, Move, RuntimeChainSeekServer, WithGenesis (..),
-                                               schemaVersion1_0)
+                                               ChainPoint, Move, RuntimeChainSeekServer, WithGenesis (..), moveSchema)
 import Language.Marlowe.Runtime.ChainSync.Database (MoveClient (..), MoveResult (..))
 import Network.Protocol.ChainSeek.Server (ChainSeekServer (..), ServerStHandshake (..), ServerStIdle (..),
                                           ServerStInit (..), ServerStNext (..))
@@ -74,9 +73,9 @@ mkWorker WorkerDependencies{..} = do
 
     server = ChainSeekServer $ pure stInit
 
-    stInit = ServerStInit \version -> pure if version == schemaVersion1_0
+    stInit = ServerStInit \version -> pure if version == moveSchema
       then SendMsgHandshakeConfirmed $ stIdle Genesis
-      else SendMsgHandshakeRejected [ schemaVersion1_0 ] ()
+      else SendMsgHandshakeRejected [ moveSchema ] ()
 
     stIdle :: ChainPoint -> IO (ServerStIdle Move ChainPoint ChainPoint IO ())
     stIdle pos = pure ServerStIdle

--- a/marlowe-protocols/marlowe-protocols.cabal
+++ b/marlowe-protocols/marlowe-protocols.cabal
@@ -53,6 +53,7 @@ library
     Network.Protocol.ChainSeek.Codec
     Network.Protocol.ChainSeek.Server
     Network.Protocol.ChainSeek.Types
+    Network.Protocol.ChainSeek.TH
     Network.Protocol.Job.Client
     Network.Protocol.Job.Codec
     Network.Protocol.Job.Server
@@ -67,6 +68,8 @@ library
     , async
     , binary
     , bytestring
+    , hashable
     , network
+    , template-haskell
     , text
     , typed-protocols

--- a/marlowe-protocols/src/Network/Protocol/ChainSeek/TH.hs
+++ b/marlowe-protocols/src/Network/Protocol/ChainSeek/TH.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Network.Protocol.ChainSeek.TH (mkSchemaVersion) where
+
+import Data.Hashable (Hashable (hash))
+import qualified Data.Text as T
+import Language.Haskell.TH
+import Network.Protocol.ChainSeek.Types (SchemaVersion (..))
+
+-- Template Haskell is used to reliably keep the schema version updated to
+-- match the query type.
+mkSchemaVersion :: String -> Name -> Q [Dec]
+mkSchemaVersion declName queryTypeName = do
+  queryTypeInfo <- reify queryTypeName
+  -- Expression: SchemaVersion (T.pack "<hash of Move type>")
+  let
+    body = appE (conE 'SchemaVersion)
+      $ parensE
+      $ appE (varE 'T.pack)
+      $ litE
+      $ stringL
+      $ "schema_" <> show (hash $ show queryTypeInfo)
+  sequence
+    [ sigD (mkName declName) $ conT ''SchemaVersion
+    , valD (varP (mkName declName)) (normalB body) []
+    ]

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Follower.hs
@@ -45,7 +45,7 @@ import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
 import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, ChainPoint, ChainSeekClient (..), ClientStHandshake (..),
                                                ClientStIdle (..), ClientStInit (..), ClientStNext (..), Move (..),
                                                RuntimeChainSeekClient, ScriptHash (..), SlotConfig, TxOutRef (..),
-                                               UTxOError, WithGenesis (..), isAfter, schemaVersion1_0, slotToUTCTime)
+                                               UTxOError, WithGenesis (..), isAfter, moveSchema, slotToUTCTime)
 import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
 import Language.Marlowe.Runtime.Core.Api (ContractId (..), Datum, IsMarloweVersion (Redeemer), MarloweVersion (..),
                                           MarloweVersionTag (..), Payout (..), SomeMarloweVersion (..),
@@ -131,7 +131,7 @@ mkFollower deps@FollowerDependencies{..} = do
   statusVar <- newTVar Pending
   cancelled <- newEmptyTMVar
   let
-    stInit = SendMsgRequestHandshake schemaVersion1_0 handshake
+    stInit = SendMsgRequestHandshake moveSchema handshake
     handshake = ClientStHandshake
       { recvMsgHandshakeRejected = \_ -> pure $ Left HansdshakeFailed
       , recvMsgHandshakeConfirmed = findContract

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-protocols.nix
@@ -37,7 +37,9 @@
           (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
           (hsPkgs."network" or (errorHandler.buildDepError "network"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           ];
@@ -49,6 +51,7 @@
           "Network/Protocol/ChainSeek/Codec"
           "Network/Protocol/ChainSeek/Server"
           "Network/Protocol/ChainSeek/Types"
+          "Network/Protocol/ChainSeek/TH"
           "Network/Protocol/Job/Client"
           "Network/Protocol/Job/Codec"
           "Network/Protocol/Job/Server"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-protocols.nix
@@ -37,7 +37,9 @@
           (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
           (hsPkgs."network" or (errorHandler.buildDepError "network"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           ];
@@ -49,6 +51,7 @@
           "Network/Protocol/ChainSeek/Codec"
           "Network/Protocol/ChainSeek/Server"
           "Network/Protocol/ChainSeek/Types"
+          "Network/Protocol/ChainSeek/TH"
           "Network/Protocol/Job/Client"
           "Network/Protocol/Job/Codec"
           "Network/Protocol/Job/Server"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-protocols.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-protocols.nix
@@ -37,7 +37,9 @@
           (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
           (hsPkgs."network" or (errorHandler.buildDepError "network"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           ];
@@ -49,6 +51,7 @@
           "Network/Protocol/ChainSeek/Codec"
           "Network/Protocol/ChainSeek/Server"
           "Network/Protocol/ChainSeek/Types"
+          "Network/Protocol/ChainSeek/TH"
           "Network/Protocol/Job/Client"
           "Network/Protocol/Job/Codec"
           "Network/Protocol/Job/Server"


### PR DESCRIPTION
Instead of relying on developers to manually update the schema version for the chain sync query every time it changes (which has so far never happened), this PR makes it so that it gets auto-generated as a hash of the type info of the query type. Note that it's not a deep traversal, it only inspects the surface-level type declaration (e.g. if one of the reference types changed, this would not change the schema version). This is better than nothing though, and changing the constructors in `Move` in any way will cause a new schema version to be generated.