### PR TITLE
Cardano Api <-> ChainSync.Api Conversion Functions

### DIFF
--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -55,6 +55,7 @@ library
   import: lang
   hs-source-dirs:   src
   exposed-modules:
+    Language.Marlowe.Runtime.Cardano.Api
     Language.Marlowe.Runtime.Cardano.Feature
     Language.Marlowe.Runtime.ChainSync
     Language.Marlowe.Runtime.ChainSync.Database

--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -55,6 +55,7 @@ library
   import: lang
   hs-source-dirs:   src
   exposed-modules:
+    Language.Marlowe.Runtime.Cardano.Feature
     Language.Marlowe.Runtime.ChainSync
     Language.Marlowe.Runtime.ChainSync.Database
     Language.Marlowe.Runtime.ChainSync.Database.PostgreSQL

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/Cardano/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/Cardano/Api.hs
@@ -18,239 +18,252 @@ import Cardano.Ledger.Credential (Ptr(Ptr))
 import Data.Bifunctor (Bifunctor(bimap))
 import Data.ByteString.Short (fromShort, toShort)
 import Data.Foldable (fold)
-import Data.Functor.Identity (Identity(..))
-import Data.Kind (Type)
 import qualified Data.Map as Map
 import Language.Marlowe.Runtime.Cardano.Feature
 import Language.Marlowe.Runtime.ChainSync.Api
 import Witherable (mapMaybe)
 
-type family UnwrapIdentity a where
-  UnwrapIdentity (Identity a) = a
-  UnwrapIdentity a = a
+toCardanoBlockHeader :: BlockHeader -> C.BlockHeader
+toCardanoBlockHeader BlockHeader{..} =
+  C.BlockHeader
+    (toCardanoSlotNo slotNo)
+    (toCardanoBlockHeaderHash headerHash)
+    (toCardanoBlockNo blockNo)
 
-class HasCardanoType a f | a -> f where
-  type CardanoType a :: Type
-  toCardano :: a -> UnwrapIdentity (f (CardanoType a))
-  fromCardano :: CardanoType a -> a
+fromCardanoBlockHeader :: C.BlockHeader -> BlockHeader
+fromCardanoBlockHeader (C.BlockHeader slotNo headerHash blockNo) =
+  BlockHeader
+    (fromCardanoSlotNo slotNo)
+    (fromCardanoBlockHeaderHash headerHash)
+    (fromCardanoBlockNo blockNo)
 
-class CardanoFeature (FeatureType a) => HasFeatureDependentCardanoType a f | a -> f where
-  type FeatureDependentCardanoType a :: Type -> Type
-  type FeatureType a :: Type -> Type
-  toCardanoFeatureDependent
-    :: FeatureType a era
-    -> a
-    -> UnwrapIdentity (f (FeatureDependentCardanoType a era))
-  fromCardanoFeatureDependent
-    :: FeatureType a era
-    -> FeatureDependentCardanoType a era
-    -> a
+toCardanoSlotNo :: SlotNo -> C.SlotNo
+toCardanoSlotNo = C.SlotNo . fromIntegral
 
-instance HasCardanoType BlockHeader Identity where
-  type CardanoType BlockHeader = C.BlockHeader
-  toCardano BlockHeader{..} = C.BlockHeader (toCardano slotNo) (toCardano headerHash) (toCardano blockNo)
-  fromCardano (C.BlockHeader slotNo headerHash blockNo) =
-    BlockHeader (fromCardano slotNo) (fromCardano headerHash) (fromCardano blockNo)
+fromCardanoSlotNo :: C.SlotNo -> SlotNo
+fromCardanoSlotNo (C.SlotNo slotNo) = fromIntegral slotNo
 
-instance HasCardanoType SlotNo Identity where
-  type CardanoType SlotNo = C.SlotNo
-  toCardano = C.SlotNo . fromIntegral
-  fromCardano (C.SlotNo slotNo) = fromIntegral slotNo
+toCardanoBlockNo :: BlockNo -> C.BlockNo
+toCardanoBlockNo = C.BlockNo . fromIntegral
 
-instance HasCardanoType BlockNo Identity where
-  type CardanoType BlockNo = C.BlockNo
-  toCardano = C.BlockNo . fromIntegral
-  fromCardano (C.BlockNo blockNo) = fromIntegral blockNo
+fromCardanoBlockNo :: C.BlockNo -> BlockNo
+fromCardanoBlockNo (C.BlockNo slotNo) = fromIntegral slotNo
 
-instance HasCardanoType BlockHeaderHash Identity where
-  type CardanoType BlockHeaderHash = C.Hash C.BlockHeader
-  toCardano = C.HeaderHash . toShort . unBlockHeaderHash
-  fromCardano (C.HeaderHash hash) = BlockHeaderHash $ fromShort hash
+toCardanoBlockHeaderHash :: BlockHeaderHash -> C.Hash C.BlockHeader
+toCardanoBlockHeaderHash = C.HeaderHash . toShort . unBlockHeaderHash
 
-instance HasCardanoType ScriptHash Maybe where
-  type CardanoType ScriptHash = C.ScriptHash
-  toCardano = C.deserialiseFromRawBytes C.AsScriptHash . unScriptHash
-  fromCardano = ScriptHash . C.serialiseToRawBytes
+fromCardanoBlockHeaderHash :: C.Hash C.BlockHeader -> BlockHeaderHash
+fromCardanoBlockHeaderHash (C.HeaderHash hash) = BlockHeaderHash $ fromShort hash
 
-instance HasCardanoType DatumHash Maybe where
-  type CardanoType DatumHash = C.Hash C.ScriptData
-  toCardano = C.deserialiseFromRawBytes (C.AsHash C.AsScriptData) . unDatumHash
-  fromCardano = DatumHash . C.serialiseToRawBytes
+toCardanoScriptHash :: ScriptHash -> Maybe C.ScriptHash
+toCardanoScriptHash = C.deserialiseFromRawBytes C.AsScriptHash . unScriptHash
 
-instance HasCardanoType Datum Identity where
-  type CardanoType Datum = C.ScriptData
-  toCardano = \case
-    Constr i ds -> C.ScriptDataConstructor i $ toCardano <$> ds
-    Map ds -> C.ScriptDataMap $ bimap toCardano toCardano <$> ds
-    List ds -> C.ScriptDataList $ toCardano <$> ds
-    I i -> C.ScriptDataNumber i
-    B bs -> C.ScriptDataBytes bs
-  fromCardano = \case
-    C.ScriptDataConstructor i ds -> Constr i $ fromCardano <$> ds
-    C.ScriptDataMap ds -> Map $ bimap fromCardano fromCardano <$> ds
-    C.ScriptDataList ds -> List $ fromCardano <$> ds
-    C.ScriptDataNumber i -> I i
-    C.ScriptDataBytes bs -> B bs
+fromCardanoScriptHash :: C.ScriptHash -> ScriptHash
+fromCardanoScriptHash = ScriptHash . C.serialiseToRawBytes
 
-instance HasCardanoType Credential Maybe where
-  type CardanoType Credential = C.PaymentCredential
-  toCardano = \case
-    PaymentKeyCredential pkh -> C.PaymentCredentialByKey <$> toCardano pkh
-    ScriptCredential sh -> C.PaymentCredentialByScript <$> toCardano sh
-  fromCardano = \case
-    C.PaymentCredentialByKey pkh -> PaymentKeyCredential $ fromCardano pkh
-    C.PaymentCredentialByScript sh -> ScriptCredential $ fromCardano sh
+toCardanoDatumHash :: DatumHash -> Maybe (C.Hash C.ScriptData)
+toCardanoDatumHash = C.deserialiseFromRawBytes (C.AsHash C.AsScriptData) . unDatumHash
 
-instance HasCardanoType StakeCredential Maybe where
-  type CardanoType StakeCredential = C.StakeCredential
-  toCardano = \case
-    StakeKeyCredential skh -> C.StakeCredentialByKey <$> toCardano skh
-    StakeScriptCredential sh -> C.StakeCredentialByScript <$> toCardano sh
-  fromCardano = \case
-    C.StakeCredentialByKey skh -> StakeKeyCredential $ fromCardano skh
-    C.StakeCredentialByScript sh -> StakeScriptCredential $ fromCardano sh
+fromCardanoDatumHash :: C.Hash C.ScriptData -> DatumHash
+fromCardanoDatumHash = DatumHash . C.serialiseToRawBytes
 
-instance HasCardanoType (Maybe StakeReference) Maybe where
-  type CardanoType (Maybe StakeReference) = C.StakeAddressReference
-  toCardano = \case
-    Nothing -> Just C.NoStakeAddress
-    Just (StakeCredential cred) -> C.StakeAddressByValue <$> toCardano cred
-    Just (StakePointer slotNo txIx certIx) -> Just
-      $ C.StakeAddressByPointer
-      $ C.StakeAddressPointer
-      $ Ptr (toCardano slotNo) (L.TxIx $ fromIntegral txIx) (toCardano certIx)
-  fromCardano = \case
-    C.NoStakeAddress -> Nothing
-    C.StakeAddressByValue credential -> Just $ StakeCredential $ fromCardano credential
-    C.StakeAddressByPointer (C.StakeAddressPointer (Ptr slotNo (L.TxIx txIx) certIx)) -> Just $ StakePointer
-      (fromCardano slotNo)
-      (fromIntegral txIx)
-      (fromCardano certIx)
+toCardanoScriptData :: Datum -> C.ScriptData
+toCardanoScriptData = \case
+  Constr i ds -> C.ScriptDataConstructor i $ toCardanoScriptData <$> ds
+  Map ds -> C.ScriptDataMap $ bimap toCardanoScriptData toCardanoScriptData <$> ds
+  List ds -> C.ScriptDataList $ toCardanoScriptData <$> ds
+  I i -> C.ScriptDataNumber i
+  B bs -> C.ScriptDataBytes bs
 
-instance HasCardanoType PaymentKeyHash Maybe where
-  type CardanoType PaymentKeyHash = C.Hash C.PaymentKey
-  toCardano = C.deserialiseFromRawBytes (C.AsHash C.AsPaymentKey) . unPaymentKeyHash
-  fromCardano = PaymentKeyHash . C.serialiseToRawBytes
+fromCardanoScriptData :: C.ScriptData -> Datum
+fromCardanoScriptData = \case
+  C.ScriptDataConstructor i ds -> Constr i $ fromCardanoScriptData <$> ds
+  C.ScriptDataMap ds -> Map $ bimap fromCardanoScriptData fromCardanoScriptData <$> ds
+  C.ScriptDataList ds -> List $ fromCardanoScriptData <$> ds
+  C.ScriptDataNumber i -> I i
+  C.ScriptDataBytes bs -> B bs
 
-instance HasCardanoType StakeKeyHash Maybe where
-  type CardanoType StakeKeyHash = C.Hash C.StakeKey
-  toCardano = C.deserialiseFromRawBytes (C.AsHash C.AsStakeKey) . unStakeKeyHash
-  fromCardano = StakeKeyHash . C.serialiseToRawBytes
+toCardanoPaymentCredential :: Credential -> Maybe C.PaymentCredential
+toCardanoPaymentCredential = \case
+  PaymentKeyCredential pkh -> C.PaymentCredentialByKey <$> toCardanoPaymentKeyHash pkh
+  ScriptCredential sh -> C.PaymentCredentialByScript <$> toCardanoScriptHash sh
 
-instance HasCardanoType PolicyId Maybe where
-  type CardanoType PolicyId = C.PolicyId
-  toCardano = C.deserialiseFromRawBytes C.AsPolicyId . unPolicyId
-  fromCardano = PolicyId . C.serialiseToRawBytes
+fromCardanoPaymentCredential :: C.PaymentCredential -> Credential
+fromCardanoPaymentCredential = \case
+  C.PaymentCredentialByKey pkh -> PaymentKeyCredential $ fromCardanoPaymentKeyHash pkh
+  C.PaymentCredentialByScript sh -> ScriptCredential $ fromCardanoScriptHash sh
 
-instance HasCardanoType TokenName Identity where
-  type CardanoType TokenName = C.AssetName
-  toCardano = C.AssetName . unTokenName
-  fromCardano (C.AssetName name) = TokenName name
+toCardanoStakeCredential :: StakeCredential -> Maybe C.StakeCredential
+toCardanoStakeCredential = \case
+  StakeKeyCredential pkh -> C.StakeCredentialByKey <$> toCardanoStakeKeyHash pkh
+  StakeScriptCredential sh -> C.StakeCredentialByScript <$> toCardanoScriptHash sh
 
-instance HasCardanoType Quantity Identity where
-  type CardanoType Quantity = C.Quantity
-  toCardano = C.Quantity . fromIntegral . unQuantity
-  fromCardano (C.Quantity q) = Quantity $ fromIntegral q
+fromCardanoStakeCredential :: C.StakeCredential -> StakeCredential
+fromCardanoStakeCredential = \case
+  C.StakeCredentialByKey pkh -> StakeKeyCredential $ fromCardanoStakeKeyHash pkh
+  C.StakeCredentialByScript sh -> StakeScriptCredential $ fromCardanoScriptHash sh
 
-instance HasCardanoType TxId Maybe where
-  type CardanoType TxId = C.TxId
-  toCardano = C.deserialiseFromRawBytes C.AsTxId . unTxId
-  fromCardano = TxId . C.serialiseToRawBytes
+toCardanoStakeAddressReference :: Maybe StakeReference -> Maybe C.StakeAddressReference
+toCardanoStakeAddressReference = \case
+  Nothing -> Just C.NoStakeAddress
+  Just (StakeCredential cred) -> C.StakeAddressByValue <$> toCardanoStakeCredential cred
+  Just (StakePointer slotNo txIx certIx) -> Just
+    $ C.StakeAddressByPointer
+    $ C.StakeAddressPointer
+    $ Ptr (toCardanoSlotNo slotNo) (L.TxIx $ fromIntegral txIx) (toCardanoCertIx certIx)
 
-instance HasCardanoType TxIx Identity where
-  type CardanoType TxIx = C.TxIx
-  toCardano = C.TxIx . fromIntegral . unTxIx
-  fromCardano (C.TxIx txIx) = TxIx $ fromIntegral txIx
+fromCardanoStakeAddressReference :: C.StakeAddressReference -> Maybe StakeReference
+fromCardanoStakeAddressReference = \case
+  C.NoStakeAddress -> Nothing
+  C.StakeAddressByValue credential -> Just $ StakeCredential $ fromCardanoStakeCredential credential
+  C.StakeAddressByPointer (C.StakeAddressPointer (Ptr slotNo (L.TxIx txIx) certIx)) -> Just $ StakePointer
+    (fromCardanoSlotNo slotNo)
+    (fromIntegral txIx)
+    (fromCardanoCertIx certIx)
 
-instance HasCardanoType CertIx Identity where
-  type CardanoType CertIx = L.CertIx
-  toCardano = L.CertIx . unCertIx
-  fromCardano (L.CertIx certIx) = CertIx certIx
+toCardanoPaymentKeyHash :: PaymentKeyHash -> Maybe (C.Hash C.PaymentKey)
+toCardanoPaymentKeyHash = C.deserialiseFromRawBytes (C.AsHash C.AsPaymentKey) . unPaymentKeyHash
 
-instance HasCardanoType TxOutRef Maybe where
-  type CardanoType TxOutRef = C.TxIn
-  toCardano TxOutRef{..} = C.TxIn <$> toCardano txId <*> pure (toCardano txIx)
-  fromCardano (C.TxIn txId txIx) = TxOutRef (fromCardano txId) (fromCardano txIx)
+fromCardanoPaymentKeyHash :: C.Hash C.PaymentKey -> PaymentKeyHash
+fromCardanoPaymentKeyHash = PaymentKeyHash . C.serialiseToRawBytes
 
-instance HasFeatureDependentCardanoType Address Maybe where
-  type FeatureDependentCardanoType Address = C.AddressInEra
-  type FeatureType Address = C.CardanoEra
-  toCardanoFeatureDependent era = withCardanoEra era
-    $ C.deserialiseFromRawBytes (C.AsAddressInEra $ cardanoEraToAsType era) . unAddress
-  fromCardanoFeatureDependent era = withCardanoEra era
-    $ Address . C.serialiseToRawBytes
+toCardanoStakeKeyHash :: StakeKeyHash -> Maybe (C.Hash C.StakeKey)
+toCardanoStakeKeyHash = C.deserialiseFromRawBytes (C.AsHash C.AsStakeKey) . unStakeKeyHash
 
-instance HasCardanoType Lovelace Identity where
-  type CardanoType Lovelace = C.Lovelace
-  toCardano = C.Lovelace . fromIntegral . unLovelace
-  fromCardano (C.Lovelace l) = Lovelace $ fromIntegral l
+fromCardanoStakeKeyHash :: C.Hash C.StakeKey -> StakeKeyHash
+fromCardanoStakeKeyHash = StakeKeyHash . C.serialiseToRawBytes
 
-instance HasCardanoType Tokens Maybe where
-  type CardanoType Tokens = C.Value
-  toCardano = fmap C.valueFromList . traverse toCardano' . Map.toList . unTokens
-    where
-      toCardano' :: (AssetId, Quantity) -> Maybe (C.AssetId, C.Quantity)
-      toCardano' (AssetId{..}, quantity) = (,)
-        <$> (C.AssetId <$> toCardano policyId <*> pure (toCardano tokenName))
-        <*> pure (toCardano quantity)
-  fromCardano = Tokens . Map.fromList . mapMaybe fromCardano' . C.valueToList
-    where
-      fromCardano' :: (C.AssetId, C.Quantity) -> Maybe (AssetId, Quantity)
-      fromCardano' (C.AdaAssetId, _) = Nothing
-      fromCardano' (C.AssetId policy name, q) =
-        Just (AssetId (fromCardano policy) (fromCardano name), fromCardano q)
+toCardanoPolicyId :: PolicyId -> Maybe C.PolicyId
+toCardanoPolicyId = C.deserialiseFromRawBytes C.AsPolicyId . unPolicyId
 
-instance HasCardanoType Assets Maybe where
-  type CardanoType Assets = C.Value
-  toCardano Assets{..} = fold <$> sequence
-    [ Just $ C.valueFromList [(C.AdaAssetId, C.lovelaceToQuantity $ toCardano ada)]
-    , toCardano tokens
-    ]
-  fromCardano value = Assets
-    { ada = maybe 0 fromCardano $ C.valueToLovelace value
-    , tokens = fromCardano value
-    }
+fromCardanoPolicyId :: C.PolicyId -> PolicyId
+fromCardanoPolicyId = PolicyId . C.serialiseToRawBytes
 
-instance HasFeatureDependentCardanoType Assets Maybe where
-  type FeatureDependentCardanoType Assets = C.TxOutValue
-  type FeatureType Assets = C.MultiAssetSupportedInEra
-  toCardanoFeatureDependent era assets = C.TxOutValue era <$> toCardano assets
-  fromCardanoFeatureDependent era = \case
-    C.TxOutValue _ value -> fromCardano value
-    C.TxOutAdaOnly era' _ -> case (era, era') of
+toCardanoAssetName :: TokenName -> C.AssetName
+toCardanoAssetName = C.AssetName . unTokenName
 
-instance HasFeatureDependentCardanoType (Maybe DatumHash, Maybe Datum) Maybe where
-  type FeatureDependentCardanoType (Maybe DatumHash, Maybe Datum) = C.TxOutDatum C.CtxTx
-  type FeatureType (Maybe DatumHash, Maybe Datum) = C.CardanoEra
-  toCardanoFeatureDependent era = case featureInCardanoEra era of
-    Nothing -> const $ Just C.TxOutDatumNone
-    Just scriptDataSupported -> \case
-      (Nothing, Nothing) -> Just C.TxOutDatumNone
-      (Just hash, Nothing) -> C.TxOutDatumHash scriptDataSupported <$> toCardano hash
-      (_, Just datum) -> Just $ C.TxOutDatumInTx scriptDataSupported $ toCardano datum
-  fromCardanoFeatureDependent _ = \case
-    C.TxOutDatumNone -> (Nothing, Nothing)
-    C.TxOutDatumHash _ hash -> (Just $ fromCardano hash, Nothing)
-    C.TxOutDatumInTx _ datum -> (Nothing, Just $ fromCardano datum)
-    C.TxOutDatumInline _ datum -> (Nothing, Just $ fromCardano datum)
+fromCardanoAssetName :: C.AssetName -> TokenName
+fromCardanoAssetName (C.AssetName name) = TokenName name
 
-instance HasFeatureDependentCardanoType TransactionOutput Maybe where
-  type FeatureDependentCardanoType TransactionOutput = C.TxOut C.CtxTx
-  type FeatureType TransactionOutput = C.MultiAssetSupportedInEra
-  toCardanoFeatureDependent era TransactionOutput{..} = C.TxOut
-    <$> toCardanoFeatureDependent (cardanoEraOfFeature era) address
-    <*> toCardanoFeatureDependent era assets
-    <*> toCardanoFeatureDependent (cardanoEraOfFeature era) (datumHash, datum)
-    <*> pure C.ReferenceScriptNone
+toCardanoQuantity :: Quantity -> C.Quantity
+toCardanoQuantity = C.Quantity . fromIntegral . unQuantity
 
-  fromCardanoFeatureDependent era (C.TxOut address value txOutDatum _) =
-    TransactionOutput
-      (fromCardanoFeatureDependent (cardanoEraOfFeature era) address)
-      (fromCardanoFeatureDependent era value)
-      hash
-      datum
-    where
-      (hash, datum) = fromCardanoFeatureDependent (cardanoEraOfFeature era) txOutDatum
+fromCardanoQuantity :: C.Quantity -> Quantity
+fromCardanoQuantity (C.Quantity q) = Quantity $ fromIntegral q
+
+toCardanoTxId :: TxId -> Maybe C.TxId
+toCardanoTxId = C.deserialiseFromRawBytes C.AsTxId . unTxId
+
+fromCardanoTxId :: C.TxId -> TxId
+fromCardanoTxId = TxId . C.serialiseToRawBytes
+
+toCardanoTxIx :: TxIx -> C.TxIx
+toCardanoTxIx = C.TxIx . fromIntegral . unTxIx
+
+fromCardanoTxIx :: C.TxIx -> TxIx
+fromCardanoTxIx (C.TxIx txIx) = TxIx $ fromIntegral txIx
+
+toCardanoCertIx :: CertIx -> L.CertIx
+toCardanoCertIx = L.CertIx . unCertIx
+
+fromCardanoCertIx :: L.CertIx -> CertIx
+fromCardanoCertIx (L.CertIx certIx) = CertIx certIx
+
+toCardanoTxIn :: TxOutRef -> Maybe C.TxIn
+toCardanoTxIn TxOutRef{..} = C.TxIn <$> toCardanoTxId txId <*> pure (toCardanoTxIx txIx)
+
+fromCardanoTxIn :: C.TxIn -> TxOutRef
+fromCardanoTxIn (C.TxIn txId txIx) = TxOutRef (fromCardanoTxId txId) (fromCardanoTxIx txIx)
+
+toCardanoAddressInEra :: C.CardanoEra era -> Address -> Maybe (C.AddressInEra era)
+toCardanoAddressInEra era = withCardanoEra era
+  $ C.deserialiseFromRawBytes (C.AsAddressInEra $ cardanoEraToAsType era) . unAddress
+
+fromCardanoAddressInEra :: C.CardanoEra era -> C.AddressInEra era -> Address
+fromCardanoAddressInEra era = withCardanoEra era
+  $ Address . C.serialiseToRawBytes
+
+toCardanoLovelace :: Lovelace -> C.Lovelace
+toCardanoLovelace = C.Lovelace . fromIntegral . unLovelace
+
+fromCardanoLovelace :: C.Lovelace -> Lovelace
+fromCardanoLovelace (C.Lovelace l) = Lovelace $ fromIntegral l
+
+tokensToCardanoValue :: Tokens -> Maybe C.Value
+tokensToCardanoValue = fmap C.valueFromList . traverse toCardanoValue' . Map.toList . unTokens
+  where
+    toCardanoValue' :: (AssetId, Quantity) -> Maybe (C.AssetId, C.Quantity)
+    toCardanoValue' (AssetId{..}, quantity) = (,)
+      <$> (C.AssetId <$> toCardanoPolicyId policyId <*> pure (toCardanoAssetName tokenName))
+      <*> pure (toCardanoQuantity quantity)
+
+tokensFromCardanoValue :: C.Value -> Tokens
+tokensFromCardanoValue = Tokens . Map.fromList . mapMaybe fromCardanoValue' . C.valueToList
+  where
+    fromCardanoValue' :: (C.AssetId, C.Quantity) -> Maybe (AssetId, Quantity)
+    fromCardanoValue' (C.AdaAssetId, _) = Nothing
+    fromCardanoValue' (C.AssetId policy name, q) =
+      Just (AssetId (fromCardanoPolicyId policy) (fromCardanoAssetName name), fromCardanoQuantity q)
+
+assetsToCardanoValue :: Assets -> Maybe C.Value
+assetsToCardanoValue Assets{..} = fold <$> sequence
+  [ Just $ C.valueFromList [(C.AdaAssetId, C.lovelaceToQuantity $ toCardanoLovelace ada)]
+  , tokensToCardanoValue tokens
+  ]
+
+assetsFromCardanoValue :: C.Value -> Assets
+assetsFromCardanoValue value = Assets
+  { ada = maybe 0 fromCardanoLovelace $ C.valueToLovelace value
+  , tokens = tokensFromCardanoValue value
+  }
+
+toCardanoTxOutValue :: C.MultiAssetSupportedInEra era -> Assets -> Maybe (C.TxOutValue era)
+toCardanoTxOutValue multiAssetsSupported assets =
+  C.TxOutValue multiAssetsSupported <$> assetsToCardanoValue assets
+
+fromCardanoTxOutValue :: C.TxOutValue era -> Assets
+fromCardanoTxOutValue = \case
+  C.TxOutValue _ value -> assetsFromCardanoValue value
+  C.TxOutAdaOnly _ lovelace -> Assets (fromCardanoLovelace lovelace) mempty
+
+toCardanoTxOutDatum
+  :: C.CardanoEra era
+  -> Maybe DatumHash
+  -> Maybe Datum
+  -> Maybe (C.TxOutDatum C.CtxTx era)
+toCardanoTxOutDatum era = curry case featureInCardanoEra era of
+  Nothing -> const $ Just C.TxOutDatumNone
+  Just scriptDataSupported -> \case
+    (Nothing, Nothing) -> Just C.TxOutDatumNone
+    (Just hash, Nothing) -> C.TxOutDatumHash scriptDataSupported <$> toCardanoDatumHash hash
+    (_, Just datum) -> Just $ C.TxOutDatumInTx scriptDataSupported $ toCardanoScriptData datum
+
+fromCardanoTxOutDatum :: C.TxOutDatum C.CtxTx era -> (Maybe DatumHash, Maybe Datum)
+fromCardanoTxOutDatum = \case
+  C.TxOutDatumNone -> (Nothing, Nothing)
+  C.TxOutDatumHash _ hash -> (Just $ fromCardanoDatumHash hash, Nothing)
+  C.TxOutDatumInTx _ datum -> (Nothing, Just $ fromCardanoScriptData datum)
+  C.TxOutDatumInline _ datum -> (Nothing, Just $ fromCardanoScriptData datum)
+
+toCardanoTxOut :: C.MultiAssetSupportedInEra era -> TransactionOutput -> Maybe (C.TxOut C.CtxTx era)
+toCardanoTxOut era TransactionOutput{..} = C.TxOut
+  <$> toCardanoAddressInEra (cardanoEraOfFeature era) address
+  <*> toCardanoTxOutValue era assets
+  <*> toCardanoTxOutDatum (cardanoEraOfFeature era) datumHash datum
+  <*> pure C.ReferenceScriptNone
+
+fromCardanoTxOut
+  :: C.CardanoEra era
+  -> C.TxOut C.CtxTx era
+  -> TransactionOutput
+fromCardanoTxOut era (C.TxOut address value txOutDatum _) =
+  TransactionOutput
+    (fromCardanoAddressInEra era address)
+    (fromCardanoTxOutValue value)
+    hash
+    datum
+  where
+    (hash, datum) = fromCardanoTxOutDatum txOutDatum
 
 cardanoEraToAsType :: C.CardanoEra era -> C.AsType era
 cardanoEraToAsType = \case

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/Cardano/Api.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/Cardano/Api.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Utilities for converting to and from Cardano API types.
+
+module Language.Marlowe.Runtime.Cardano.Api
+  where
+
+import qualified Cardano.Api as C
+import qualified Cardano.Api.Shelley as C
+import Data.Bifunctor (Bifunctor(bimap))
+import Data.Foldable (fold)
+import Data.Functor.Identity (Identity(..))
+import Data.Kind (Type)
+import qualified Data.Map as Map
+import Language.Marlowe.Runtime.Cardano.Feature
+import Language.Marlowe.Runtime.ChainSync.Api
+import Witherable (mapMaybe)
+
+type family UnwrapIdentity a where
+  UnwrapIdentity (Identity a) = a
+  UnwrapIdentity a = a
+
+class HasCardanoType a f | a -> f where
+  type CardanoType a :: Type
+  toCardano :: a -> UnwrapIdentity (f (CardanoType a))
+  fromCardano :: CardanoType a -> a
+
+class CardanoFeature (CardanoFeatureType a) => HasCardanoTypeWithEra a f | a -> f where
+  type CardanoTypeWithEra a :: Type -> Type
+  type CardanoFeatureType a :: Type -> Type
+  toCardanoInEra
+    :: CardanoFeatureType a era
+    -> a
+    -> UnwrapIdentity (f (CardanoTypeWithEra a era))
+  fromCardanoInEra
+    :: CardanoFeatureType a era
+    -> CardanoTypeWithEra a era
+    -> a
+
+instance HasCardanoType ScriptHash Maybe where
+  type CardanoType ScriptHash = C.ScriptHash
+  toCardano = C.deserialiseFromRawBytes C.AsScriptHash . unScriptHash
+  fromCardano = ScriptHash . C.serialiseToRawBytes
+
+instance HasCardanoType DatumHash Maybe where
+  type CardanoType DatumHash = C.Hash C.ScriptData
+  toCardano = C.deserialiseFromRawBytes (C.AsHash C.AsScriptData) . unDatumHash
+  fromCardano = DatumHash . C.serialiseToRawBytes
+
+instance HasCardanoType Datum Identity where
+  type CardanoType Datum = C.ScriptData
+  toCardano = \case
+    Constr i ds -> C.ScriptDataConstructor i $ toCardano <$> ds
+    Map ds -> C.ScriptDataMap $ bimap toCardano toCardano <$> ds
+    List ds -> C.ScriptDataList $ toCardano <$> ds
+    I i -> C.ScriptDataNumber i
+    B bs -> C.ScriptDataBytes bs
+  fromCardano = \case
+    C.ScriptDataConstructor i ds -> Constr i $ fromCardano <$> ds
+    C.ScriptDataMap ds -> Map $ bimap fromCardano fromCardano <$> ds
+    C.ScriptDataList ds -> List $ fromCardano <$> ds
+    C.ScriptDataNumber i -> I i
+    C.ScriptDataBytes bs -> B bs
+
+instance HasCardanoType PaymentKeyHash Maybe where
+  type CardanoType PaymentKeyHash = C.Hash C.PaymentKey
+  toCardano = C.deserialiseFromRawBytes (C.AsHash C.AsPaymentKey) . unPaymentKeyHash
+  fromCardano = PaymentKeyHash . C.serialiseToRawBytes
+
+instance HasCardanoType PolicyId Maybe where
+  type CardanoType PolicyId = C.PolicyId
+  toCardano = C.deserialiseFromRawBytes C.AsPolicyId . unPolicyId
+  fromCardano = PolicyId . C.serialiseToRawBytes
+
+instance HasCardanoType TokenName Identity where
+  type CardanoType TokenName = C.AssetName
+  toCardano = C.AssetName . unTokenName
+  fromCardano (C.AssetName name) = TokenName name
+
+instance HasCardanoType Quantity Identity where
+  type CardanoType Quantity = C.Quantity
+  toCardano = C.Quantity . fromIntegral . unQuantity
+  fromCardano (C.Quantity q) = Quantity $ fromIntegral q
+
+instance HasCardanoType TxId Maybe where
+  type CardanoType TxId = C.TxId
+  toCardano = C.deserialiseFromRawBytes C.AsTxId . unTxId
+  fromCardano = TxId . C.serialiseToRawBytes
+
+instance HasCardanoType TxIx Identity where
+  type CardanoType TxIx = C.TxIx
+  toCardano = C.TxIx . fromIntegral . unTxIx
+  fromCardano (C.TxIx txIx) = TxIx $ fromIntegral txIx
+
+instance HasCardanoType TxOutRef Maybe where
+  type CardanoType TxOutRef = C.TxIn
+  toCardano TxOutRef{..} = C.TxIn <$> toCardano txId <*> pure (toCardano txIx)
+  fromCardano (C.TxIn txId txIx) = TxOutRef (fromCardano txId) (fromCardano txIx)
+
+instance HasCardanoTypeWithEra Address Maybe where
+  type CardanoTypeWithEra Address = C.AddressInEra
+  type CardanoFeatureType Address = C.CardanoEra
+  toCardanoInEra era = withCardanoEra era
+    $ C.deserialiseFromRawBytes (C.AsAddressInEra $ cardanoEraToAsType era) . unAddress
+  fromCardanoInEra era = withCardanoEra era
+    $ Address . C.serialiseToRawBytes
+
+instance HasCardanoType Lovelace Identity where
+  type CardanoType Lovelace = C.Lovelace
+  toCardano = C.Lovelace . fromIntegral . unLovelace
+  fromCardano (C.Lovelace l) = Lovelace $ fromIntegral l
+
+instance HasCardanoType Tokens Maybe where
+  type CardanoType Tokens = C.Value
+  toCardano = fmap C.valueFromList . traverse toCardano' . Map.toList . unTokens
+    where
+      toCardano' :: (AssetId, Quantity) -> Maybe (C.AssetId, C.Quantity)
+      toCardano' (AssetId{..}, quantity) = (,)
+        <$> (C.AssetId <$> toCardano policyId <*> pure (toCardano tokenName))
+        <*> pure (toCardano quantity)
+  fromCardano = Tokens . Map.fromList . mapMaybe fromCardano' . C.valueToList
+    where
+      fromCardano' :: (C.AssetId, C.Quantity) -> Maybe (AssetId, Quantity)
+      fromCardano' (C.AdaAssetId, _) = Nothing
+      fromCardano' (C.AssetId policy name, q) =
+        Just (AssetId (fromCardano policy) (fromCardano name), fromCardano q)
+
+instance HasCardanoType Assets Maybe where
+  type CardanoType Assets = C.Value
+  toCardano Assets{..} = fold <$> sequence
+    [ Just $ C.valueFromList [(C.AdaAssetId, C.lovelaceToQuantity $ toCardano ada)]
+    , toCardano tokens
+    ]
+  fromCardano value = Assets
+    { ada = maybe 0 fromCardano $ C.valueToLovelace value
+    , tokens = fromCardano value
+    }
+
+instance HasCardanoTypeWithEra Assets Maybe where
+  type CardanoTypeWithEra Assets = C.TxOutValue
+  type CardanoFeatureType Assets = C.MultiAssetSupportedInEra
+  toCardanoInEra era assets = C.TxOutValue era <$> toCardano assets
+  fromCardanoInEra era = \case
+    C.TxOutValue _ value -> fromCardano value
+    C.TxOutAdaOnly era' _ -> case (era, era') of
+
+instance HasCardanoTypeWithEra (Maybe DatumHash, Maybe Datum) Maybe where
+  type CardanoTypeWithEra (Maybe DatumHash, Maybe Datum) = C.TxOutDatum C.CtxTx
+  type CardanoFeatureType (Maybe DatumHash, Maybe Datum) = C.CardanoEra
+  toCardanoInEra era = case featureInCardanoEra era of
+    Nothing -> const $ Just C.TxOutDatumNone
+    Just scriptDataSupported -> \case
+      (Nothing, Nothing) -> Just C.TxOutDatumNone
+      (Just hash, Nothing) -> C.TxOutDatumHash scriptDataSupported <$> toCardano hash
+      (_, Just datum) -> Just $ C.TxOutDatumInTx scriptDataSupported $ toCardano datum
+  fromCardanoInEra _ = \case
+    C.TxOutDatumNone -> (Nothing, Nothing)
+    C.TxOutDatumHash _ hash -> (Just $ fromCardano hash, Nothing)
+    C.TxOutDatumInTx _ datum -> (Nothing, Just $ fromCardano datum)
+    C.TxOutDatumInline _ datum -> (Nothing, Just $ fromCardano datum)
+
+instance HasCardanoTypeWithEra TransactionOutput Maybe where
+  type CardanoTypeWithEra TransactionOutput = C.TxOut C.CtxTx
+  type CardanoFeatureType TransactionOutput = C.MultiAssetSupportedInEra
+  toCardanoInEra era TransactionOutput{..} = C.TxOut
+    <$> toCardanoInEra (cardanoEraOfFeature era) address
+    <*> toCardanoInEra era assets
+    <*> toCardanoInEra (cardanoEraOfFeature era) (datumHash, datum)
+    <*> pure C.ReferenceScriptNone
+
+  fromCardanoInEra era (C.TxOut address value txOutDatum _) =
+    TransactionOutput
+      (fromCardanoInEra (cardanoEraOfFeature era) address)
+      (fromCardanoInEra era value)
+      hash
+      datum
+    where
+      (hash, datum) = fromCardanoInEra (cardanoEraOfFeature era) txOutDatum
+
+cardanoEraToAsType :: C.CardanoEra era -> C.AsType era
+cardanoEraToAsType = \case
+  C.ByronEra -> C.AsByronEra
+  C.ShelleyEra -> C.AsShelleyEra
+  C.AllegraEra -> C.AsAllegraEra
+  C.MaryEra -> C.AsMaryEra
+  C.AlonzoEra -> C.AsAlonzoEra
+  C.BabbageEra -> C.AsBabbageEra

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/Cardano/Feature.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/Cardano/Feature.hs
@@ -1,0 +1,383 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- | Conversion and casting utilities for Cardano feature objects that use
+-- CardanoEra and ShelleyBasedEra tags.
+
+module Language.Marlowe.Runtime.Cardano.Feature
+  where
+
+import Cardano.Api
+import Cardano.Api.Shelley
+import Data.Functor.Product (Product(..))
+import Data.Functor.These (These1(..))
+
+withCardanoEra :: forall era f r. CardanoFeature f => f era -> (IsCardanoEra era => r) -> r
+withCardanoEra f = case cardanoEraOfFeature f of
+  ByronEra -> id
+  ShelleyEra -> id
+  AllegraEra -> id
+  MaryEra -> id
+  AlonzoEra -> id
+  BabbageEra -> id
+
+withShelleyBasedEra :: forall era f r. ShelleyFeature f => f era -> (IsShelleyBasedEra era => r) -> r
+withShelleyBasedEra f = case shelleyBasedEraOfFeature f of
+  ShelleyBasedEraShelley -> id
+  ShelleyBasedEraAllegra -> id
+  ShelleyBasedEraMary -> id
+  ShelleyBasedEraAlonzo -> id
+  ShelleyBasedEraBabbage -> id
+
+class CardanoFeature f where
+  featureInCardanoEra :: CardanoEra era -> Maybe (f era)
+  cardanoEraOfFeature :: f era -> CardanoEra era
+
+class CardanoFeature f => ShelleyFeature f where
+  featureInShelleyBasedEra :: ShelleyBasedEra era -> Maybe (f era)
+  featureInShelleyBasedEra = featureInCardanoEra . shelleyBasedToCardanoEra
+  shelleyBasedEraOfFeature :: f era -> ShelleyBasedEra era
+
+instance CardanoFeature CardanoEra where
+  featureInCardanoEra = Just
+  cardanoEraOfFeature = id
+
+instance CardanoFeature ShelleyBasedEra where
+  featureInCardanoEra = \case
+    ByronEra -> Nothing
+    ShelleyEra -> Just ShelleyBasedEraShelley
+    AllegraEra -> Just ShelleyBasedEraAllegra
+    MaryEra -> Just ShelleyBasedEraMary
+    AlonzoEra -> Just ShelleyBasedEraAlonzo
+    BabbageEra -> Just ShelleyBasedEraBabbage
+  cardanoEraOfFeature = shelleyBasedToCardanoEra
+
+instance ShelleyFeature ShelleyBasedEra where
+  featureInShelleyBasedEra = Just
+  shelleyBasedEraOfFeature = id
+
+-- The product of two Cardano features is a Cardano feature that is available
+-- in eras where both features are available.
+instance (CardanoFeature f, CardanoFeature g) => CardanoFeature (Product f g) where
+  featureInCardanoEra era = Pair <$> featureInCardanoEra era <*> featureInCardanoEra era
+  cardanoEraOfFeature (Pair f _) = cardanoEraOfFeature f
+
+-- The non-exclusive sum of two Cardano features is a Cardano feature that is
+-- available in eras when either feature is available.
+instance (CardanoFeature f, CardanoFeature g) => CardanoFeature (These1 f g) where
+  featureInCardanoEra era = case (featureInCardanoEra era, featureInCardanoEra era) of
+    (Nothing, Nothing) -> Nothing
+    (Just f, Nothing) -> Just $ This1 f
+    (Nothing, Just g) -> Just $ That1 g
+    (Just f, Just g) -> Just $ These1 f g
+  cardanoEraOfFeature (This1 f) = cardanoEraOfFeature f
+  cardanoEraOfFeature (That1 g) = cardanoEraOfFeature g
+  cardanoEraOfFeature (These1 f _) = cardanoEraOfFeature f
+
+instance (ShelleyFeature f, ShelleyFeature g) => ShelleyFeature (Product f g) where
+  featureInShelleyBasedEra era = Pair <$> featureInShelleyBasedEra era <*> featureInShelleyBasedEra era
+  shelleyBasedEraOfFeature (Pair f _) = shelleyBasedEraOfFeature f
+
+instance (ShelleyFeature f, ShelleyFeature g) => ShelleyFeature (These1 f g) where
+  featureInShelleyBasedEra era = case (featureInShelleyBasedEra era, featureInShelleyBasedEra era) of
+    (Nothing, Nothing) -> Nothing
+    (Just f, Nothing) -> Just $ This1 f
+    (Nothing, Just g) -> Just $ That1 g
+    (Just f, Just g) -> Just $ These1 f g
+  shelleyBasedEraOfFeature (This1 f) = shelleyBasedEraOfFeature f
+  shelleyBasedEraOfFeature (That1 g) = shelleyBasedEraOfFeature g
+  shelleyBasedEraOfFeature (These1 f _) = shelleyBasedEraOfFeature f
+
+instance CardanoFeature CollateralSupportedInEra where
+  featureInCardanoEra = collateralSupportedInEra
+  cardanoEraOfFeature = \case
+    CollateralInAlonzoEra -> AlonzoEra
+    CollateralInBabbageEra -> BabbageEra
+
+instance ShelleyFeature CollateralSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    CollateralInAlonzoEra -> ShelleyBasedEraAlonzo
+    CollateralInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature MultiAssetSupportedInEra where
+  featureInCardanoEra = hush . multiAssetSupportedInEra
+  cardanoEraOfFeature = \case
+    MultiAssetInMaryEra -> MaryEra
+    MultiAssetInAlonzoEra -> AlonzoEra
+    MultiAssetInBabbageEra -> BabbageEra
+
+instance ShelleyFeature MultiAssetSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    MultiAssetInMaryEra -> ShelleyBasedEraMary
+    MultiAssetInAlonzoEra -> ShelleyBasedEraAlonzo
+    MultiAssetInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature OnlyAdaSupportedInEra where
+  featureInCardanoEra = whine . multiAssetSupportedInEra
+  cardanoEraOfFeature = \case
+    AdaOnlyInByronEra -> ByronEra
+    AdaOnlyInShelleyEra -> ShelleyEra
+    AdaOnlyInAllegraEra -> AllegraEra
+
+instance CardanoFeature TxFeesExplicitInEra where
+  featureInCardanoEra = hush . txFeesExplicitInEra
+  cardanoEraOfFeature = \case
+    TxFeesExplicitInShelleyEra -> ShelleyEra
+    TxFeesExplicitInAllegraEra -> AllegraEra
+    TxFeesExplicitInMaryEra -> MaryEra
+    TxFeesExplicitInAlonzoEra -> AlonzoEra
+    TxFeesExplicitInBabbageEra -> BabbageEra
+
+instance ShelleyFeature TxFeesExplicitInEra where
+  shelleyBasedEraOfFeature = \case
+    TxFeesExplicitInShelleyEra -> ShelleyBasedEraShelley
+    TxFeesExplicitInAllegraEra -> ShelleyBasedEraAllegra
+    TxFeesExplicitInMaryEra -> ShelleyBasedEraMary
+    TxFeesExplicitInAlonzoEra -> ShelleyBasedEraAlonzo
+    TxFeesExplicitInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature TxFeesImplicitInEra where
+  featureInCardanoEra = whine . txFeesExplicitInEra
+  cardanoEraOfFeature = \case
+    TxFeesImplicitInByronEra -> ByronEra
+
+instance CardanoFeature ValidityUpperBoundSupportedInEra where
+  featureInCardanoEra = validityUpperBoundSupportedInEra
+  cardanoEraOfFeature = \case
+    ValidityUpperBoundInShelleyEra -> ShelleyEra
+    ValidityUpperBoundInAllegraEra -> AllegraEra
+    ValidityUpperBoundInMaryEra -> MaryEra
+    ValidityUpperBoundInAlonzoEra -> AlonzoEra
+    ValidityUpperBoundInBabbageEra -> BabbageEra
+
+instance ShelleyFeature ValidityUpperBoundSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    ValidityUpperBoundInShelleyEra -> ShelleyBasedEraShelley
+    ValidityUpperBoundInAllegraEra -> ShelleyBasedEraAllegra
+    ValidityUpperBoundInMaryEra -> ShelleyBasedEraMary
+    ValidityUpperBoundInAlonzoEra -> ShelleyBasedEraAlonzo
+    ValidityUpperBoundInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature ValidityNoUpperBoundSupportedInEra where
+  featureInCardanoEra = validityNoUpperBoundSupportedInEra
+  cardanoEraOfFeature = \case
+    ValidityNoUpperBoundInByronEra -> ByronEra
+    ValidityNoUpperBoundInAllegraEra -> AllegraEra
+    ValidityNoUpperBoundInMaryEra -> MaryEra
+    ValidityNoUpperBoundInAlonzoEra -> AlonzoEra
+    ValidityNoUpperBoundInBabbageEra -> BabbageEra
+
+instance CardanoFeature ValidityLowerBoundSupportedInEra where
+  featureInCardanoEra = validityLowerBoundSupportedInEra
+  cardanoEraOfFeature = \case
+    ValidityLowerBoundInAllegraEra -> AllegraEra
+    ValidityLowerBoundInMaryEra -> MaryEra
+    ValidityLowerBoundInAlonzoEra -> AlonzoEra
+    ValidityLowerBoundInBabbageEra -> BabbageEra
+
+instance ShelleyFeature ValidityLowerBoundSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    ValidityLowerBoundInAllegraEra -> ShelleyBasedEraAllegra
+    ValidityLowerBoundInMaryEra -> ShelleyBasedEraMary
+    ValidityLowerBoundInAlonzoEra -> ShelleyBasedEraAlonzo
+    ValidityLowerBoundInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature TxMetadataSupportedInEra where
+  featureInCardanoEra = txMetadataSupportedInEra
+  cardanoEraOfFeature = \case
+    TxMetadataInShelleyEra -> ShelleyEra
+    TxMetadataInAllegraEra -> AllegraEra
+    TxMetadataInMaryEra -> MaryEra
+    TxMetadataInAlonzoEra -> AlonzoEra
+    TxMetadataInBabbageEra -> BabbageEra
+
+instance ShelleyFeature TxMetadataSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    TxMetadataInShelleyEra -> ShelleyBasedEraShelley
+    TxMetadataInAllegraEra -> ShelleyBasedEraAllegra
+    TxMetadataInMaryEra -> ShelleyBasedEraMary
+    TxMetadataInAlonzoEra -> ShelleyBasedEraAlonzo
+    TxMetadataInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature AuxScriptsSupportedInEra where
+  featureInCardanoEra = auxScriptsSupportedInEra
+  cardanoEraOfFeature = \case
+    AuxScriptsInAllegraEra -> AllegraEra
+    AuxScriptsInMaryEra -> MaryEra
+    AuxScriptsInAlonzoEra -> AlonzoEra
+    AuxScriptsInBabbageEra -> BabbageEra
+
+instance ShelleyFeature AuxScriptsSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    AuxScriptsInAllegraEra -> ShelleyBasedEraAllegra
+    AuxScriptsInMaryEra -> ShelleyBasedEraMary
+    AuxScriptsInAlonzoEra -> ShelleyBasedEraAlonzo
+    AuxScriptsInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature TxExtraKeyWitnessesSupportedInEra where
+  featureInCardanoEra = \case
+    AlonzoEra -> Just ExtraKeyWitnessesInAlonzoEra
+    BabbageEra -> Just ExtraKeyWitnessesInBabbageEra
+    _ -> Nothing
+  cardanoEraOfFeature = \case
+    ExtraKeyWitnessesInAlonzoEra -> AlonzoEra
+    ExtraKeyWitnessesInBabbageEra -> BabbageEra
+
+instance ShelleyFeature TxExtraKeyWitnessesSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    ExtraKeyWitnessesInAlonzoEra -> ShelleyBasedEraAlonzo
+    ExtraKeyWitnessesInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature ScriptDataSupportedInEra where
+  featureInCardanoEra = scriptDataSupportedInEra
+  cardanoEraOfFeature = \case
+    ScriptDataInAlonzoEra -> AlonzoEra
+    ScriptDataInBabbageEra -> BabbageEra
+
+instance ShelleyFeature ScriptDataSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    ScriptDataInAlonzoEra -> ShelleyBasedEraAlonzo
+    ScriptDataInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature WithdrawalsSupportedInEra where
+  featureInCardanoEra = withdrawalsSupportedInEra
+  cardanoEraOfFeature = \case
+    WithdrawalsInShelleyEra -> ShelleyEra
+    WithdrawalsInAllegraEra -> AllegraEra
+    WithdrawalsInMaryEra -> MaryEra
+    WithdrawalsInAlonzoEra -> AlonzoEra
+    WithdrawalsInBabbageEra -> BabbageEra
+
+instance ShelleyFeature WithdrawalsSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    WithdrawalsInShelleyEra -> ShelleyBasedEraShelley
+    WithdrawalsInAllegraEra -> ShelleyBasedEraAllegra
+    WithdrawalsInMaryEra -> ShelleyBasedEraMary
+    WithdrawalsInAlonzoEra -> ShelleyBasedEraAlonzo
+    WithdrawalsInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature CertificatesSupportedInEra where
+  featureInCardanoEra = certificatesSupportedInEra
+  cardanoEraOfFeature = \case
+    CertificatesInShelleyEra -> ShelleyEra
+    CertificatesInAllegraEra -> AllegraEra
+    CertificatesInMaryEra -> MaryEra
+    CertificatesInAlonzoEra -> AlonzoEra
+    CertificatesInBabbageEra -> BabbageEra
+
+instance ShelleyFeature CertificatesSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    CertificatesInShelleyEra -> ShelleyBasedEraShelley
+    CertificatesInAllegraEra -> ShelleyBasedEraAllegra
+    CertificatesInMaryEra -> ShelleyBasedEraMary
+    CertificatesInAlonzoEra -> ShelleyBasedEraAlonzo
+    CertificatesInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature UpdateProposalSupportedInEra where
+  featureInCardanoEra = updateProposalSupportedInEra
+  cardanoEraOfFeature = \case
+    UpdateProposalInShelleyEra -> ShelleyEra
+    UpdateProposalInAllegraEra -> AllegraEra
+    UpdateProposalInMaryEra -> MaryEra
+    UpdateProposalInAlonzoEra -> AlonzoEra
+    UpdateProposalInBabbageEra -> BabbageEra
+
+instance ShelleyFeature UpdateProposalSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    UpdateProposalInShelleyEra -> ShelleyBasedEraShelley
+    UpdateProposalInAllegraEra -> ShelleyBasedEraAllegra
+    UpdateProposalInMaryEra -> ShelleyBasedEraMary
+    UpdateProposalInAlonzoEra -> ShelleyBasedEraAlonzo
+    UpdateProposalInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature ReferenceTxInsScriptsInlineDatumsSupportedInEra where
+  featureInCardanoEra = \case
+    BabbageEra -> Just ReferenceTxInsScriptsInlineDatumsInBabbageEra
+    _ -> Nothing
+  cardanoEraOfFeature = \case
+    ReferenceTxInsScriptsInlineDatumsInBabbageEra -> BabbageEra
+
+instance ShelleyFeature ReferenceTxInsScriptsInlineDatumsSupportedInEra where
+  shelleyBasedEraOfFeature = \case
+    ReferenceTxInsScriptsInlineDatumsInBabbageEra -> ShelleyBasedEraBabbage
+
+instance CardanoFeature (ScriptLanguageInEra SimpleScriptV1) where
+  featureInCardanoEra = \case
+    ShelleyEra -> Just SimpleScriptV1InShelley
+    AllegraEra -> Just SimpleScriptV1InAllegra
+    MaryEra -> Just SimpleScriptV1InMary
+    AlonzoEra -> Just SimpleScriptV1InAlonzo
+    BabbageEra -> Just SimpleScriptV1InBabbage
+    _ -> Nothing
+  cardanoEraOfFeature = \case
+    SimpleScriptV1InShelley -> ShelleyEra
+    SimpleScriptV1InAllegra -> AllegraEra
+    SimpleScriptV1InMary -> MaryEra
+    SimpleScriptV1InAlonzo -> AlonzoEra
+    SimpleScriptV1InBabbage -> BabbageEra
+
+instance ShelleyFeature (ScriptLanguageInEra SimpleScriptV1) where
+  shelleyBasedEraOfFeature = \case
+    SimpleScriptV1InShelley -> ShelleyBasedEraShelley
+    SimpleScriptV1InAllegra -> ShelleyBasedEraAllegra
+    SimpleScriptV1InMary -> ShelleyBasedEraMary
+    SimpleScriptV1InAlonzo -> ShelleyBasedEraAlonzo
+    SimpleScriptV1InBabbage -> ShelleyBasedEraBabbage
+
+instance CardanoFeature (ScriptLanguageInEra SimpleScriptV2) where
+  featureInCardanoEra = \case
+    AllegraEra -> Just SimpleScriptV2InAllegra
+    MaryEra -> Just SimpleScriptV2InMary
+    AlonzoEra -> Just SimpleScriptV2InAlonzo
+    BabbageEra -> Just SimpleScriptV2InBabbage
+    _ -> Nothing
+  cardanoEraOfFeature = \case
+    SimpleScriptV2InAllegra -> AllegraEra
+    SimpleScriptV2InMary -> MaryEra
+    SimpleScriptV2InAlonzo -> AlonzoEra
+    SimpleScriptV2InBabbage -> BabbageEra
+
+instance ShelleyFeature (ScriptLanguageInEra SimpleScriptV2) where
+  shelleyBasedEraOfFeature = \case
+    SimpleScriptV2InAllegra -> ShelleyBasedEraAllegra
+    SimpleScriptV2InMary -> ShelleyBasedEraMary
+    SimpleScriptV2InAlonzo -> ShelleyBasedEraAlonzo
+    SimpleScriptV2InBabbage -> ShelleyBasedEraBabbage
+
+instance CardanoFeature (ScriptLanguageInEra PlutusScriptV1) where
+  featureInCardanoEra = \case
+    AlonzoEra -> Just PlutusScriptV1InAlonzo
+    BabbageEra -> Just PlutusScriptV1InBabbage
+    _ -> Nothing
+  cardanoEraOfFeature = \case
+    PlutusScriptV1InAlonzo -> AlonzoEra
+    PlutusScriptV1InBabbage -> BabbageEra
+
+instance ShelleyFeature (ScriptLanguageInEra PlutusScriptV1) where
+  shelleyBasedEraOfFeature = \case
+    PlutusScriptV1InAlonzo -> ShelleyBasedEraAlonzo
+    PlutusScriptV1InBabbage -> ShelleyBasedEraBabbage
+
+instance CardanoFeature (ScriptLanguageInEra PlutusScriptV2) where
+  featureInCardanoEra = \case
+    BabbageEra -> Just PlutusScriptV2InBabbage
+    _ -> Nothing
+  cardanoEraOfFeature = \case
+    PlutusScriptV2InBabbage -> BabbageEra
+
+instance ShelleyFeature (ScriptLanguageInEra PlutusScriptV2) where
+  shelleyBasedEraOfFeature = \case
+    PlutusScriptV2InBabbage -> ShelleyBasedEraBabbage
+
+hush :: Either a b -> Maybe b
+hush = either (const Nothing) Just
+
+whine :: Either a b -> Maybe a
+whine = either Just (const Nothing)
+
+castInShelleyBasedEra :: (ShelleyFeature f, ShelleyFeature g) => f era -> Maybe (g era)
+castInShelleyBasedEra = featureInShelleyBasedEra . shelleyBasedEraOfFeature
+
+castInCardanoEra :: (CardanoFeature f, CardanoFeature g) => f era -> Maybe (g era)
+castInCardanoEra = featureInCardanoEra . cardanoEraOfFeature

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -280,7 +280,7 @@ data WalletContext = WalletContext
 
 -- | Data from Marlowe Scripts needed to solve the constraints.
 data MarloweContext v = MarloweContext
-  { stakeCredential :: Maybe Chain.Credential
+  { stakeCredential :: Maybe Chain.StakeCredential
   -- ^ The stake credential to use when building a new marlowe script address.
   , scriptOutput :: Maybe (Core.TransactionScriptOutput v)
   -- ^ The UTXO at the script address, if any.

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
@@ -72,6 +72,8 @@
           ];
         buildable = true;
         modules = [
+          "Language/Marlowe/Runtime/Cardano/Api"
+          "Language/Marlowe/Runtime/Cardano/Feature"
           "Language/Marlowe/Runtime/ChainSync"
           "Language/Marlowe/Runtime/ChainSync/Database"
           "Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
@@ -72,6 +72,8 @@
           ];
         buildable = true;
         modules = [
+          "Language/Marlowe/Runtime/Cardano/Api"
+          "Language/Marlowe/Runtime/Cardano/Feature"
           "Language/Marlowe/Runtime/ChainSync"
           "Language/Marlowe/Runtime/ChainSync/Database"
           "Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL"

--- a/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-windows/.plan.nix/marlowe-chain-sync.nix
@@ -72,6 +72,8 @@
           ];
         buildable = true;
         modules = [
+          "Language/Marlowe/Runtime/Cardano/Api"
+          "Language/Marlowe/Runtime/Cardano/Feature"
           "Language/Marlowe/Runtime/ChainSync"
           "Language/Marlowe/Runtime/ChainSync/Database"
           "Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL"


### PR DESCRIPTION
Especially in transaction creation, we need to convert a lot between cardano API types and chain sync types. It's time we collected the functionality for doing so in a single location.

Since some of the types are era-dependent (further, they are feature-dependent), there are two ways to convert: regular conversion (via `HasCardanoType`) and feature-dependent conversion (via `HasFeatureDependentCardanoType`).

The `Feature` module abstracts away a lot of boilerplate that arises from using these era-dependent feature-proof objects. Now we can cast easily between them, extract the cardano era or shelley-based era, and try and obtain them from the era objects.