### PR TITLE
Implement LoadMarloweContext

### DIFF
--- a/marlowe-runtime/marlowe-follower/Main.hs
+++ b/marlowe-runtime/marlowe-follower/Main.hs
@@ -101,6 +101,7 @@ logChanges contractId readChanges = forever do
 
 logCreateStep :: MarloweVersion v -> ContractId -> BlockHeader -> CreateStep v -> IO ()
 logCreateStep version contractId BlockHeader{..} CreateStep{..} = do
+  let TransactionScriptOutput scriptAddress _ _ datum = createOutput
   setSGR [SetColor Foreground Vivid Yellow]
   putStr "transaction "
   putStr $ T.unpack $ encodeBase16 $ unTxId $ txId $ unContractId contractId

--- a/marlowe-runtime/marlowe-history-cli/Main.hs
+++ b/marlowe-runtime/marlowe-history-cli/Main.hs
@@ -280,6 +280,7 @@ logHistory contractId (SomeHistory version History{..}) = do
 
 logCreateStep :: MarloweVersion v -> ContractId -> BlockHeader -> CreateStep v -> IO ()
 logCreateStep version contractId BlockHeader{..} CreateStep{..} = do
+  let TransactionScriptOutput scriptAddress _ _ datum = createOutput
   setSGR [SetColor Foreground Vivid Yellow]
   putStr "transaction "
   putStr $ T.unpack $ encodeBase16 $ unTxId $ txId $ unContractId contractId

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -137,13 +137,12 @@ instance Binary (TransactionOutput 'V1) where
   put TransactionOutput{..} = do
     put payouts
     put scriptOutput
-  get = TransactionOutput
-    <$> get
-    <*> get
+  get = TransactionOutput <$> get <*> get
 
 data Payout v = Payout
-  { assets :: Chain.Assets
-  , datum  :: PayoutDatum v
+  { address :: Chain.Address
+  , assets :: Chain.Assets
+  , datum :: PayoutDatum v
   }
 
 deriving instance Show (Payout 'V1)
@@ -151,12 +150,15 @@ deriving instance Eq (Payout 'V1)
 
 instance Binary (Payout 'V1) where
   put Payout{..} = do
+    put address
     put assets
     put datum
-  get = Payout <$> get <*> get
+  get = Payout <$> get <*> get <*> get
 
 data TransactionScriptOutput v = TransactionScriptOutput
-  { utxo  :: TxOutRef
+  { address :: Chain.Address
+  , assets :: Chain.Assets
+  , utxo  :: TxOutRef
   , datum :: Datum v
   }
 
@@ -165,9 +167,11 @@ deriving instance Eq (TransactionScriptOutput 'V1)
 
 instance Binary (TransactionScriptOutput 'V1) where
   put TransactionScriptOutput{..} = do
+    put address
+    put assets
     put utxo
     putDatum MarloweV1 datum
-  get = TransactionScriptOutput <$> get <*> getDatum MarloweV1
+  get = TransactionScriptOutput <$> get <*> get <*> get <*> getDatum MarloweV1
 
 data SomeMarloweVersion = forall v. SomeMarloweVersion (MarloweVersion v)
 

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History/Api.hs
@@ -72,8 +72,7 @@ data FollowerStatus
   deriving anyclass Binary
 
 data CreateStep v = CreateStep
-  { datum               :: Datum v
-  , scriptAddress       :: Chain.Address
+  { createOutput :: TransactionScriptOutput v
   , payoutValidatorHash :: ScriptHash
   }
 
@@ -90,10 +89,9 @@ instance Show SomeCreateStep where
 
 instance Binary (CreateStep 'V1) where
   put CreateStep{..} = do
-    putDatum MarloweV1 datum
-    put scriptAddress
+    put createOutput
     put payoutValidatorHash
-  get = CreateStep <$> getDatum MarloweV1 <*> get <*> get
+  get = CreateStep <$> get <*> get
 
 data RedeemStep v = RedeemStep
   { utxo        :: TxOutRef

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/BuildConstraints.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/BuildConstraints.hs
@@ -7,7 +7,7 @@ module Language.Marlowe.Runtime.Transaction.BuildConstraints
 import qualified Data.Aeson as Aeson
 import Data.Map (Map)
 import Data.Time (UTCTime)
-import Language.Marlowe.Runtime.ChainSync.Api (Address, SlotConfig, TokenName, TransactionOutput)
+import Language.Marlowe.Runtime.ChainSync.Api (Address, SlotConfig, TokenName)
 import Language.Marlowe.Runtime.Core.Api (Contract, MarloweVersion, PayoutDatum, Redeemer, TransactionScriptOutput)
 import Language.Marlowe.Runtime.Transaction.Api (ApplyInputsError, CreateError, WithdrawError)
 import Language.Marlowe.Runtime.Transaction.Constraints (TxConstraints)
@@ -27,7 +27,7 @@ buildCreateConstraints = error "not implemented"
 buildApplyInputsConstraints
   :: SlotConfig -- ^ The slot config used to convert the validity interval to slots.
   -> MarloweVersion v -- ^ The Marlowe version to build the transaction for.
-  -> (TransactionScriptOutput v, TransactionOutput) -- ^ The previous script output for the contract with raw TxOut.
+  -> TransactionScriptOutput v -- ^ The previous script output for the contract
   -> Maybe UTCTime -- ^ The minimum bound of the validity interval (inclusive).
                    -- If not specified, the current time is used.
   -> Maybe UTCTime -- ^ The maximum bound of the validity interval (exclusive).

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -7,7 +7,7 @@ module Language.Marlowe.Runtime.Transaction.Constraints
   where
 
 import qualified Cardano.Api as Cardano
-import Cardano.Api.Shelley (NetworkId, StakeCredential)
+import Cardano.Api.Shelley (NetworkId)
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Data.Aeson as Aeson
 import Data.Binary (Binary)
@@ -279,18 +279,18 @@ data WalletContext = WalletContext
   }
 
 -- | Data from Marlowe Scripts needed to solve the constraints.
-data MarloweContext = MarloweContext
-  { stakeCredential :: Maybe StakeCredential
+data MarloweContext v = MarloweContext
+  { stakeCredential :: Maybe Chain.Credential
   -- ^ The stake credential to use when building a new marlowe script address.
-  , scriptOutput :: Maybe (Chain.TxOutRef, Chain.TransactionOutput)
+  , scriptOutput :: Maybe (Core.TransactionScriptOutput v)
   -- ^ The UTXO at the script address, if any.
-  , payoutOutputs :: Map Chain.TxOutRef Chain.TransactionOutput
+  , payoutOutputs :: Map Chain.TxOutRef (Core.Payout v)
   -- ^ The UTXOs at the payout address.
   }
 
 type SolveConstraints era v
    = Cardano.ScriptDataSupportedInEra era
-  -> MarloweContext
+  -> MarloweContext v
   -> WalletContext
   -> TxConstraints v
   -> Either UnsolvableConstraintsError (Cardano.TxBody era)

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Query.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Query.hs
@@ -1,27 +1,123 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Language.Marlowe.Runtime.Transaction.Query
   where
 
-import Data.Map (Map)
-import Language.Marlowe.Runtime.ChainSync.Api (TransactionOutput, TxOutRef)
-import Language.Marlowe.Runtime.Core.Api (ContractId, MarloweVersion, PayoutDatum, TransactionScriptOutput)
+import Data.List (scanl')
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as Map
+import Data.Type.Equality (testEquality, type (:~:)(Refl))
+import Language.Marlowe.Protocol.Sync.Client
+import Language.Marlowe.Runtime.ChainSync.Api (StakeReference(..), stakeReference)
+import Language.Marlowe.Runtime.Core.Api
+import Language.Marlowe.Runtime.History.Api
 import Language.Marlowe.Runtime.Transaction.Api
 import Language.Marlowe.Runtime.Transaction.Constraints
+import qualified Language.Marlowe.Runtime.Transaction.Constraints as Constraints
 
 type LoadWalletContext = WalletAddresses -> IO WalletContext
 
-type LoadMarloweScriptOutput =
-  forall v. MarloweVersion v -> ContractId -> IO (Maybe (TransactionScriptOutput v, TransactionOutput))
-
-type LoadPayoutScriptOutputs =
-  forall v. MarloweVersion v -> PayoutDatum v -> IO (Map TxOutRef TransactionOutput)
+type LoadMarloweContext = forall v
+   . MarloweVersion v
+  -> ContractId
+  -> IO (Either LoadMarloweContextError (MarloweContext v))
 
 loadWalletContext :: LoadWalletContext
 loadWalletContext = error "not implemented"
 
-loadMarloweScriptOutput :: LoadMarloweScriptOutput
-loadMarloweScriptOutput = error "not implemented"
+-- | Loads the current MarloweContext for a contract by its ID.
+loadMarloweContext
+  :: (forall a. MarloweSyncClient IO a -> IO a)
+  -> LoadMarloweContext
+loadMarloweContext runClient desiredVersion contractId = runClient client
+  where
+    client = MarloweSyncClient $ pure clientInit
+    -- Start by following the contract
+    clientInit = SendMsgFollowContract contractId clientFollow
 
-loadPayoutScriptOutputs :: LoadPayoutScriptOutputs
-loadPayoutScriptOutputs = error "not implemented"
+    clientFollow = ClientStFollow
+      -- If the contract isn't found, return an error
+      { recvMsgContractNotFound = pure $ Left LoadMarloweContextErrorNotFound
+      -- Otherwise,
+      , recvMsgContractFound = \blockHeader actualVersion createStep ->
+          -- Otherwise, check the desired version matches the actual one
+          pure case testEquality desiredVersion actualVersion of
+            Nothing -> SendMsgDone
+              $ Left
+              $ LoadMarloweContextErrorVersionMismatch
+              $ SomeMarloweVersion actualVersion
+            -- Build the initial context and use it as a seed for the loop.
+            Just Refl -> clientIdle $ pure (blockHeader, initialContext createStep)
+      }
+
+    -- Request the next steps in the contract
+    clientIdle = SendMsgRequestNext . clientNext
+    clientNext contexts = ClientStNext
+      -- If the creation event was rolled back, return an error
+      { recvMsgRollBackCreation =
+          (pure :: forall a. a -> IO a) $ Left LoadMarloweContextErrorNotFound
+      -- Handle rollbacks
+      , recvMsgRollBackward =
+          pure . handleRollback contexts
+      -- Handle new steps
+      , recvMsgRollForward = \blockHeader ->
+          pure . clientIdle . appendSteps contexts blockHeader
+      -- If we are told to wait (because there are no more steps to send),
+      -- we've reached the tip of the contract. Return the most recent
+      -- accumulated context.
+      , recvMsgWait =
+          pure $ SendMsgCancel $ SendMsgDone $ Right $ snd $ NE.head contexts
+      }
+
+    initialContext :: CreateStep v -> MarloweContext v
+    initialContext CreateStep{..} = MarloweContext
+      -- Get the stake credential from the script address.
+      { stakeCredential = case stakeReference scriptAddress of
+          Just (StakeCredential credential) -> Just credential
+          _ -> Nothing
+      -- Get the script output of the create event.
+      , scriptOutput = Just createOutput
+      -- No payouts to start with
+      , payoutOutputs = mempty
+      }
+      where
+        TransactionScriptOutput scriptAddress _ _ _ = createOutput
+
+    handleRollback contexts@((blockHeader, _) :| contexts') rollbackBlock
+      -- If the latest block is after the rollback block
+      | blockHeader > rollbackBlock = case contexts' of
+          -- And the previous contexts is non-empty, keep rolling back
+          s : ss -> handleRollback (s :| ss) rollbackBlock
+          -- And the previous contexts is empty, return an error
+          [] -> SendMsgDone $ Left LoadMarloweContextErrorNotFound
+      -- Otherwise, resume from this block.
+      | otherwise = clientIdle contexts
+
+    appendSteps contexts@((_, prevContext) :| _) blockHeader steps =
+      prependList
+        -- drop 1 because scanl' starts with the seed value (i.e. prevContext)
+        ((blockHeader,) <$> drop 1 (scanl' applyStep prevContext steps))
+        contexts
+
+    prependList :: [a] -> NonEmpty a -> NonEmpty a
+    prependList = \case
+      [] -> id
+      x : xs -> \(y :| ys) -> x :| xs <> (y : ys)
+
+    -- Update the context with a new step
+    applyStep context = \case
+      -- For ApplyTransaction steps
+      ApplyTransaction Transaction{output = TransactionOutput{..}} -> context
+        -- Replace the scriptOutput with that of the new transaction
+        { Constraints.scriptOutput = scriptOutput
+        -- Add new payouts
+        , Constraints.payoutOutputs = payoutOutputs context <> payouts
+        }
+      -- For RedeemPayout steps
+      RedeemPayout RedeemStep{..} -> context
+        -- Remove the payout that was redeemed
+        { Constraints.payoutOutputs = Map.delete utxo $ payoutOutputs context
+        }

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
@@ -850,7 +850,7 @@ checkPayoutOpenRedeemedBefore = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                    , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
                         (Chain.TxOutRef applyInputsTxId 0)
@@ -931,7 +931,7 @@ checkPayoutOpenRedeemedAfter = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                    , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
                         (Chain.TxOutRef applyInputsTxId 0)
@@ -995,7 +995,7 @@ checkPayoutOpenRedeemedTogether = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                    , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
                         (Chain.TxOutRef applyInputsTxId 0)

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
@@ -44,10 +44,10 @@ import Language.Marlowe.Runtime.Core.Api
   ( ContractId(..)
   , MarloweVersion(..)
   , MarloweVersionTag(..)
-  , Payout(..)
+  , Payout(Payout)
   , Transaction(..)
   , TransactionOutput(..)
-  , TransactionScriptOutput(..)
+  , TransactionScriptOutput(TransactionScriptOutput)
   , parseContractId
   , toChainPayoutDatum
   )
@@ -143,7 +143,7 @@ createTx =
     validityRange = Chain.Unbounded
     metadata = Nothing
     inputs = mempty
-    outputs = [createOutput]
+    outputs = [creationOutput]
     mintedTokens = Chain.Tokens mempty
   in
     Chain.Transaction{..}
@@ -157,8 +157,8 @@ testScriptAddress = mkScriptAddress $ marloweScript currentV1Scripts
 testPayoutValidatorAddress :: Chain.Address
 testPayoutValidatorAddress = mkScriptAddress $ payoutScript currentV1Scripts
 
-createOutput :: Chain.TransactionOutput
-createOutput =
+creationOutput :: Chain.TransactionOutput
+creationOutput =
   let
     address = testScriptAddress
     assets = Chain.Assets
@@ -248,7 +248,7 @@ payout =
       }
     datum = Chain.AssetId policyId (Chain.TokenName "test_role")
   in
-    Payout{..}
+    Payout testPayoutValidatorAddress assets datum
 
 payoutUTxO :: TxOutRef
 payoutUTxO = TxOutRef applyInputsTxId 1
@@ -257,7 +257,7 @@ payoutOutput :: Chain.TransactionOutput
 payoutOutput =
   let
     address = testPayoutValidatorAddress
-    Payout{assets} = payout
+    Payout _ assets _ = payout
     datumHash = Nothing
     datum = Just $ toChainPayoutDatum MarloweV1 $ AssetId policyId (Chain.TokenName "test_role")
   in
@@ -289,7 +289,7 @@ redeemPayoutOutput :: Chain.TransactionOutput
 redeemPayoutOutput =
   let
     address = "6022c79fed0291c432b62f585d3f1074bf3a5f1df86f61fcca14a5d6d6"
-    Payout{assets} = payout
+    Payout _ assets _ = payout
     datumHash = Nothing
     datum = Nothing
   in
@@ -375,7 +375,7 @@ checkByronAddress = do
   FollowerTestResult{..} <- runFollowerTest
     $ ConfirmHandshake
     $ ExpectQuery (FindTx createTxId)
-    $ RollForward createTx { Chain.outputs = [createOutput { address = "" }] } point1 point1
+    $ RollForward createTx { Chain.outputs = [creationOutput { address = "" }] } point1 point1
     $ ExpectDone ()
   followerError `shouldBe` Just (ExtractContractFailed ByronAddress)
   followerChanges `shouldBe` Nothing
@@ -385,7 +385,7 @@ checkNonScriptAddress = do
   FollowerTestResult{..} <- runFollowerTest
     $ ConfirmHandshake
     $ ExpectQuery (FindTx createTxId)
-    $ RollForward createTx { Chain.outputs = [createOutput { address = "6022c79fed0291c432b62f585d3f1074bf3a5f1df86f61fcca14a5d6d6" }] } point1 point1
+    $ RollForward createTx { Chain.outputs = [creationOutput { address = "6022c79fed0291c432b62f585d3f1074bf3a5f1df86f61fcca14a5d6d6" }] } point1 point1
     $ ExpectDone ()
   followerError `shouldBe` Just (ExtractContractFailed NonScriptAddress)
   followerChanges `shouldBe` Nothing
@@ -395,7 +395,7 @@ checkInvalidScriptHash = do
   FollowerTestResult{..} <- runFollowerTest
     $ ConfirmHandshake
     $ ExpectQuery (FindTx createTxId)
-    $ RollForward createTx { Chain.outputs = [createOutput { address = "7022c79fed0291c432b62f585d3f1074bf3a5f1df86f61fcca14a5d6d6" }] } point1 point1
+    $ RollForward createTx { Chain.outputs = [creationOutput { address = "7022c79fed0291c432b62f585d3f1074bf3a5f1df86f61fcca14a5d6d6" }] } point1 point1
     $ ExpectDone ()
   followerError `shouldBe` Just (ExtractContractFailed InvalidScriptHash)
   followerChanges `shouldBe` Nothing
@@ -405,7 +405,7 @@ checkNoCreateDatum = do
   FollowerTestResult{..} <- runFollowerTest
     $ ConfirmHandshake
     $ ExpectQuery (FindTx createTxId)
-    $ RollForward createTx { Chain.outputs = [createOutput { Chain.datum = Nothing }] } point1 point1
+    $ RollForward createTx { Chain.outputs = [creationOutput { Chain.datum = Nothing }] } point1 point1
     $ ExpectDone ()
   followerError `shouldBe` Just (ExtractContractFailed NoCreateDatum)
   followerChanges `shouldBe` Nothing
@@ -415,7 +415,7 @@ checkInvalidCreateDatum = do
   FollowerTestResult{..} <- runFollowerTest
     $ ConfirmHandshake
     $ ExpectQuery (FindTx createTxId)
-    $ RollForward createTx { Chain.outputs = [createOutput { Chain.datum = Just $ Chain.I 0 }] } point1 point1
+    $ RollForward createTx { Chain.outputs = [creationOutput { Chain.datum = Just $ Chain.I 0 }] } point1 point1
     $ ExpectDone ()
   followerError `shouldBe` Just (ExtractContractFailed InvalidCreateDatum)
   followerChanges `shouldBe` Nothing
@@ -440,9 +440,8 @@ checkNotCreationTransaction = do
 
 checkCreation :: Expectation
 checkCreation = do
-  let datum = createDatum
-  let scriptAddress = testScriptAddress
   let payoutValidatorHash = payoutScript currentV1Scripts
+  let createOutput = TransactionScriptOutput testScriptAddress mempty createUTxO createDatum
   FollowerTestResult{..} <- runFollowerTest
     $ ConfirmHandshake
     $ ExpectQuery (FindTx createTxId)
@@ -675,10 +674,11 @@ checkRollbackToCreationWithInputs = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput mempty $ Just TransactionScriptOutput
-                        { utxo = Chain.TxOutRef applyInputsTxId 0
-                        , datum = createDatum
-                        }
+                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                        testScriptAddress
+                        mempty
+                        (Chain.TxOutRef applyInputsTxId 0)
+                        createDatum
                     }
                 ]
             , create = Nothing
@@ -745,10 +745,11 @@ checkRollbackToTransaction = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput mempty $ Just TransactionScriptOutput
-                        { utxo = Chain.TxOutRef applyInputsTxId 0
-                        , datum = createDatum
-                        }
+                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                        testScriptAddress
+                        mempty
+                        (Chain.TxOutRef applyInputsTxId 0)
+                        createDatum
                     }
                 ]
             , create = Nothing
@@ -819,10 +820,11 @@ checkNonCloseTransaction = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput mempty $ Just TransactionScriptOutput
-                        { utxo = Chain.TxOutRef applyInputsTxId 0
-                        , datum = createDatum
-                        }
+                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                        testScriptAddress
+                        mempty
+                        (Chain.TxOutRef applyInputsTxId 0)
+                        createDatum
                     }
                 ]
             , create = Nothing
@@ -848,10 +850,11 @@ checkPayoutOpenRedeemedBefore = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just TransactionScriptOutput
-                        { utxo = Chain.TxOutRef applyInputsTxId 0
-                        , datum = createDatum
-                        }
+                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                        testScriptAddress
+                        mempty
+                        (Chain.TxOutRef applyInputsTxId 0)
+                        createDatum
                     }
                 ]
             , create = Nothing
@@ -928,10 +931,11 @@ checkPayoutOpenRedeemedAfter = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just TransactionScriptOutput
-                        { utxo = Chain.TxOutRef applyInputsTxId 0
-                        , datum = createDatum
-                        }
+                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                        testScriptAddress
+                        mempty
+                        (Chain.TxOutRef applyInputsTxId 0)
+                        createDatum
                     }
                 ]
             , create = Nothing
@@ -991,10 +995,11 @@ checkPayoutOpenRedeemedTogether = do
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
                     , redeemer = applyInputsRedeemer
-                    , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just TransactionScriptOutput
-                        { utxo = Chain.TxOutRef applyInputsTxId 0
-                        , datum = createDatum
-                        }
+                    , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
+                        testScriptAddress
+                        mempty
+                        (Chain.TxOutRef applyInputsTxId 0)
+                        createDatum
                     }
                 ]
             , create = Nothing


### PR DESCRIPTION
Implements one of the two queries needed for transaction creation. Also:

- Adds `address` and `assets` to `TransactionScriptOutput`
- Adds `address` to `Payout`
- Embeds a `TransacriontScriptoutput` inside `CreateStep`