### PR TITLE
SCP-4465 add flag to control simulation mode for marlowe cli dsl

### DIFF
--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Test.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Test.hs
@@ -22,12 +22,12 @@ module Language.Marlowe.CLI.Command.Test
   , runTestCommand
   ) where
 
-import Data.Maybe (fromMaybe)
 import Cardano.Api (IsShelleyBasedEra, NetworkId)
 import Control.Monad.Except (MonadError, MonadIO)
+import Data.Maybe (fromMaybe)
 import Language.Marlowe.CLI.Command.Parse (parseAddress, parseNetworkId)
 import Language.Marlowe.CLI.Test (runTests)
-import Language.Marlowe.CLI.Test.Types (MarloweTests (ScriptTests), ExecutionMode(..), Seconds(..))
+import Language.Marlowe.CLI.Test.Types (ExecutionMode(..), MarloweTests(ScriptTests), Seconds(..))
 import Language.Marlowe.CLI.Types (CliEnv, CliError, askEra)
 
 import Control.Monad.Reader.Class (MonadReader)

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test.hs
@@ -42,7 +42,7 @@ import Control.Monad.Reader (ReaderT(runReaderT), runReader)
 import Language.Marlowe.CLI.Cardano.Api (toPlutusProtocolVersion)
 import Language.Marlowe.CLI.IO (decodeFileStrict, getDefaultCostModel, queryInEra, readSigningKey)
 import Language.Marlowe.CLI.Test.Script (scriptTest)
-import Language.Marlowe.CLI.Test.Types (MarloweTests (..), Wallet (Wallet), ExecutionMode)
+import Language.Marlowe.CLI.Test.Types (ExecutionMode, MarloweTests(..), Wallet(Wallet))
 import Language.Marlowe.CLI.Transaction (querySlotConfig)
 import Language.Marlowe.CLI.Types (CliEnv(CliEnv), CliError(..), SigningKeyFile(SigningKeyFile))
 import qualified Language.Marlowe.CLI.Types as T
@@ -65,16 +65,16 @@ runTests era ScriptTests{..} =
         LocalNodeConnectInfo
         {
           localConsensusModeParams = CardanoModeParams $ EpochSlots 21600
-        , localNodeNetworkId       = network
-        , localNodeSocketPath      = socketPath
+        , localNodeNetworkId       = stNetwork
+        , localNodeSocketPath      = stSocketPath
         }
     protocol <- runCli $ queryInEra connection C.QueryProtocolParameters
-    faucetSigningKey <- readSigningKey (SigningKeyFile faucetSigningKeyFile)
+    faucetSigningKey <- readSigningKey (SigningKeyFile stFaucetSigningKeyFile)
     let
       protocolVersion = toPlutusProtocolVersion $ protocolParamProtocolVersion protocol
-      faucet = Wallet faucetAddress faucetSigningKey mempty mempty
+      faucet = Wallet stFaucetAddress faucetSigningKey mempty mempty
 
     slotConfig <- runCli $ querySlotConfig connection
-    tests' <- mapM decodeFileStrict tests
-    mapM_ (scriptTest era protocolVersion costModel connection faucet slotConfig executionMode) tests'
+    tests' <- mapM decodeFileStrict stTests
+    mapM_ (scriptTest era protocolVersion costModel connection faucet slotConfig stExecutionMode) tests'
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test.hs
@@ -42,7 +42,7 @@ import Control.Monad.Reader (ReaderT(runReaderT), runReader)
 import Language.Marlowe.CLI.Cardano.Api (toPlutusProtocolVersion)
 import Language.Marlowe.CLI.IO (decodeFileStrict, getDefaultCostModel, queryInEra, readSigningKey)
 import Language.Marlowe.CLI.Test.Script (scriptTest)
-import Language.Marlowe.CLI.Test.Types (MarloweTests(..), Wallet(Wallet))
+import Language.Marlowe.CLI.Test.Types (MarloweTests (..), Wallet (Wallet), ExecutionMode)
 import Language.Marlowe.CLI.Transaction (querySlotConfig)
 import Language.Marlowe.CLI.Types (CliEnv(CliEnv), CliError(..), SigningKeyFile(SigningKeyFile))
 import qualified Language.Marlowe.CLI.Types as T
@@ -76,5 +76,5 @@ runTests era ScriptTests{..} =
 
     slotConfig <- runCli $ querySlotConfig connection
     tests' <- mapM decodeFileStrict tests
-    mapM_ (scriptTest era protocolVersion costModel connection faucet slotConfig) tests'
+    mapM_ (scriptTest era protocolVersion costModel connection faucet slotConfig executionMode) tests'
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
@@ -124,6 +124,7 @@ import Language.Marlowe.CLI.Test.Types
   , seConnection
   , seCostModelParams
   , seEra
+  , seExecutionMode
   , seProtocolVersion
   , seSlotConfig
   , seExecutionMode

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
@@ -746,7 +746,7 @@ scriptTest era protocolVersion costModel connection faucet slotConfig ScriptTest
         interpret operation
 
     void $ catchError
-      (runReaderT (execStateT interpretLoop (scriptState faucet)) (ScriptEnv connection costModel era protocolVersion slotConfig SimulationMode))
+      (runReaderT (execStateT interpretLoop (scriptState faucet)) (ScriptEnv connection costModel era protocolVersion slotConfig executionMode))
       $ \e -> do
         -- TODO: Clean up wallets and instances.
         liftIO (print e)

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
@@ -126,6 +126,7 @@ import Language.Marlowe.CLI.Test.Types
   , seProtocolVersion
   , seSlotConfig
   , seTransactionTimeout
+  , seExecutionTimeout
   , ssContracts
   , ssCurrencies
   , ssReferenceScripts
@@ -171,7 +172,8 @@ interpret FundWallet {..} = do
   (Wallet faucetAddress faucetSigningKey _ _) <- getFaucet
   (Wallet address _ _ _) <- findWallet soWalletNickname
   connection <- view seConnection
-  Seconds timeout <- view seTransactionTimeout
+  -- Seconds timeout <- view seTransactionTimeout
+  executionTimeout <- view seExecutionTimeout
   txBody <- runCli "[FundWallet] " $ buildFaucetImpl
     connection
     values
@@ -179,7 +181,7 @@ interpret FundWallet {..} = do
     faucetAddress
     faucetSigningKey
     defaultCoinSelectionStrategy
-    (Just timeout)
+    executionTimeout
 
   let
     transaction = WalletTransaction { wtFees = 0, wtTxBody=txBody  }
@@ -193,7 +195,8 @@ interpret SplitWallet {..} = do
   let
     values = [ C.lovelaceToValue v | v <- soValues ]
 
-  Seconds timeout <- view seTransactionTimeout
+  -- Seconds timeout <- view seTransactionTimeout
+  executionTimeout <- view seExecutionTimeout
   void $ runCli "[createCollaterals] " $ buildFaucetImpl
     connection
     values
@@ -201,7 +204,7 @@ interpret SplitWallet {..} = do
     address
     skey
     defaultCoinSelectionStrategy
-    (Just timeout)
+    executionTimeout
 
 interpret so@Mint {..} = do
   currencies <- use ssCurrencies
@@ -217,7 +220,8 @@ interpret so@Mint {..} = do
     pure ((tokenName, amount, Just destAddress), (nickname, wallet, tokenName, amount))
   logSoMsg' so $ "Minting currency " <> show soCurrencyNickname <> " with tokens distribution: " <> show soTokenDistribution
   connection <- view seConnection
-  Seconds timeout <- view seTransactionTimeout
+  -- Seconds timeout <- view seTransactionTimeout
+  executionTimeout <- view seExecutionTimeout
   (_, policy) <- runCli "[Mint] " $ buildMintingImpl
     connection
     faucetSigningKey
@@ -226,7 +230,7 @@ interpret so@Mint {..} = do
     Nothing
     2_000_000       -- FIXME: should we compute minAda here?
     faucetAddress
-    (Just timeout)
+    executionTimeout
 
   let
     currencySymbol = mpsSymbol . fromCardanoPolicyId $ policy
@@ -389,7 +393,8 @@ interpret so@Publish {..} = do
       pure marloweScriptRefs
     Nothing -> do
       logSoMsg' so "Scripts not found so publishing them."
-      Seconds timeout <- view seTransactionTimeout
+      -- Seconds timeout <- view seTransactionTimeout
+      executionTimeout <- view seExecutionTimeout
       runSoCli so $ publishImpl
         connection
         waSigningKey
@@ -397,7 +402,7 @@ interpret so@Publish {..} = do
         waAddress
         publishingStrategy
         (CoinSelectionStrategy False False [])
-        timeout
+        executionTimeout
         (PrintStats True)
 
   assign ssReferenceScripts (Just marloweScriptRefs)
@@ -450,7 +455,8 @@ autoRunTransaction currency defaultSubmitter prev curr@T.MarloweTransaction {..}
       Nothing -> throwError "[autoRunTransaction] Contract requires a role currency which was not specified."
 
   connection <- view seConnection
-  Seconds timeout <- view seTransactionTimeout
+  -- Seconds timeout <- view seTransactionTimeout
+  executionTimeout <- view seExecutionTimeout
   txBody <- runCli "[AutoRun] " $ autoRunTransactionImpl
       connection
       prev
@@ -458,7 +464,7 @@ autoRunTransaction currency defaultSubmitter prev curr@T.MarloweTransaction {..}
       address
       [skey]
       C.TxMetadataNone
-      (Just timeout)
+      executionTimeout
       True
       invalid
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Script.hs
@@ -127,7 +127,6 @@ import Language.Marlowe.CLI.Test.Types
   , seExecutionMode
   , seProtocolVersion
   , seSlotConfig
-  , seExecutionMode
   , ssContracts
   , ssCurrencies
   , ssReferenceScripts

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -62,9 +62,9 @@ module Language.Marlowe.CLI.Test.Types
   , seConnection
   , seCostModelParams
   , seEra
+  , seExecutionMode
   , seProtocolVersion
   , seSlotConfig
-  , seExecutionMode
   , ssContracts
   , ssCurrencies
   , ssReferenceScripts

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -104,13 +104,13 @@ data MarloweTests era a =
     -- | Test contracts on-chain.
     ScriptTests
     {
-      network              :: NetworkId   -- ^ The network ID, if any.
-    , socketPath           :: FilePath    -- ^ The path to the node socket.
-    , faucetSigningKeyFile :: FilePath    -- ^ The file containing the faucet's signing key.
-    , faucetAddress        :: AddressInEra era  -- ^ The faucet address.
-    , burnAddress          :: AddressInEra era -- ^ The address to which to send unneeded native tokens.
-    , executionMode        :: ExecutionMode
-    , tests                :: [a]         -- ^ Input for the tests.
+      stNetwork              :: NetworkId   -- ^ The network ID, if any.
+    , stSocketPath           :: FilePath    -- ^ The path to the node socket.
+    , stFaucetSigningKeyFile :: FilePath    -- ^ The file containing the faucet's signing key.
+    , stFaucetAddress        :: AddressInEra era  -- ^ The faucet address.
+    , stBurnAddress          :: AddressInEra era -- ^ The address to which to send unneeded native tokens.
+    , stExecutionMode        :: ExecutionMode
+    , stTests                :: [a]         -- ^ Input for the tests.
     }
     deriving stock (Eq, Generic, Show)
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -64,6 +64,7 @@ module Language.Marlowe.CLI.Test.Types
   , seProtocolVersion
   , seSlotConfig
   , seTransactionTimeout
+  , seExecutionTimeoute
   , ssContracts
   , ssCurrencies
   , ssReferenceScripts
@@ -113,6 +114,8 @@ data MarloweTests era a =
     }
     deriving stock (Eq, Generic, Show)
 
+-- | Configuration for executing Marlowe CLI DSL commands on the blockchain
+data ExecutionMode = PureSimulation | OnChainExecution { transactionTimeout :: Seconds }
 
 -- | An on-chain test of the Marlowe contract and payout validators.
 data ScriptTest =
@@ -486,7 +489,8 @@ data ScriptEnv era = ScriptEnv
   , _seEra                :: ScriptDataSupportedInEra era
   , _seProtocolVersion    :: ProtocolVersion
   , _seSlotConfig         :: SlotConfig
-  , _seTransactionTimeout :: Seconds
+  -- , _seTransactionTimeout :: Seconds
+  , _seExecutionTimeout   :: ExecutionMode
   }
 
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -32,6 +32,7 @@ module Language.Marlowe.CLI.Test.Types
   , ContractSource(..)
   , CurrencyNickname(..)
   , CustomCurrency(..)
+  , ExecutionMode(..)
   , Finished
   , MarloweContract(..)
   , MarloweReferenceScripts(..)
@@ -63,14 +64,12 @@ module Language.Marlowe.CLI.Test.Types
   , seEra
   , seProtocolVersion
   , seSlotConfig
-  , seTransactionTimeout
-  , seExecutionTimeoute
+  , seExecutionMode
   , ssContracts
   , ssCurrencies
   , ssReferenceScripts
   , ssWallets
   ) where
-
 
 import Cardano.Api
   (AddressInEra, CardanoMode, LocalNodeConnectInfo, Lovelace, NetworkId, PolicyId, ScriptDataSupportedInEra, TxBody)
@@ -115,7 +114,7 @@ data MarloweTests era a =
     deriving stock (Eq, Generic, Show)
 
 -- | Configuration for executing Marlowe CLI DSL commands on the blockchain
-data ExecutionMode = PureSimulation | OnChainExecution { transactionTimeout :: Seconds }
+data ExecutionMode = SimulationMode | OnChainMode { transactionTimeout :: Seconds }
 
 -- | An on-chain test of the Marlowe contract and payout validators.
 data ScriptTest =
@@ -489,8 +488,7 @@ data ScriptEnv era = ScriptEnv
   , _seEra                :: ScriptDataSupportedInEra era
   , _seProtocolVersion    :: ProtocolVersion
   , _seSlotConfig         :: SlotConfig
-  -- , _seTransactionTimeout :: Seconds
-  , _seExecutionTimeout   :: ExecutionMode
+  , _seExecutionMode      :: ExecutionMode
   }
 
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -114,6 +114,11 @@ data MarloweTests era a =
     deriving stock (Eq, Generic, Show)
 
 -- | Configuration for executing Marlowe CLI DSL commands on the blockchain
+-- | The idea behind simulation mode is to use it as a "first line of defense" to detect
+-- | errors in code or in the test case itself before spending the time/resources to run the same
+-- | scenarios on chain.
+-- | Tests that fail in simulation mode should also fail on chain
+-- | Tests that pass on chain should also pass in simulation mode
 data ExecutionMode = SimulationMode | OnChainMode { transactionTimeout :: Seconds }
 
 -- | An on-chain test of the Marlowe contract and payout validators.

--- a/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Test/Types.hs
@@ -109,6 +109,7 @@ data MarloweTests era a =
     , faucetSigningKeyFile :: FilePath    -- ^ The file containing the faucet's signing key.
     , faucetAddress        :: AddressInEra era  -- ^ The faucet address.
     , burnAddress          :: AddressInEra era -- ^ The address to which to send unneeded native tokens.
+    , executionMode        :: ExecutionMode
     , tests                :: [a]         -- ^ Input for the tests.
     }
     deriving stock (Eq, Generic, Show)
@@ -119,7 +120,8 @@ data MarloweTests era a =
 -- | scenarios on chain.
 -- | Tests that fail in simulation mode should also fail on chain
 -- | Tests that pass on chain should also pass in simulation mode
-data ExecutionMode = SimulationMode | OnChainMode { transactionTimeout :: Seconds }
+data ExecutionMode = SimulationMode | OnChainMode { transactionSubmissionTimeout :: Seconds }
+    deriving stock (Eq, Show)
 
 -- | An on-chain test of the Marlowe contract and payout validators.
 data ScriptTest =
@@ -485,6 +487,7 @@ scriptState faucet = do
   ScriptState mempty mempty Nothing wallets
 
 newtype Seconds = Seconds Int
+    deriving stock (Eq, Show)
 
 
 data ScriptEnv era = ScriptEnv

--- a/marlowe-cli/src/Language/Marlowe/CLI/Transaction.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Transaction.hs
@@ -861,7 +861,7 @@ publishImpl :: forall era m
             -> AddressInEra era                  -- ^ The change address.
             -> PublishingStrategy era
             -> CoinSelectionStrategy
-            -> Maybe Int
+            -> Int
             -> PrintStats
             -> m (MarloweScriptsRefs MarlowePlutusVersion era)
 publishImpl connection signingKey expires changeAddress publishingStrategy coinSelectionStrategy timeout printStats = do
@@ -874,8 +874,7 @@ publishImpl connection signingKey expires changeAddress publishingStrategy coinS
     coinSelectionStrategy
     printStats
 
-  forM_ timeout
-    $ submitBody connection txBody [signingKey]
+  void $ submitBody connection txBody [signingKey] timeout
   findMarloweScriptsRefs connection publishingStrategy printStats >>= \case
     Nothing -> throwError . CliError $ "Unable to find just published scripts by tx:" <> show (getTxId txBody)
     Just m  -> pure m

--- a/marlowe-cli/src/Language/Marlowe/CLI/Transaction.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Transaction.hs
@@ -861,7 +861,7 @@ publishImpl :: forall era m
             -> AddressInEra era                  -- ^ The change address.
             -> PublishingStrategy era
             -> CoinSelectionStrategy
-            -> Int
+            -> Maybe Int
             -> PrintStats
             -> m (MarloweScriptsRefs MarlowePlutusVersion era)
 publishImpl connection signingKey expires changeAddress publishingStrategy coinSelectionStrategy timeout printStats = do
@@ -874,7 +874,8 @@ publishImpl connection signingKey expires changeAddress publishingStrategy coinS
     coinSelectionStrategy
     printStats
 
-  void $ submitBody connection txBody [signingKey] timeout
+  forM_ timeout
+    $ submitBody connection txBody [signingKey]
   findMarloweScriptsRefs connection publishingStrategy printStats >>= \case
     Nothing -> throwError . CliError $ "Unable to find just published scripts by tx:" <> show (getTxId txBody)
     Just m  -> pure m


### PR DESCRIPTION
<!--
Adds functionality to allow the marlowe cli dsl to skip on chain execution. We also add an optional flag `--simulation-mode` to the marlowe cli test command to skip on chain execution from the command line.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
