### PR TITLE
Update constraints

### DIFF
--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -33,13 +33,7 @@ data TxConstraints v = TxConstraints
   , payToRoles :: Map (Core.PayoutDatum v) Chain.Assets
   , marloweOutputConstraints :: MarloweOutputConstraints v
   , signatureConstraints :: Set Chain.PaymentKeyHash
-  -- ^ Extra payment key hashes that require signatures.
   , metadataConstraints :: Map Int Aeson.Value
-  -- ^ Metadata to add to the transaction.
-  --
-  -- Rules to check:
-  --   1. forall (i, value) in the constraints, the transaction contains value
-  --     at index i of its metadata.
   }
 
 deriving instance Show (TxConstraints 'V1)
@@ -235,6 +229,13 @@ mustConsumePayouts payoutDatum = mempty { payoutInputConstraints = Set.singleton
 --      key.
 requiresSignature :: Core.IsMarloweVersion v => Chain.PaymentKeyHash -> TxConstraints v
 requiresSignature pkh = mempty { signatureConstraints = Set.singleton pkh }
+
+-- | Require the transaction include the given metadata.
+--
+-- Requires that:
+--   1. The given metadata is present in the given index in the transaction.
+requiresMetadata :: Core.IsMarloweVersion v => Int -> Aeson.Value -> TxConstraints v
+requiresMetadata i value = mempty { metadataConstraints = Map.singleton i value }
 
 instance Core.IsMarloweVersion v => Semigroup (TxConstraints v) where
   a <> b = case Core.marloweVersion @v of

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 
 module Language.Marlowe.Runtime.Transaction.Constraints
@@ -11,71 +13,63 @@ import qualified Data.Aeson as Aeson
 import Data.Binary (Binary)
 import Data.Function (on)
 import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
+import Language.Marlowe.Runtime.Core.Api (MarloweVersionTag(..))
 import qualified Language.Marlowe.Runtime.Core.Api as Core
 import qualified Language.Marlowe.Runtime.SystemStart as Cardano
 import qualified Plutus.V2.Ledger.Api as P
 
 -- | Describes a set of Marlowe-specific conditions that a transaction must satisfy.
 data TxConstraints v = TxConstraints
-  { inputConstraint :: InputConstraint v
-  -- ^ The constraint on the script input of the transaction
-  , roleTokenConstraints :: Set RoleTokenConstraint
-  -- ^ Constraints related to role tokens
-  , outputConstraints :: [OutputConstraint v]
-  -- ^ Constraints on the outputs of a transaction
+  { marloweInputConstraints :: MarloweInputConstraints v
+  , payoutInputConstraints :: Set (Core.PayoutDatum v)
+  , roleTokenConstraints :: RoleTokenConstraints
+  , payToAddresses :: Map Chain.Address Chain.Assets
+  , payToRoles :: Map (Core.PayoutDatum v) Chain.Assets
+  , marloweOutputConstraints :: MarloweOutputConstraints v
   , signatureConstraints :: Set Chain.PaymentKeyHash
   -- ^ Extra payment key hashes that require signatures.
-  --
-  -- Rules to check (for each key in the set):
-  --   1. If none of the inputs specify the key as a witness, then the
-  --      txExtraKeyWits of the body content contain it.
-  --   2. If theExtraKeyWits of the body content does not contain the key, then
-  --      at least one input does.
   , metadataConstraints :: Map Int Aeson.Value
   -- ^ Metadata to add to the transaction.
   --
   -- Rules to check:
   --   1. forall (i, value) in the constraints, the transaction contains value
   --     at index i of its metadata.
-  } deriving (Eq, Ord, Show)
+  }
 
--- | A constraint related to a role token.
-data RoleTokenConstraint
-  = MintRoleToken Chain.TxOutRef Chain.AssetId Chain.Address
-  -- ^ Specifies that the transaction must mint one role token with the given
-  -- AssetId and send it to the given address, along with the min UTXO ADA. The
-  -- TxOutRef must be consumed by the transaction, as it was used to create the
-  -- policyId
-  --
-  -- Rules to check:
-  --   1. The transaction mints one token with the given assetId.
-  --   2. The transaction sends one token with the given assetId to the given address.
-  --   3. The output in rule 2 does not contain any other tokens aside from ADA.
-  --   4. The transaction consumes the given TxOutRef.
-  | SpendRoleToken Chain.AssetId
-  -- ^ Specifies that the transaction must spend a UTXO containing 1 role token
-  -- of the given assetId. Furthermore, the transaction must send an output
-  -- back to the same address with the all the assets, including the role
-  -- token, as the spent UTXO.
-  --
-  -- Rules to check:
-  --   1. The transaction consumes a UTXO that contains the necessary role
-  --      token.
-  --   2. The transaction sends the role token back to the address from which
-  --      the UTXO in rule 1 was spent in a single output.
-  --   3. The output in rule 2 includes all other assets contained in the UTXO
-  --      in rule 1.
-  --   4. The output in rule 2 contains no other tokens except for optional
-  --      additional ADA.
+deriving instance Show (TxConstraints 'V1)
+deriving instance Eq (TxConstraints 'V1)
+
+-- | Constraints related to role tokens.
+data RoleTokenConstraints
+  = RoleTokenConstraintsNone
+  | MintRoleTokens Chain.TxOutRef (Map Chain.AssetId Chain.Address)
+  | SpendRoleTokens (Set Chain.AssetId)
   deriving (Eq, Ord, Show)
+
+instance Semigroup RoleTokenConstraints where
+  a <> RoleTokenConstraintsNone = a
+  MintRoleTokens _ a <> MintRoleTokens ref b = MintRoleTokens ref $ a <> b
+  SpendRoleTokens a <> SpendRoleTokens b = SpendRoleTokens $ a <> b
+  _ <> b = b
+
+instance Monoid RoleTokenConstraints where
+  mempty = RoleTokenConstraintsNone
 
 -- | Require the transaction to mint 1 role token with the specified assetId and
 -- send it to the given address. Additionally, require that the given UTXO is
 -- consumed.
+--
+-- Requires that:
+--   1. The transaction mints one token with the given assetId.
+--   2. The transaction sends one token with the given assetId to the given address.
+--   3. The output in rule 2 does not contain any other tokens aside from ADA.
+--   4. The transaction consumes the given TxOutRef.
 mustMintRoleToken
   :: Core.IsMarloweVersion v
   => Chain.TxOutRef
@@ -83,166 +77,190 @@ mustMintRoleToken
   -> Chain.Address
   -> TxConstraints v
 mustMintRoleToken txOutRef assetId address =
-  mempty { roleTokenConstraints = Set.singleton $ MintRoleToken txOutRef assetId address }
+  mempty { roleTokenConstraints = MintRoleTokens txOutRef $ Map.singleton assetId address }
 
 -- | Require the transaction to spend a UTXO with 1 role token of the specified
 -- assetID. It also needs to send an identical output (same assets) to the
 -- address that held the spent UTXO.
+--
+-- Requires that:
+--   1. The transaction consumes a UTXO that contains the necessary role
+--      token.
+--   2. The transaction produces an output that is identical to the output from
+--      rule 1.
 mustSpendRoleToken :: Core.IsMarloweVersion v => Chain.AssetId -> TxConstraints v
-mustSpendRoleToken assetId = mempty { roleTokenConstraints = Set.singleton $ SpendRoleToken assetId }
+mustSpendRoleToken assetId = mempty { roleTokenConstraints = SpendRoleTokens $ Set.singleton assetId }
 
--- | Constraints on the outputs of the transaction.
-data OutputConstraint v
-  = PayAssets Chain.Assets Chain.Address
-  -- ^ Specifies that the transaction must send the given assets to the given
-  -- address.
-  --
-  -- Rules to check:
-  --   1. The total assets sent to the address cover at least the specified amount.
-  --   2. Let t be the transaction body, c be the constraint set, and p be the
-  --      PayAssets constraint from c under consideration. If t satisfies c, then
-  --      t' satisfies c', where t' is t with the required assets of p removed
-  --      from the total output to the address of p and c' is c with p removed.
-  | SendToMarloweScript Chain.Assets (Core.Datum v)
-  -- ^ Specifies that the transaction must send the given assets and the given
-  --   datum to a Marlowe script address of the correct version.
-  --
-  -- Rules to check:
-  --   1. The transaction sends an output with the given assets and datum to a
-  --      script address.
-  --   2. The script address in rule 1 is in the script address set for the
-  --      corresponding Marlowe version.
-  | SendToPayoutScript Chain.Assets (Core.PayoutDatum v)
-  -- ^ Specifies that the transaction must send the given assets and the given
-  --   datum to the Payout script address associated with the Marlowe script
-  --   address of the contract.
-  --
-  -- Rules to check:
-  --   1. The transaction sends an output with the given assets and datum to a
-  --      script address.
-  --   2. The transaction consumes an output from a marlowe script address.
-  --   2. The script address in rule 1 is the payout script address associated
-  --      with the marlowe script address in rule 2.
+data MarloweOutputConstraints v
+  = MarloweOutputConstraintsNone
+  | MarloweOutput Chain.Assets (Core.Datum v)
+
+deriving instance Show (MarloweOutputConstraints 'V1)
+deriving instance Eq (MarloweOutputConstraints 'V1)
+
+instance Semigroup (MarloweOutputConstraints v) where
+  a <> MarloweOutputConstraintsNone = a
+  _ <> b = b
+
+instance Monoid (MarloweOutputConstraints v) where
+  mempty = MarloweOutputConstraintsNone
 
 -- | Require the transaction to send the specified assets to the address.
+--
+-- Requires that:
+--   postulate:
+--     total :: Address -> TxBody era -> TxOutValue era
+--     subValue :: TxOutValue era -> TxOutValue era -> TxOutValue era
+--   given:
+--     constraints :: TxConstraints v
+--     assets :: Assets
+--     address :: Address
+--   define:
+--     payConstraint = mustPayToAddress assets address
+--     Right txBody = solveConstraints $ constraints <> payConstraint
+--     Right txBody' = solveConstraints constraints
+--   1. fromCardano (total address txBody `subValue` total address txBody') == assets
 mustPayToAddress :: Core.IsMarloweVersion v => Chain.Assets -> Chain.Address -> TxConstraints v
-mustPayToAddress assets address = mempty { outputConstraints = [PayAssets assets address] }
+mustPayToAddress assets address = mempty { payToAddresses = Map.singleton address assets }
 
 -- | Require the transaction to send an output to the marlowe script address
 -- with the given assets and the given datum.
+--
+-- Requires that:
+--   1. The transaction sends an output with the given assets and datum to a
+--      script address.
+--   2. The script address in rule 1 is in the script address set for the
+--      corresponding Marlowe version.
 mustSendMarloweOutput :: Core.IsMarloweVersion v => Chain.Assets -> Core.Datum v -> TxConstraints v
 mustSendMarloweOutput assets datum =
-  mempty { outputConstraints = [SendToMarloweScript assets datum] }
+  mempty { marloweOutputConstraints = MarloweOutput assets datum }
 
 -- | Require the transaction to send an output to the payout script address
 -- with the given assets and the given datum.
-mustSendPayoutOutput :: Core.IsMarloweVersion v => Chain.Assets -> Core.PayoutDatum v -> TxConstraints v
-mustSendPayoutOutput assets datum =
-  mempty { outputConstraints = [SendToPayoutScript assets datum] }
+--
+-- Requires that:
+--   postulate:
+--     total :: PayoutDatum v -> TxBody era -> TxOutValue era
+--     subValue :: TxOutValue era -> TxOutValue era -> TxOutValue era
+--   given:
+--     constraints :: TxConstraints v
+--     assets :: Assets
+--     role :: PayoutDatum v
+--   define:
+--     payConstraint = mustPayToRole assets role
+--     Right txBody = solveConstraints $ constraints <> payConstraint
+--     Right txBody' = solveConstraints constraints
+--   1. fromCardano (total role txBody `subValue` total role txBody') == assets
+--   2. The transaction sends an output to a script address.
+--   3. The datum of the output in rule 2 is equal to the role.
+--   4. The transaction consumes an output from a marlowe script address.
+--   5. The script address in rule 1 is the payout script address associated
+--      with the marlowe script address in rule 2.
+mustPayToRole :: Core.IsMarloweVersion v => Chain.Assets -> Core.PayoutDatum v -> TxConstraints v
+mustPayToRole assets datum =
+  mempty { payToRoles = Map.singleton datum assets }
 
-data InputConstraint v
-  = NoInput
-  -- ^ Specifies that the transaction consumes no marlowe or payout script
-  -- inputs. Corresponds to the create transaction type.
-  --
-  -- Rules to check:
-  --   1. All inputs of the transaction do not come from any of the script
-  --      addresses (marlowe or payout) associated with marlowe version v.
+-- | Get the total amount required to be paid to the given address.
+getTotalForAddress :: Chain.Address -> TxConstraints v -> Chain.Assets
+getTotalForAddress address = fromMaybe mempty . Map.lookup address . payToAddresses
+
+-- | Get the total amount required to be paid to the given role.
+getTotalForRole
+  :: forall v
+   . Core.IsMarloweVersion v
+  => Core.PayoutDatum v
+  -> TxConstraints v
+  -> Chain.Assets
+getTotalForRole role = case Core.marloweVersion @v of
+  Core.MarloweV1 -> fromMaybe mempty . Map.lookup role . payToRoles
+
+data MarloweInputConstraints v
+  = MarloweInputConstraintsNone
   | MarloweInput P.POSIXTime P.POSIXTime (Core.Redeemer v)
-  -- ^ Specifies that the transaction consumes the Marlowe UTXO with the given
-  -- TxOutRef.
-  --
-  -- Rules to check:
-  --   1. The input at the Marlowe Script Address for the contract is consumed.
-  --   2. The input in rule 1 includes the given redeemer.
-  --   3. The validity range of the transaction matches the given min and max
-  --      validity bounds (converted to slots).
-  --   4. The input in rule 1 comes from one of the marlowe script addresses
-  --      associated with marlowe version v.
-  --   5. All other inputs do not come from any of the marlowe or payout script
-  --      addresses associated with marlowe version v.
-  --   6. If there are any outputs to a script address associated with
-  --      version v, then there must be only 1 such output and the address
-  --      must match the address of the input from rule 1.
-  | PayoutInputs (Core.PayoutDatum v)
-  -- ^ Specifies that the transaction consumes all UTXOs from the given payout
-  -- validator address with the given datum.
-  --
-  -- Rules to check:
-  --   1. At least one UTXO is consumed that bears the correct payout datum.
-  --   2. All such inputs that satisfy rule 1 come from the same address.
-  --   3. The address from rule 2 exists in the set of payout validator
-  --      addresses associated with marlowe version v.
-  --   4. For all inputs i that do not satisfy rule 1, the address of i does
-  --      not exist in the set of payout script addresses associated with
-  --      Marlowe version v.
-  --   5. For all inputs i, the address of i does not exist in the set of
-  --      Marlowe script addresses associated with Marlowe version v.
 
--- | Require the transaction to consume the input from the Marlowe script with
--- the given validity interval and redeemer (input). Used for apply-inputs.
+deriving instance Show (MarloweInputConstraints 'V1)
+deriving instance Eq (MarloweInputConstraints 'V1)
+
+instance Semigroup (MarloweInputConstraints v) where
+  a <> MarloweInputConstraintsNone = a
+  _ <> b = b
+
+instance Monoid (MarloweInputConstraints v) where
+  mempty = MarloweInputConstraintsNone
+
+-- | Require the transaction to consume the UTXO for the current contract from
+-- the Marlowe script with the given validity interval and redeemer (input).
+-- Used for apply-inputs.
+--
+-- Requires that:
+--   1. The input at the Marlowe Script Address for the contract is consumed.
+--   2. The input in rule 1 includes the given redeemer.
+--   3. The validity range of the transaction matches the given min and max
+--      validity bounds (converted to slots).
+--   4. The input in rule 1 comes from one of the marlowe script addresses
+--      associated with marlowe version v.
+--   5. All other inputs do not come from a script address.
+--   6. If 'computeTransaction' returns 'Close' for the previous datum and the redeemer,
+--      there are no outputs to any Marlowe script address.
+--   7. Otherwise, there is an output to the same address as the input with the
+--      correct datum and assets.
 mustConsumeMarloweOutput :: Core.IsMarloweVersion v => P.POSIXTime -> P.POSIXTime -> Core.Redeemer v -> TxConstraints v
 mustConsumeMarloweOutput invalidBefore invalidHereafter inputs =
-  mempty { inputConstraint = MarloweInput invalidBefore invalidHereafter inputs }
+  mempty { marloweInputConstraints = MarloweInput invalidBefore invalidHereafter inputs }
 
 -- | Require the transaction to consume any input from the payout script that
 -- bear the given datum.
+--
+-- Requires that:
+--   1. At least one UTXO is consumed that bears the correct payout datum.
+--   2. All such inputs that satisfy rule 1 come from the same address.
+--   3. The address from rule 2 exists in the set of payout validator
+--      addresses associated with marlowe version v.
+--   4. For all inputs i that do not satisfy rule 1, the address of i does
+--      not exist in the set of payout script addresses associated with
+--      Marlowe version v.
+--   5. For all inputs i, the address of i does not exist in the set of
+--      Marlowe script addresses associated with Marlowe version v.
 mustConsumePayouts :: Core.IsMarloweVersion v => Core.PayoutDatum v -> TxConstraints v
-mustConsumePayouts payoutDatum = mempty { inputConstraint = PayoutInputs payoutDatum }
+mustConsumePayouts payoutDatum = mempty { payoutInputConstraints = Set.singleton payoutDatum }
 
 -- | Require the transaction to hold a signature for the given payment key
 -- hash.
+--
+-- Requires that:
+--   1. If none of the inputs are from an address withe a matching payment key,
+--      then the txExtraKeyWits of the body content contain the given hash.
+--   2. If theExtraKeyWits of the body content does not contain the given hash,
+--      then at least one input must be from an address with a matching payment
+--      key.
 requiresSignature :: Core.IsMarloweVersion v => Chain.PaymentKeyHash -> TxConstraints v
 requiresSignature pkh = mempty { signatureConstraints = Set.singleton pkh }
 
-instance Core.IsMarloweVersion v => Show (OutputConstraint v) where
-  showsPrec = case Core.marloweVersion @v of
-    Core.MarloweV1 -> showsPrec
-
-instance Core.IsMarloweVersion v => Eq (OutputConstraint v) where
-  (==) = case Core.marloweVersion @v of
-    Core.MarloweV1 -> (==)
-
-instance Core.IsMarloweVersion v => Ord (OutputConstraint v) where
-  compare = case Core.marloweVersion @v of
-    Core.MarloweV1 -> compare
-
-instance Core.IsMarloweVersion v => Show (InputConstraint v) where
-  showsPrec = case Core.marloweVersion @v of
-    Core.MarloweV1 -> showsPrec
-
-instance Core.IsMarloweVersion v => Eq (InputConstraint v) where
-  (==) = case Core.marloweVersion @v of
-    Core.MarloweV1 -> (==)
-
-instance Core.IsMarloweVersion v => Ord (InputConstraint v) where
-  compare = case Core.marloweVersion @v of
-    Core.MarloweV1 -> compare
-
-instance Semigroup (InputConstraint v) where
-  a <> NoInput = a
-  _ <> b = b
-
-instance Monoid (InputConstraint v) where
-  mempty = NoInput
-
 instance Core.IsMarloweVersion v => Semigroup (TxConstraints v) where
-  a <> b = TxConstraints
-    { inputConstraint = on (<>) inputConstraint a b
-    , roleTokenConstraints = on (<>) roleTokenConstraints a b
-    , outputConstraints = on (<>) outputConstraints a b
-    , signatureConstraints = on (<>) signatureConstraints a b
-    , metadataConstraints = on (<>) metadataConstraints a b
-    }
+  a <> b = case Core.marloweVersion @v of
+    Core.MarloweV1 -> TxConstraints
+      { marloweInputConstraints = on (<>) marloweInputConstraints a b
+      , payoutInputConstraints = on Set.union payoutInputConstraints a b
+      , roleTokenConstraints = on (<>) roleTokenConstraints a b
+      , payToAddresses = on (Map.unionWith (<>)) payToAddresses a b
+      , payToRoles = on (Map.unionWith (<>)) payToRoles a b
+      , marloweOutputConstraints = on (<>) marloweOutputConstraints a b
+      , signatureConstraints = on (<>) signatureConstraints a b
+      , metadataConstraints = on (<>) metadataConstraints a b
+      }
 
 instance Core.IsMarloweVersion v => Monoid (TxConstraints v) where
-  mempty = TxConstraints
-    { inputConstraint = mempty
-    , roleTokenConstraints = mempty
-    , outputConstraints = mempty
-    , signatureConstraints = mempty
-    , metadataConstraints = mempty
-    }
+  mempty = case Core.marloweVersion @v of
+    Core.MarloweV1 -> TxConstraints
+      { marloweInputConstraints = mempty
+      , payoutInputConstraints = mempty
+      , roleTokenConstraints = mempty
+      , payToAddresses = mempty
+      , payToRoles = mempty
+      , marloweOutputConstraints = mempty
+      , signatureConstraints = mempty
+      , metadataConstraints = mempty
+      }
 
 data ConstraintCheck
   = CheckTrue

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -263,28 +263,6 @@ instance Core.IsMarloweVersion v => Monoid (TxConstraints v) where
       , metadataConstraints = mempty
       }
 
-data ConstraintCheck
-  = CheckTrue
-  | CheckFalseMissingSignature Chain.PaymentKeyHash
-  | CheckFalseRoleTokenNotMinted Chain.TokenName
-  | CheckFalseRoleTokenNotPaid Chain.TokenName Chain.Address
-  | CheckFalseRoleTokenNotSpent Chain.AssetId
-  | CheckFalseRoleTokenNotReturned Chain.AssetId
-  | CheckFalseExtraneousTokens Chain.TxIx Chain.Assets
-  | CheckFalseInsufficientAssets Chain.Address Chain.Assets
-  | CheckFalseRoleTokenOutputAltered Chain.TxIx
-  deriving (Show, Eq, Ord)
-
--- | Determines if the given transaction body satisfies the given constraints.
-satisfiesConstraints
-  :: Cardano.ProtocolParameters
-  -> Cardano.TxBody era
-  -> MarloweContext
-  -> WalletContext
-  -> TxConstraints v
-  -> ConstraintCheck
-satisfiesConstraints = error "not implemented"
-
 -- | Errors that can occur when trying to solve the constraints.
 data UnsolvableConstraintsError
   deriving (Eq, Show, Generic, Binary)


### PR DESCRIPTION
I've updated the constraints module based on the changes I discussed with @bwbush and @dino-iog. Notably, the policyID for minted role tokens must be computed when solving the constraints. This means that `buildCreateConstraints` will need to do some preliminary coin selection to get a UTXO that can be used to compute the policyID. In addition, the min UTXO requirement for the contract must also be performed by `buildCreateConstraints` and reflected in the `SendToMarloweScript` constraint (in both the `Assets` and the `accounts` of the `Datum`).