### PR TITLE
SCP-4150 SCP-4461 Fixed interval closure in validator.

### DIFF
--- a/marlowe-cli/marlowe-cli.cabal
+++ b/marlowe-cli/marlowe-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: marlowe-cli
-version: 0.0.7.0
+version: 0.0.7.1
 license: Apache-2.0
 license-files:
   LICENSE

--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: marlowe
-version: 0.1.0.1
+version: 0.1.0.2
 license: Apache-2.0
 license-files:
   LICENSE

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -118,15 +118,15 @@ tests = testGroup "Contracts"
 marloweValidatorSize :: IO ()
 marloweValidatorSize = do
     let validator = Scripts.validatorScript marloweValidator
-    let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
+    let vsize = SBS.length . SBS.toShort . LB.toStrict $ Serialise.serialise validator
     assertBool ("smallTypedValidator is too large " <> show vsize) (vsize < 15200)
 
 -- | Test that the untyped validator is not too large.
 smallMarloweValidatorSize :: IO ()
 smallMarloweValidatorSize = do
     let validator = Scripts.validatorScript smallMarloweValidator
-    let vsize = SBS.length. SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 12700)
+    let vsize = SBS.length . SBS.toShort . LB.toStrict $ Serialise.serialise validator
+    assertBool ("smallUntypedValidator is too large " <> show vsize) (vsize < 12750)
 
 
 -- | Test `extractNonMerkleizedContractRoles`.

--- a/marlowe/test/Spec/Marlowe/Plutus/Prelude.hs
+++ b/marlowe/test/Spec/Marlowe/Plutus/Prelude.hs
@@ -23,7 +23,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (Arbitrary (..), Gen, Property, elements, forAll, frequency, listOf, property,
                               testProperty)
 
-import qualified PlutusTx.Prelude as P (all, any, filter, find, fmap, foldMap, snd, (&&), (==))
+import qualified PlutusTx.Prelude as P (all, any, filter, find, fmap, foldMap, snd, (&&), (==), fromEnum)
 
 
 -- | Run tests.
@@ -39,6 +39,7 @@ tests =
     , testProperty "`foldMap` matches standard prelude"               checkFoldMap
     , testProperty "`filter` matches standard prelude"                checkFilter
     , testProperty "`find` matches standard prelude"                  checkFind
+    , testProperty "`fromEnum` on `Bool`"                             checkBoolEnum
     , testProperty "`instance Eq (Maybe a)` matches standard prelude" checkEqMaybe
     , testProperty "`instance Eq DatumHash`"                          checkEqDatumHash
     , testProperty "`instance Eq ValidatorHash`"                      checkEqValidatorHash
@@ -149,6 +150,18 @@ checkFind =
         f = (< y)
       in
         P.find f xs == find f xs
+
+
+-- | Check that `fromEnum True == 1` and `fromEnum False == 0`
+checkBoolEnum :: Property
+checkBoolEnum =
+  property
+    . forAll arbitrary
+    $ \x ->
+      fromInteger (P.fromEnum x) == fromEnum x
+        && if x
+             then P.fromEnum x == 1
+             else P.fromEnum x == 0
 
 
 -- | Compare `instance Eq (Maybe a)` to standard prelude.

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cli.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cli.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe-cli"; version = "0.0.7.0"; };
+      identifier = { name = "marlowe-cli"; version = "0.0.7.1"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "brian.bush@iohk.io";

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; limit-static-analysis-time = true; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe"; version = "0.1.0.1"; };
+      identifier = { name = "marlowe"; version = "0.1.0.2"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "alexander.nemish@iohk.io";

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cli.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cli.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe-cli"; version = "0.0.7.0"; };
+      identifier = { name = "marlowe-cli"; version = "0.0.7.1"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "brian.bush@iohk.io";

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; limit-static-analysis-time = true; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe"; version = "0.1.0.1"; };
+      identifier = { name = "marlowe"; version = "0.1.0.2"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "alexander.nemish@iohk.io";

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-cli.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-cli.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe-cli"; version = "0.0.7.0"; };
+      identifier = { name = "marlowe-cli"; version = "0.0.7.1"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "brian.bush@iohk.io";

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; limit-static-analysis-time = true; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe"; version = "0.1.0.1"; };
+      identifier = { name = "marlowe"; version = "0.1.0.2"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "alexander.nemish@iohk.io";


### PR DESCRIPTION
The `FIXME` regarding interval computations in the Marlowe semantics validator was addressed by converting open POSIX time intervals provided by Plutus to the closed interval required by Marlowe semantics. If an open interval is provided to the validator, then it is shrunk inward by 1 millisecond on the open side(s).

All on- and off-chain tests pass.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
