### PR TITLE
Scp 4447 chainseek tx submission

### DIFF
--- a/marlowe-chain-sync/app/Main.hs
+++ b/marlowe-chain-sync/app/Main.hs
@@ -1,7 +1,17 @@
+{-# LANGUAGE GADTs #-}
 module Main
   where
 
-import Cardano.Api (CardanoMode, ConsensusModeParams(..), EpochSlots(..), LocalNodeConnectInfo(..), queryNodeLocalState)
+import Cardano.Api
+  ( CardanoEra(..)
+  , CardanoMode
+  , ConsensusModeParams(..)
+  , EpochSlots(..)
+  , EraInMode(..)
+  , LocalNodeConnectInfo(..)
+  , TxInMode(..)
+  , queryNodeLocalState
+  )
 import qualified Cardano.Api as Cardano
 import Cardano.Api.Byron (toByronRequiresNetworkMagic)
 import qualified Cardano.Chain.Genesis as Byron
@@ -23,11 +33,14 @@ import Language.Marlowe.Runtime.ChainSync.Api (WithGenesis(..), runtimeChainSeek
 import Language.Marlowe.Runtime.ChainSync.Database (hoistDatabaseQueries)
 import qualified Language.Marlowe.Runtime.ChainSync.Database.PostgreSQL as PostgreSQL
 import Language.Marlowe.Runtime.ChainSync.Genesis (computeByronGenesisBlock)
+import Language.Marlowe.Runtime.ChainSync.JobServer (RunJobServer(..))
 import Language.Marlowe.Runtime.ChainSync.QueryServer (RunQueryServer(..))
 import Language.Marlowe.Runtime.ChainSync.Server (RunChainSeekServer(..))
 import Network.Channel (effectChannel, socketAsChannel)
 import Network.Protocol.ChainSeek.Server (chainSeekServerPeer)
 import Network.Protocol.Driver (mkDriver)
+import Network.Protocol.Job.Codec (codecJob)
+import Network.Protocol.Job.Server (jobServerPeer)
 import Network.Protocol.Query.Codec (codecQuery)
 import Network.Protocol.Query.Server (queryServerPeer)
 import Network.Socket
@@ -59,47 +72,62 @@ run :: Options -> IO ()
 run Options{..} = withSocketsDo do
   chainSeekAddr <- resolve port
   queryAddr <- resolve queryPort
+  commandAddr <- resolve commandPort
   bracket (open chainSeekAddr) close \chainSeekSocket -> do
     bracket (open queryAddr) close \querySocket -> do
-      socketIdVar <- newTVarIO @Int 0
-      pool <- Pool.acquire (100, secondsToNominalDiffTime 5, fromString databaseUri)
-      genesisConfigResult <- runExceptT do
-        hash <- ExceptT $ pure $ decodeAbstractHash genesisConfigHash
-        (hash,) <$> withExceptT
-          (const "failed to read byron genesis file")
-          (Byron.mkConfigFromFile (toByronRequiresNetworkMagic networkId) genesisConfigFile hash)
-      (hash, genesisConfig) <- either (fail . unpack) pure genesisConfigResult
-      let genesisBlock = computeByronGenesisBlock (abstractHashToBytes hash) genesisConfig
-      chainSync <- atomically $ mkChainSync ChainSyncDependencies
-        { connectToLocalNode = Cardano.connectToLocalNode localNodeConnectInfo
-        , databaseQueries = hoistDatabaseQueries
-            (either throwUsageError pure <=< Pool.use pool)
-            (PostgreSQL.databaseQueries genesisBlock)
-        , persistRateLimit
-        , genesisBlock
-          , acceptRunChainSeekServer = do
-              socketId <- atomically do
-                modifyTVar socketIdVar (+1)
-                readTVar socketIdVar
-              (conn, _ :: SockAddr) <- accept chainSeekSocket
-              let
-                driver = mkDriver throwIO runtimeChainSeekCodec
-                  $ effectChannel (logSend socketId) (logRecv socketId)
-                  $ socketAsChannel conn
-              pure $ RunChainSeekServer \server -> do
-                let peer = chainSeekServerPeer Genesis server
-                fst <$> (runPeerWithDriver driver peer (startDState driver) `finally` close conn)
-        , acceptRunQueryServer = do
-            (conn, _ :: SockAddr) <- accept querySocket
-            let driver = mkDriver throwIO codecQuery $ socketAsChannel conn
-            pure $ RunQueryServer \server -> do
-              let peer = queryServerPeer server
-              fst <$> runPeerWithDriver driver peer (startDState driver)
-        , queryLocalNodeState = queryNodeLocalState localNodeConnectInfo
-        , maxCost
-        , costModel
-        }
-      runChainSync chainSync
+      bracket (open commandAddr) close \commandSocket -> do
+        socketIdVar <- newTVarIO @Int 0
+        pool <- Pool.acquire (100, secondsToNominalDiffTime 5, fromString databaseUri)
+        genesisConfigResult <- runExceptT do
+          hash <- ExceptT $ pure $ decodeAbstractHash genesisConfigHash
+          (hash,) <$> withExceptT
+            (const "failed to read byron genesis file")
+            (Byron.mkConfigFromFile (toByronRequiresNetworkMagic networkId) genesisConfigFile hash)
+        (hash, genesisConfig) <- either (fail . unpack) pure genesisConfigResult
+        let genesisBlock = computeByronGenesisBlock (abstractHashToBytes hash) genesisConfig
+        chainSync <- atomically $ mkChainSync ChainSyncDependencies
+          { connectToLocalNode = Cardano.connectToLocalNode localNodeConnectInfo
+          , databaseQueries = hoistDatabaseQueries
+              (either throwUsageError pure <=< Pool.use pool)
+              (PostgreSQL.databaseQueries genesisBlock)
+          , persistRateLimit
+          , genesisBlock
+            , acceptRunChainSeekServer = do
+                socketId <- atomically do
+                  modifyTVar socketIdVar (+1)
+                  readTVar socketIdVar
+                (conn, _ :: SockAddr) <- accept chainSeekSocket
+                let
+                  driver = mkDriver throwIO runtimeChainSeekCodec
+                    $ effectChannel (logSend socketId) (logRecv socketId)
+                    $ socketAsChannel conn
+                pure $ RunChainSeekServer \server -> do
+                  let peer = chainSeekServerPeer Genesis server
+                  fst <$> (runPeerWithDriver driver peer (startDState driver) `finally` close conn)
+          , acceptRunQueryServer = do
+              (conn, _ :: SockAddr) <- accept querySocket
+              let driver = mkDriver throwIO codecQuery $ socketAsChannel conn
+              pure $ RunQueryServer \server -> do
+                let peer = queryServerPeer server
+                fst <$> runPeerWithDriver driver peer (startDState driver)
+          , acceptRunJobServer = do
+              (conn, _ :: SockAddr) <- accept commandSocket
+              let driver = mkDriver throwIO codecJob $ socketAsChannel conn
+              pure $ RunJobServer \server -> do
+                let peer = jobServerPeer server
+                fst <$> runPeerWithDriver driver peer (startDState driver)
+          , queryLocalNodeState = queryNodeLocalState localNodeConnectInfo
+          , submitTxToNodeLocal = \era tx -> Cardano.submitTxToNodeLocal localNodeConnectInfo $ TxInMode tx case era of
+              ByronEra -> ByronEraInCardanoMode
+              ShelleyEra -> ShelleyEraInCardanoMode
+              AllegraEra -> AllegraEraInCardanoMode
+              MaryEra -> MaryEraInCardanoMode
+              AlonzoEra -> AlonzoEraInCardanoMode
+              BabbageEra -> BabbageEraInCardanoMode
+          , maxCost
+          , costModel
+          }
+        runChainSync chainSync
   where
     logSend i bytes =
       hPutStr stderr ("send[" <> show i <> "]: ") *> TL.hPutStrLn stderr (encodeBase16 bytes)

--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -61,6 +61,7 @@ library
     Language.Marlowe.Runtime.ChainSync.Database
     Language.Marlowe.Runtime.ChainSync.Database.PostgreSQL
     Language.Marlowe.Runtime.ChainSync.Genesis
+    Language.Marlowe.Runtime.ChainSync.JobServer
     Language.Marlowe.Runtime.ChainSync.NodeClient
     Language.Marlowe.Runtime.ChainSync.Server
     Language.Marlowe.Runtime.ChainSync.QueryServer

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/JobServer.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/JobServer.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StrictData #-}
+
+module Language.Marlowe.Runtime.ChainSync.JobServer
+  where
+
+import Cardano.Api (CardanoEra(..), CardanoMode, ScriptDataSupportedInEra(..), Tx, TxValidationErrorInMode)
+import Control.Concurrent.Async (Concurrently(..))
+import Control.Concurrent.STM (STM, atomically)
+import Control.Exception (SomeException, catch)
+import Data.Void (Void)
+import Language.Marlowe.Runtime.ChainSync.Api (ChainSyncCommand(..))
+import Network.Protocol.Job.Server
+import Ouroboros.Network.Protocol.LocalTxSubmission.Client (SubmitResult(..))
+import System.IO (hPutStrLn, stderr)
+
+newtype RunJobServer m = RunJobServer (forall a. JobServer ChainSyncCommand m a -> IO a)
+
+data ChainSyncJobServerDependencies = ChainSyncJobServerDependencies
+  { acceptRunJobServer :: IO (RunJobServer IO)
+  , submitTxToNodeLocal
+      :: forall era
+       . CardanoEra era
+      -> Tx era
+      -> IO (SubmitResult (TxValidationErrorInMode CardanoMode))
+  }
+
+newtype ChainSyncJobServer = ChainSyncJobServer
+  { runChainSyncJobServer :: IO Void
+  }
+
+mkChainSyncJobServer :: ChainSyncJobServerDependencies -> STM ChainSyncJobServer
+mkChainSyncJobServer ChainSyncJobServerDependencies{..} = do
+  let
+    runChainSyncJobServer = do
+      runJobServer <- acceptRunJobServer
+      Worker{..} <- atomically $ mkWorker WorkerDependencies {..}
+      runConcurrently $
+        Concurrently (runWorker `catch` catchWorker) *> Concurrently runChainSyncJobServer
+  pure $ ChainSyncJobServer { runChainSyncJobServer }
+
+catchWorker :: SomeException -> IO ()
+catchWorker = hPutStrLn stderr . ("Job worker crashed with exception: " <>) . show
+
+data WorkerDependencies = WorkerDependencies
+  { runJobServer      :: RunJobServer IO
+  , submitTxToNodeLocal
+      :: forall era
+       . CardanoEra era
+      -> Tx era
+      -> IO (SubmitResult (TxValidationErrorInMode CardanoMode))
+  }
+
+newtype Worker = Worker
+  { runWorker :: IO ()
+  }
+
+mkWorker :: WorkerDependencies -> STM Worker
+mkWorker WorkerDependencies{..} =
+  let
+    RunJobServer run = runJobServer
+  in
+    pure Worker { runWorker = run server }
+  where
+    server :: JobServer ChainSyncCommand IO ()
+    server = liftCommandHandler $ flip either (\case) \case
+      SubmitTx era tx -> ((),) <$> do
+        result <- submitTxToNodeLocal
+          case era of
+            ScriptDataInAlonzoEra -> AlonzoEra
+            ScriptDataInBabbageEra -> BabbageEra
+          tx
+        pure case result of
+          SubmitFail err -> Left $ show err
+          SubmitSuccess -> Right ()

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
@@ -78,6 +78,7 @@
           "Language/Marlowe/Runtime/ChainSync/Database"
           "Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL"
           "Language/Marlowe/Runtime/ChainSync/Genesis"
+          "Language/Marlowe/Runtime/ChainSync/JobServer"
           "Language/Marlowe/Runtime/ChainSync/NodeClient"
           "Language/Marlowe/Runtime/ChainSync/Server"
           "Language/Marlowe/Runtime/ChainSync/QueryServer"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
@@ -78,6 +78,7 @@
           "Language/Marlowe/Runtime/ChainSync/Database"
           "Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL"
           "Language/Marlowe/Runtime/ChainSync/Genesis"
+          "Language/Marlowe/Runtime/ChainSync/JobServer"
           "Language/Marlowe/Runtime/ChainSync/NodeClient"
           "Language/Marlowe/Runtime/ChainSync/Server"
           "Language/Marlowe/Runtime/ChainSync/QueryServer"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-chain-sync.nix
@@ -78,6 +78,7 @@
           "Language/Marlowe/Runtime/ChainSync/Database"
           "Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL"
           "Language/Marlowe/Runtime/ChainSync/Genesis"
+          "Language/Marlowe/Runtime/ChainSync/JobServer"
           "Language/Marlowe/Runtime/ChainSync/NodeClient"
           "Language/Marlowe/Runtime/ChainSync/Server"
           "Language/Marlowe/Runtime/ChainSync/QueryServer"


### PR DESCRIPTION
Adds a proxy API for node Tx submission to chainseekd. Something we might want to think about is how we want to handle node connections going forward. As it stands, `chainseekd` is becoming the node proxy for Marlowe Runtime. Is this what we want? Its name is a bit misleading if that is the case.