### PR TITLE
SCP-4319 Create top level Module construct in Extended

### DIFF
--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -166,4 +166,4 @@ test-suite marlowe-test
         tasty-quickcheck,
         text,
         these,
-        directory,
+        filepath,

--- a/marlowe/marlowe.cabal
+++ b/marlowe/marlowe.cabal
@@ -58,6 +58,7 @@ library
     deriving-aeson,
     mtl,
     newtype-generics,
+    ordered-containers,
     plutus-ledger-ada,
     plutus-ledger-api,
     plutus-ledger-slot,
@@ -73,6 +74,7 @@ library
   exposed-modules:
     Language.Marlowe
     Language.Marlowe.Extended.V1
+    Language.Marlowe.Extended.V1.Metadata.Types
     Language.Marlowe.Core.V1.Semantics
     Language.Marlowe.Core.V1.Semantics.Types
     Language.Marlowe.Core.V1.Semantics.Types.Address
@@ -123,6 +125,9 @@ test-suite marlowe-test
         Spec.Marlowe.Plutus.Transaction
         Spec.Marlowe.Plutus.Types
         Spec.Marlowe.Plutus.Value
+        Spec.Marlowe.Serialization
+        Spec.Marlowe.Serialization.CoreJson
+        Spec.Marlowe.Serialization.ExtendedJson
         Spec.Marlowe.Semantics.Arbitrary
         Spec.Marlowe.Semantics.AssocMap
         Spec.Marlowe.Semantics.Compute
@@ -161,3 +166,4 @@ test-suite marlowe-test
         tasty-quickcheck,
         text,
         these,
+        directory,

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -683,8 +683,8 @@ instance FromJSON TransactionInput where
                      mapM parseJSON (F.toList cl)
                                                       ))
     where parseTimeInterval = withObject "TimeInterval" (\v ->
-            do from <- POSIXTime <$> (withInteger =<< (v .: "from"))
-               to <- POSIXTime <$> (withInteger =<< (v .: "to"))
+            do from <- POSIXTime <$> (withInteger "TimeInterval from" =<< (v .: "from"))
+               to <- POSIXTime <$> (withInteger "TimeInterval to" =<< (v .: "to"))
                return (from, to)
                                                       )
   parseJSON _ = Haskell.fail "TransactionInput must be an object"
@@ -714,7 +714,7 @@ instance FromJSON TransactionWarning where
               Just butOnlyPaid -> TransactionPartialPay <$> (v .: "account")
                                                         <*> (v .: "to_payee")
                                                         <*> (v .: "of_token")
-                                                        <*> getInteger butOnlyPaid
+                                                        <*> getInteger "but only paid" butOnlyPaid
                                                         <*> (v .: "asked_to_pay"))
     <|> (TransactionShadowing <$> (v .: "value_id")
                               <*> (v .: "had_value")

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics/Types.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics/Types.hs
@@ -225,6 +225,7 @@ data Contract = Close
   deriving stock (Haskell.Show,Generic,Haskell.Eq,Haskell.Ord)
   deriving anyclass (Pretty)
 
+
 {-| Marlowe contract internal state. Stored in a /Datum/ of a transaction output.
 -}
 data State = State { accounts    :: Accounts
@@ -382,7 +383,7 @@ instance FromJSON State where
          State <$> (v .: "accounts" >>= fromJSONAssocMap)
                <*> (v .: "choices" >>= fromJSONAssocMap)
                <*> (v .: "boundValues" >>= fromJSONAssocMap)
-               <*> (POSIXTime <$> (withInteger =<< (v .: "minTime")))
+               <*> (POSIXTime <$> (withInteger "minTime" =<< (v .: "minTime")))
                                  )
 
 instance ToJSON State where
@@ -446,7 +447,6 @@ instance FromJSON ValueId where
 instance ToJSON ValueId where
     toJSON (ValueId x) = JSON.String (Text.decodeUtf8 $ fromBuiltin x)
 
-
 instance FromJSON (Value Observation) where
   parseJSON (Object v) =
         (AvailableMoney <$> (v .: "in_account")
@@ -466,7 +466,7 @@ instance FromJSON (Value Observation) where
               <*> (v .: "else"))
   parseJSON (String "time_interval_start") = return TimeIntervalStart
   parseJSON (String "time_interval_end") = return TimeIntervalEnd
-  parseJSON (Number n) = Constant <$> getInteger n
+  parseJSON (Number n) = Constant <$> getInteger "constant value" n
   parseJSON _ = Haskell.fail "Value must be either an object or an integer"
 instance ToJSON (Value Observation) where
   toJSON (AvailableMoney accountId token) = object
@@ -566,8 +566,8 @@ instance ToJSON Observation where
 
 instance FromJSON Bound where
   parseJSON = withObject "Bound" (\v ->
-       Bound <$> (getInteger =<< (v .: "from"))
-             <*> (getInteger =<< (v .: "to"))
+       Bound <$> (getInteger "lower bound"=<< (v .: "from"))
+             <*> (getInteger "higher bound" =<< (v .: "to"))
                                  )
 instance ToJSON Bound where
   toJSON (Bound from to) = object
@@ -649,7 +649,7 @@ instance FromJSON Contract where
                    withArray "Case list" (\cl ->
                      mapM parseJSON (F.toList cl)
                                           ))
-              <*> (POSIXTime <$> (withInteger =<< (v .: "timeout")))
+              <*> (POSIXTime <$> (withInteger "when timeout" =<< (v .: "timeout")))
               <*> (v .: "timeout_continuation"))
     <|> (Let <$> (v .: "let")
              <*> (v .: "be")

--- a/marlowe/src/Language/Marlowe/Extended/V1/Metadata/Types.hs
+++ b/marlowe/src/Language/Marlowe/Extended/V1/Metadata/Types.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Language.Marlowe.Extended.V1.Metadata.Types
+  where
+
+import Data.Aeson (FromJSON, Value, parseJSON, withArray, withObject, (.:))
+import Data.Aeson.Types (Parser)
+import Data.Bifunctor (Bifunctor(first))
+import qualified Data.Foldable as F
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Map.Ordered (OMap)
+import qualified Data.Map.Ordered as OMap
+import Data.Set (Set)
+import Data.Set.Ordered (OSet)
+import Data.Text.Encoding as Text
+import qualified GHC.Generics
+import Plutus.V1.Ledger.Api (TokenName)
+import qualified Plutus.V1.Ledger.Value as Val
+
+data ContractType
+  = Escrow
+  | EscrowWithCollateral
+  | ZeroCouponBond
+  | CouponBondGuaranteed
+  | Swap
+  | ContractForDifferences
+  | Other
+    deriving stock (Show,Eq,GHC.Generics.Generic)
+    deriving anyclass (FromJSON)
+
+
+data NumberFormat
+  = DefaultFormat
+  | DecimalFormat Int String
+  | TimeFormat
+   deriving stock (Show,Eq,GHC.Generics.Generic)
+   deriving anyclass (FromJSON)
+
+
+data NumberFormatType
+  = DefaultFormatType
+  | DecimalFormatType
+  | TimeFormatType
+  deriving stock (Show, Eq, GHC.Generics.Generic)
+  deriving anyclass (FromJSON)
+
+data ValueParameterInfo = ValueParameterInfo
+  { valueParameterFormat      :: NumberFormat
+  , valueParameterDescription :: String
+  }
+  deriving stock (Show, Eq, GHC.Generics.Generic)
+  deriving anyclass (FromJSON)
+
+
+data ChoiceInfo = ChoiceInfo
+  { choiceFormat      :: NumberFormat
+  , choiceDescription :: String
+  }
+  deriving stock (Show, Eq, GHC.Generics.Generic)
+  deriving anyclass (FromJSON)
+
+type ChoiceName = String
+
+data MetaData = MetaData
+  { contractType              :: ContractType
+  , contractName              :: String
+  , contractShortDescription  :: String
+  , contractLongDescription   :: String
+  , roleDescriptions          :: Map TokenName String
+  -- Order map of time parameters. Key is parameter name, value is parameter description
+  , timeParameterDescriptions :: OMap String String
+  -- Order map of value parameters. Key is parameter name, value is parameter information
+  , valueParameterInfo        :: OMap String ValueParameterInfo
+  , choiceInfo                :: Map ChoiceName ChoiceInfo
+  }
+  deriving stock (Show, Eq, GHC.Generics.Generic)
+
+
+instance FromJSON MetaData where
+    parseJSON =
+        withObject "Module" (\v -> do
+            cType <- v .: "contractType"
+            cName <- v .: "contractName"
+            cShortDescription <- v .: "contractShortDescription"
+            cLongDescription <- v .: "contractLongDescription"
+            roleDesc <- (v .: "roleDescriptions")
+                >>= withArray "Role descriptions"
+                        (\pl -> mapM parseRoleDesc (F.toList pl)
+                        )
+            timeParametersDesc <-
+                (v .: "timeParameterDescriptions")
+                    >>= withArray "Time parameters"
+                        (\pl -> mapM parseJSON (F.toList pl)
+                        )
+            valParameterInfo <-
+                (v .: "valueParameterInfo")  >>= withArray "Value parameters"
+                        (\pl -> mapM parseJSON (F.toList pl)
+                        )
+            chParameterInfo <-
+                (v .: "choiceInfo")  >>= withArray "choice info"
+                        (\pl -> mapM parseJSON (F.toList pl)
+                        )
+
+            return $ MetaData
+                { contractType = cType
+                , contractName = cName
+                , contractShortDescription = cShortDescription
+                , contractLongDescription = cLongDescription
+                , roleDescriptions = Map.fromList roleDesc
+                , timeParameterDescriptions = OMap.fromList timeParametersDesc
+                , valueParameterInfo = OMap.fromList valParameterInfo
+                , choiceInfo = Map.fromList chParameterInfo
+                }
+        )
+        where
+        parseRoleDesc :: Value -> Parser (TokenName, String)
+        parseRoleDesc val = first (Val.tokenName . Text.encodeUtf8 ) <$> parseJSON val
+
+data MetadataHintInfo = MetadataHintInfo
+  { roles           :: Set TokenName
+  , timeParameters  :: OSet String
+  , valueParameters :: OSet String
+  , choiceNames     :: Set String
+  }
+  deriving stock (Show,Eq)

--- a/marlowe/src/Language/Marlowe/ParserUtil.hs
+++ b/marlowe/src/Language/Marlowe/ParserUtil.hs
@@ -5,13 +5,13 @@ import qualified Data.Aeson as JSON
 import Data.Aeson.Types hiding (Error, Value)
 import Data.Scientific (Scientific, floatingOrInteger)
 
-getInteger :: Scientific -> Parser Integer
-getInteger x = case (floatingOrInteger x :: Either Double Integer) of
+getInteger :: String -> Scientific -> Parser Integer
+getInteger ctx x = case (floatingOrInteger x :: Either Double Integer) of
                  Right a -> return a
-                 Left _  -> fail "Account number is not an integer"
+                 Left _  -> fail $ "parsing " ++ ctx ++ " failed, expected integer, but encountered floating point"
 
-withInteger :: JSON.Value -> Parser Integer
-withInteger = withScientific "" getInteger
+withInteger :: String -> JSON.Value -> Parser Integer
+withInteger ctx = withScientific ctx $ getInteger ctx
 
 customOptions :: Options
 customOptions = defaultOptions

--- a/marlowe/test/Spec.hs
+++ b/marlowe/test/Spec.hs
@@ -24,11 +24,10 @@ module Main
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
-import qualified Spec.Marlowe.Marlowe
-  (prop_contractJsonLoops, prop_intervalErrorJsonLoops, prop_marloweParamsJsonLoops, prop_noFalsePositives, tests)
+import qualified Spec.Marlowe.Marlowe (prop_noFalsePositives, tests)
 import qualified Spec.Marlowe.Plutus (tests)
 import qualified Spec.Marlowe.Semantics (tests)
-
+import qualified Spec.Marlowe.Serialization (tests)
 
 -- | Timeout seconds for static analysis, which can take so much time on a complex contract
 --   that it exceeds hydra/CI resource limits, see SCP-4267.
@@ -55,12 +54,7 @@ tests =
       [
         testProperty "No false positives" $ Spec.Marlowe.Marlowe.prop_noFalsePositives timeout
       ]
-    , testGroup "JSON Serialisation"
-      [
-        testProperty "Serialise deserialise Contract loops" Spec.Marlowe.Marlowe.prop_contractJsonLoops
-      , testProperty "Serialise deserialise MarloweParams loops" Spec.Marlowe.Marlowe.prop_marloweParamsJsonLoops
-      , testProperty "Serialise deserialise IntervalError loops" Spec.Marlowe.Marlowe.prop_intervalErrorJsonLoops
-      ]
+    , Spec.Marlowe.Serialization.tests
     , Spec.Marlowe.Semantics.tests
     , Spec.Marlowe.Plutus.tests
     ]

--- a/marlowe/test/Spec/Marlowe/Serialization.hs
+++ b/marlowe/test/Spec/Marlowe/Serialization.hs
@@ -11,7 +11,7 @@
 -----------------------------------------------------------------------------
 
 
-module Spec.Marlowe.Semantics
+module Spec.Marlowe.Serialization
   ( -- * Testing
     tests
   ) where
@@ -19,18 +19,14 @@ module Spec.Marlowe.Semantics
 
 import Test.Tasty (TestTree, testGroup)
 
-import qualified Spec.Marlowe.Semantics.Compute (tests)
-import qualified Spec.Marlowe.Semantics.Entropy (tests)
-import qualified Spec.Marlowe.Semantics.Functions (tests)
-import qualified Spec.Marlowe.Semantics.Golden (tests)
+import qualified Spec.Marlowe.Serialization.CoreJson (tests)
+import qualified Spec.Marlowe.Serialization.ExtendedJson (tests)
 
 -- | Run the tests.
 tests :: TestTree
 tests =
-  testGroup "Semantics"
+  testGroup "Serialization"
     [
-      Spec.Marlowe.Semantics.Entropy.tests
-    , Spec.Marlowe.Semantics.Functions.tests
-    , Spec.Marlowe.Semantics.Compute.tests
-    , Spec.Marlowe.Semantics.Golden.tests
+      Spec.Marlowe.Serialization.CoreJson.tests
+    , Spec.Marlowe.Serialization.ExtendedJson.tests
     ]

--- a/marlowe/test/Spec/Marlowe/Serialization/CoreJson.hs
+++ b/marlowe/test/Spec/Marlowe/Serialization/CoreJson.hs
@@ -1,0 +1,79 @@
+-----------------------------------------------------------------------------
+--
+-- Module      :  $Headers
+-- License     :  Apache 2.0
+--
+-- Stability   :  Experimental
+-- Portability :  Portable
+--
+-- | This suite tests the Json serialization of the Marlowe core module
+--
+-----------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+
+module Spec.Marlowe.Serialization.CoreJson
+  ( tests
+  ) where
+
+import Control.Arrow (Arrow((***)))
+import Data.Aeson (decode, encode)
+import Data.ByteString (ByteString)
+import Language.Marlowe (IntervalError(..), MarloweParams(MarloweParams), POSIXTime(..))
+import Language.Marlowe.Core.V1.Semantics.Types (Contract)
+import Plutus.V1.Ledger.Api (CurrencySymbol(CurrencySymbol), toBuiltin)
+import Spec.Marlowe.Common (contractGen, shrinkContract)
+import Test.QuickCheck (Gen, Property, arbitrary, (===))
+import Test.QuickCheck.Instances.ByteString ()
+import Test.QuickCheck.Property (forAll, forAllShrink, withMaxSuccess)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests = testGroup "Core Contract Serialization"
+    [ testProperty "Serialise deserialise Contract loops" prop_contractJsonLoops
+    , testProperty "Serialise deserialise MarloweParams loops" prop_marloweParamsJsonLoops
+    , testProperty "Serialise deserialise IntervalError loops" prop_intervalErrorJsonLoops
+    ]
+
+
+-- | Test that JSON decoding inverts encoding for a contract.
+contractJsonLoops :: Contract -> Property
+contractJsonLoops cont = decode (encode cont) === Just cont
+
+-- | Test that JSON decoding inverts encoding for contracts.
+prop_contractJsonLoops :: Property
+prop_contractJsonLoops = withMaxSuccess 1000 $ forAllShrink contractGen shrinkContract contractJsonLoops
+
+
+
+-- | Test that JSON decoding inverts encoding for Marlowe parameters.
+marloweParamsJsonLoops :: MarloweParams -> Property
+marloweParamsJsonLoops mp = decode (encode mp) === Just mp
+
+-- | Test that JSON decoding inverts encoding for Marlowe parameters.
+prop_marloweParamsJsonLoops :: Property
+prop_marloweParamsJsonLoops = withMaxSuccess 1000 $ forAll gen marloweParamsJsonLoops
+  where
+    gen = do
+      c <- toBuiltin <$> (arbitrary :: Gen ByteString)
+      return $ MarloweParams (CurrencySymbol c)
+
+-- | Test that JSON decoding inverts encoding for an interval error.
+intervalErrorJsonLoops :: IntervalError -> Property
+intervalErrorJsonLoops ie = decode (encode ie) === Just ie
+
+
+-- | Test that JSON decoding inverts encoding for interval errors.
+prop_intervalErrorJsonLoops :: Property
+prop_intervalErrorJsonLoops = withMaxSuccess 1000 $ forAll gen intervalErrorJsonLoops
+  where
+    gen = do
+      b <- arbitrary
+      if b
+      then do
+        t <- (POSIXTime *** POSIXTime) <$> arbitrary
+        return $ InvalidInterval t
+      else do
+        s <- POSIXTime <$> arbitrary
+        t <- (POSIXTime *** POSIXTime) <$> arbitrary
+        return $ IntervalInPastError s t

--- a/marlowe/test/Spec/Marlowe/Serialization/ExtendedJson.hs
+++ b/marlowe/test/Spec/Marlowe/Serialization/ExtendedJson.hs
@@ -1,0 +1,50 @@
+-----------------------------------------------------------------------------
+--
+-- Module      :  $Headers
+-- License     :  Apache 2.0
+--
+-- Stability   :  Experimental
+-- Portability :  Portable
+--
+-- | This suite tests the Json serialization of the Marlowe extended module
+--
+-----------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+
+module Spec.Marlowe.Serialization.ExtendedJson
+  ( tests
+  ) where
+
+import Data.Aeson (eitherDecodeFileStrict)
+import Language.Marlowe.Extended.V1 (Contract, Module)
+import System.Directory (getCurrentDirectory)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertFailure, testCase)
+
+tests :: TestTree
+tests = testGroup "Extended Contract Serialization"
+    [ testCase "Golden Swap contract" testGoldenSwapContract
+    , testCase "Golden Swap module" testGoldenSwapModule
+    ]
+
+-- TODO: Do a small non-property round-trip with example contracts.
+
+
+-- | Checks that we can decode the Golden JSON Contract for Swap
+testGoldenSwapContract :: IO ()
+testGoldenSwapContract = do
+    filePath <- (\d -> d ++ "/test/Spec/Marlowe/Serialization/golden/swap-contract.json") <$> getCurrentDirectory
+    mContract <- eitherDecodeFileStrict filePath
+    case mContract of
+        Left err              -> assertFailure err
+        Right (_ :: Contract) -> return ()
+
+-- | Checks that we can decode the Golden JSON Module for Swap
+-- | TODO: If we are more of these tests, add a helper function with a Proxy type
+testGoldenSwapModule :: IO ()
+testGoldenSwapModule = do
+    filePath <- (\d -> d ++ "/test/Spec/Marlowe/Serialization/golden/swap-module.json") <$> getCurrentDirectory
+    mContract <- eitherDecodeFileStrict filePath
+    case mContract of
+        Left err            -> assertFailure err
+        Right (_ :: Module) -> return ()

--- a/marlowe/test/Spec/Marlowe/Serialization/ExtendedJson.hs
+++ b/marlowe/test/Spec/Marlowe/Serialization/ExtendedJson.hs
@@ -17,7 +17,7 @@ module Spec.Marlowe.Serialization.ExtendedJson
 
 import Data.Aeson (eitherDecodeFileStrict)
 import Language.Marlowe.Extended.V1 (Contract, Module)
-import System.Directory (getCurrentDirectory)
+import System.FilePath ((</>))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase)
 
@@ -29,12 +29,13 @@ tests = testGroup "Extended Contract Serialization"
 
 -- TODO: Do a small non-property round-trip with example contracts.
 
+goldenPath :: FilePath
+goldenPath = "test" </> "Spec" </> "Marlowe" </> "Serialization" </> "golden"
 
 -- | Checks that we can decode the Golden JSON Contract for Swap
 testGoldenSwapContract :: IO ()
 testGoldenSwapContract = do
-    filePath <- (\d -> d ++ "/test/Spec/Marlowe/Serialization/golden/swap-contract.json") <$> getCurrentDirectory
-    mContract <- eitherDecodeFileStrict filePath
+    mContract <- eitherDecodeFileStrict $ goldenPath </> "swap-contract.json"
     case mContract of
         Left err              -> assertFailure err
         Right (_ :: Contract) -> return ()
@@ -43,8 +44,7 @@ testGoldenSwapContract = do
 -- | TODO: If we are more of these tests, add a helper function with a Proxy type
 testGoldenSwapModule :: IO ()
 testGoldenSwapModule = do
-    filePath <- (\d -> d ++ "/test/Spec/Marlowe/Serialization/golden/swap-module.json") <$> getCurrentDirectory
-    mContract <- eitherDecodeFileStrict filePath
-    case mContract of
+    mModule <- eitherDecodeFileStrict $ goldenPath </> "swap-module.json"
+    case mModule of
         Left err            -> assertFailure err
         Right (_ :: Module) -> return ()

--- a/marlowe/test/Spec/Marlowe/Serialization/golden/swap-contract.json
+++ b/marlowe/test/Spec/Marlowe/Serialization/golden/swap-contract.json
@@ -1,0 +1,91 @@
+{
+  "when": [
+    {
+      "then": {
+        "when": [
+          {
+            "then": {
+              "token": {
+                "token_name": "",
+                "currency_symbol": ""
+              },
+              "to": {
+                "party": {
+                  "role_token": "Dollar provider"
+                }
+              },
+              "then": {
+                "token": {
+                  "token_name": "dollar",
+                  "currency_symbol": "85bb65"
+                },
+                "to": {
+                  "party": {
+                    "role_token": "Ada provider"
+                  }
+                },
+                "then": "close",
+                "pay": {
+                  "constant_param": "Amount of dollars"
+                },
+                "from_account": {
+                  "role_token": "Dollar provider"
+                }
+              },
+              "pay": {
+                "times": {
+                  "constant_param": "Amount of Ada"
+                },
+                "multiply": 1000000
+              },
+              "from_account": {
+                "role_token": "Ada provider"
+              }
+            },
+            "case": {
+              "party": {
+                "role_token": "Dollar provider"
+              },
+              "of_token": {
+                "token_name": "dollar",
+                "currency_symbol": "85bb65"
+              },
+              "into_account": {
+                "role_token": "Dollar provider"
+              },
+              "deposits": {
+                "constant_param": "Amount of dollars"
+              }
+            }
+          }
+        ],
+        "timeout_continuation": "close",
+        "timeout": {
+          "time_param": "Timeout for dollar deposit"
+        }
+      },
+      "case": {
+        "party": {
+          "role_token": "Ada provider"
+        },
+        "of_token": {
+          "token_name": "",
+          "currency_symbol": ""
+        },
+        "into_account": {
+          "role_token": "Ada provider"
+        },
+        "deposits": {
+          "times": {
+            "constant_param": "Amount of Ada"
+          },
+          "multiply": 1000000
+        }
+      }
+    }
+  ],
+  "timeout_continuation": "close",
+  "timeout": {
+    "time_param": "Timeout for Ada deposit"
+  }
+}

--- a/marlowe/test/Spec/Marlowe/Serialization/golden/swap-module.json
+++ b/marlowe/test/Spec/Marlowe/Serialization/golden/swap-module.json
@@ -1,0 +1,134 @@
+{
+  "metadata": {
+    "valueParameterInfo": [
+      [
+        "Amount of Ada",
+        {
+          "valueParameterFormat": {
+            "contents": [0, "₳"],
+            "tag": "DecimalFormat"
+          },
+          "valueParameterDescription": "Amount of Ada to be exchanged for dollars."
+        }
+      ],
+      [
+        "Amount of dollars",
+        {
+          "valueParameterFormat": {
+            "contents": [0, "$"],
+            "tag": "DecimalFormat"
+          },
+          "valueParameterDescription": "Amount of dollar tokens to be exchanged for Ada."
+        }
+      ]
+    ],
+    "timeParameterDescriptions": [
+      ["Timeout for Ada deposit", "Deadline by which Ada must be deposited."],
+      [
+        "Timeout for dollar deposit",
+        "Deadline by which dollar tokens must be deposited (must be after the deadline for Ada deposit)."
+      ]
+    ],
+    "roleDescriptions": [
+      ["Ada provider", "The party that provides the Ada."],
+      ["Dollar provider", "The party that provides the dollar tokens."]
+    ],
+    "contractType": "Swap",
+    "contractShortDescription": "Atomically exchange of Ada and dollar tokens.",
+    "contractName": "Swap of Ada and dollar tokens",
+    "contractLongDescription": "Waits until one party deposits Ada and the other party deposits dollar tokens. If both parties collaborate it carries the exchange atomically, otherwise parties are refunded.",
+    "choiceInfo": []
+  },
+  "me_version": 1,
+  "contract": {
+    "when": [
+      {
+        "then": {
+          "when": [
+            {
+              "then": {
+                "token": {
+                  "token_name": "",
+                  "currency_symbol": ""
+                },
+                "to": {
+                  "party": {
+                    "role_token": "Dollar provider"
+                  }
+                },
+                "then": {
+                  "token": {
+                    "token_name": "dollar",
+                    "currency_symbol": "85bb65"
+                  },
+                  "to": {
+                    "party": {
+                      "role_token": "Ada provider"
+                    }
+                  },
+                  "then": "close",
+                  "pay": {
+                    "constant_param": "Amount of dollars"
+                  },
+                  "from_account": {
+                    "role_token": "Dollar provider"
+                  }
+                },
+                "pay": {
+                  "times": {
+                    "constant_param": "Amount of Ada"
+                  },
+                  "multiply": 1000000
+                },
+                "from_account": {
+                  "role_token": "Ada provider"
+                }
+              },
+              "case": {
+                "party": {
+                  "role_token": "Dollar provider"
+                },
+                "of_token": {
+                  "token_name": "dollar",
+                  "currency_symbol": "85bb65"
+                },
+                "into_account": {
+                  "role_token": "Dollar provider"
+                },
+                "deposits": {
+                  "constant_param": "Amount of dollars"
+                }
+              }
+            }
+          ],
+          "timeout_continuation": "close",
+          "timeout": {
+            "time_param": "Timeout for dollar deposit"
+          }
+        },
+        "case": {
+          "party": {
+            "role_token": "Ada provider"
+          },
+          "of_token": {
+            "token_name": "",
+            "currency_symbol": ""
+          },
+          "into_account": {
+            "role_token": "Ada provider"
+          },
+          "deposits": {
+            "times": {
+              "constant_param": "Amount of Ada"
+            },
+            "multiply": 1000000
+          }
+        }
+      }
+    ],
+    "timeout_continuation": "close",
+    "timeout": {
+      "time_param": "Timeout for Ada deposit"
+    }
+  }
+}

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
@@ -43,6 +43,7 @@
           (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
+          (hsPkgs."ordered-containers" or (errorHandler.buildDepError "ordered-containers"))
           (hsPkgs."plutus-ledger-ada" or (errorHandler.buildDepError "plutus-ledger-ada"))
           (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-ledger-slot" or (errorHandler.buildDepError "plutus-ledger-slot"))
@@ -59,6 +60,7 @@
         modules = [
           "Language/Marlowe"
           "Language/Marlowe/Extended/V1"
+          "Language/Marlowe/Extended/V1/Metadata/Types"
           "Language/Marlowe/Core/V1/Semantics"
           "Language/Marlowe/Core/V1/Semantics/Types"
           "Language/Marlowe/Core/V1/Semantics/Types/Address"
@@ -100,6 +102,7 @@
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             ];
           buildable = true;
           modules = [
@@ -117,6 +120,9 @@
             "Spec/Marlowe/Plutus/Transaction"
             "Spec/Marlowe/Plutus/Types"
             "Spec/Marlowe/Plutus/Value"
+            "Spec/Marlowe/Serialization"
+            "Spec/Marlowe/Serialization/CoreJson"
+            "Spec/Marlowe/Serialization/ExtendedJson"
             "Spec/Marlowe/Semantics/Arbitrary"
             "Spec/Marlowe/Semantics/AssocMap"
             "Spec/Marlowe/Semantics/Compute"

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe.nix
@@ -102,7 +102,7 @@
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             ];
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -474,6 +474,7 @@
         "logict".revision = (((hackage."logict")."0.7.0.3").revisions).default;
         "mersenne-random-pure64".revision = (((hackage."mersenne-random-pure64")."0.2.2.0").revisions).default;
         "mersenne-random-pure64".flags.small_base = false;
+        "ordered-containers".revision = (((hackage."ordered-containers")."0.2.2").revisions).default;
         "these".revision = (((hackage."these")."1.1.1.1").revisions).default;
         "these".flags.assoc = true;
         "split".revision = (((hackage."split")."0.2.3.4").revisions).default;
@@ -1499,6 +1500,7 @@
           "cardano-crypto".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
           "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
+          "ordered-containers".components.library.planned = lib.mkOverride 900 true;
           "hpc".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "websockets-snap".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
@@ -43,6 +43,7 @@
           (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
+          (hsPkgs."ordered-containers" or (errorHandler.buildDepError "ordered-containers"))
           (hsPkgs."plutus-ledger-ada" or (errorHandler.buildDepError "plutus-ledger-ada"))
           (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-ledger-slot" or (errorHandler.buildDepError "plutus-ledger-slot"))
@@ -59,6 +60,7 @@
         modules = [
           "Language/Marlowe"
           "Language/Marlowe/Extended/V1"
+          "Language/Marlowe/Extended/V1/Metadata/Types"
           "Language/Marlowe/Core/V1/Semantics"
           "Language/Marlowe/Core/V1/Semantics/Types"
           "Language/Marlowe/Core/V1/Semantics/Types/Address"
@@ -100,6 +102,7 @@
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             ];
           buildable = true;
           modules = [
@@ -117,6 +120,9 @@
             "Spec/Marlowe/Plutus/Transaction"
             "Spec/Marlowe/Plutus/Types"
             "Spec/Marlowe/Plutus/Value"
+            "Spec/Marlowe/Serialization"
+            "Spec/Marlowe/Serialization/CoreJson"
+            "Spec/Marlowe/Serialization/ExtendedJson"
             "Spec/Marlowe/Semantics/Arbitrary"
             "Spec/Marlowe/Semantics/AssocMap"
             "Spec/Marlowe/Semantics/Compute"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe.nix
@@ -102,7 +102,7 @@
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             ];
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -479,6 +479,7 @@
         "logict".revision = (((hackage."logict")."0.7.0.3").revisions).default;
         "mersenne-random-pure64".revision = (((hackage."mersenne-random-pure64")."0.2.2.0").revisions).default;
         "mersenne-random-pure64".flags.small_base = false;
+        "ordered-containers".revision = (((hackage."ordered-containers")."0.2.2").revisions).default;
         "these".revision = (((hackage."these")."1.1.1.1").revisions).default;
         "these".flags.assoc = true;
         "split".revision = (((hackage."split")."0.2.3.4").revisions).default;
@@ -1507,6 +1508,7 @@
           "cardano-crypto".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
           "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
+          "ordered-containers".components.library.planned = lib.mkOverride 900 true;
           "hpc".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "websockets-snap".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
@@ -43,6 +43,7 @@
           (hsPkgs."deriving-aeson" or (errorHandler.buildDepError "deriving-aeson"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."newtype-generics" or (errorHandler.buildDepError "newtype-generics"))
+          (hsPkgs."ordered-containers" or (errorHandler.buildDepError "ordered-containers"))
           (hsPkgs."plutus-ledger-ada" or (errorHandler.buildDepError "plutus-ledger-ada"))
           (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-ledger-slot" or (errorHandler.buildDepError "plutus-ledger-slot"))
@@ -59,6 +60,7 @@
         modules = [
           "Language/Marlowe"
           "Language/Marlowe/Extended/V1"
+          "Language/Marlowe/Extended/V1/Metadata/Types"
           "Language/Marlowe/Core/V1/Semantics"
           "Language/Marlowe/Core/V1/Semantics/Types"
           "Language/Marlowe/Core/V1/Semantics/Types/Address"
@@ -100,6 +102,7 @@
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             ];
           buildable = true;
           modules = [
@@ -117,6 +120,9 @@
             "Spec/Marlowe/Plutus/Transaction"
             "Spec/Marlowe/Plutus/Types"
             "Spec/Marlowe/Plutus/Value"
+            "Spec/Marlowe/Serialization"
+            "Spec/Marlowe/Serialization/CoreJson"
+            "Spec/Marlowe/Serialization/ExtendedJson"
             "Spec/Marlowe/Semantics/Arbitrary"
             "Spec/Marlowe/Semantics/AssocMap"
             "Spec/Marlowe/Semantics/Compute"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe.nix
@@ -102,7 +102,7 @@
             (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             ];
           buildable = true;
           modules = [

--- a/nix/pkgs/haskell/materialized-windows/default.nix
+++ b/nix/pkgs/haskell/materialized-windows/default.nix
@@ -479,6 +479,7 @@
         "logict".revision = (((hackage."logict")."0.7.0.3").revisions).default;
         "mersenne-random-pure64".revision = (((hackage."mersenne-random-pure64")."0.2.2.0").revisions).default;
         "mersenne-random-pure64".flags.small_base = false;
+        "ordered-containers".revision = (((hackage."ordered-containers")."0.2.2").revisions).default;
         "these".revision = (((hackage."these")."1.1.1.1").revisions).default;
         "these".flags.assoc = true;
         "split".revision = (((hackage."split")."0.2.3.4").revisions).default;
@@ -1502,6 +1503,7 @@
           "cardano-crypto".components.library.planned = lib.mkOverride 900 true;
           "tls".components.library.planned = lib.mkOverride 900 true;
           "bytestring-strict-builder".components.library.planned = lib.mkOverride 900 true;
+          "ordered-containers".components.library.planned = lib.mkOverride 900 true;
           "hpc".components.library.planned = lib.mkOverride 900 true;
           "http-types".components.library.planned = lib.mkOverride 900 true;
           "websockets-snap".components.library.planned = lib.mkOverride 900 true;


### PR DESCRIPTION
This PR is the same as [PR-192](https://github.com/input-output-hk/marlowe-cardano/pull/192) but in Haskell instead of PureScript. 

It adds a top-level construct in Marlowe Extended called `Module` that helps with adding a version number in the Json serialization and its the candidate to extend to add `imports/exports` in the future (hence the name), and also functions that can be converted to merkelized Marlowe Core.

This PR is related to the following MIP discussion: https://github.com/input-output-hk/MIPs/discussions/7 

I've also fixed the serialization of timeout to match the PureScript counterpart.
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
