### PR TITLE
Use correct type for redeemer

### DIFF
--- a/marlowe-runtime/cli/Language/Marlowe/Runtime/CLI/Command/Apply.hs
+++ b/marlowe-runtime/cli/Language/Marlowe/Runtime/CLI/Command/Apply.hs
@@ -15,6 +15,7 @@ import Language.Marlowe.Runtime.CLI.Monad (CLI)
 import Language.Marlowe.Runtime.CLI.Option (txOutRefParser)
 import Language.Marlowe.Runtime.ChainSync.Api (unPolicyId)
 import Language.Marlowe.Runtime.Core.Api (ContractId(..), IsMarloweVersion(..), MarloweVersionTag(..))
+import qualified Language.Marlowe.Scripts as V1
 import qualified Language.Marlowe.Util as V1
 import Options.Applicative
 import qualified Plutus.V1.Ledger.Api as P
@@ -127,7 +128,7 @@ singleInputParser verb contentParser = info (txCommandParser parser)
       <*> validityLowerBoundParser
       <*> validityUpperBoundParser
     inputParser = do
-      content <- V1.NormalInput <$> contentParser
+      content <- V1.Input <$> contentParser
       mContinuation <- optional continuationParser
       pure case mContinuation of
         Nothing -> ContractInputsByValue [content]

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
@@ -54,6 +54,7 @@ import Language.Marlowe.Runtime.Core.Api
 import Language.Marlowe.Runtime.Core.ScriptRegistry (MarloweScripts(..), currentV1Scripts)
 import Language.Marlowe.Runtime.History.Api
 import Language.Marlowe.Runtime.History.Follower
+import qualified Language.Marlowe.Scripts as V1
 import qualified Plutus.V1.Ledger.Value as Plutus
 import qualified PlutusTx.AssocMap as AMap
 import Test.Hspec (Expectation, Spec, it, shouldBe)
@@ -177,8 +178,8 @@ closeTxIn =
   in
     Chain.TransactionInput createTxId 0 testScriptAddress (Just $ toDatum createDatum) redeemer
 
-closeRedeemer :: [V1.Input]
-closeRedeemer = [ V1.NormalInput V1.INotify ]
+closeRedeemer :: V1.MarloweInput
+closeRedeemer = [ V1.Input V1.INotify ]
 
 closeTxId :: TxId
 closeTxId = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -195,7 +196,7 @@ closeTx =
   in
     Chain.Transaction{..}
 
-applyInputsRedeemer :: [V1.Input]
+applyInputsRedeemer :: V1.MarloweInput
 applyInputsRedeemer = []
 
 applyInputsTxIn :: Chain.TransactionInput

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
@@ -41,6 +41,7 @@ import Language.Marlowe.Runtime.ChainSync.Api
   )
 import Language.Marlowe.Runtime.Core.Api
 import Language.Marlowe.Runtime.History.Api
+import Language.Marlowe.Scripts (marloweTxInputsFromInputs)
 import Numeric.Natural (Natural)
 import qualified Plutus.V1.Ledger.Api as P
 import qualified PlutusTx.AssocMap as AM
@@ -348,7 +349,7 @@ genApplyInputsV1 payoutAddress blockHeader contractId TransactionScriptOutput{..
       , blockHeader
       , validityLowerBound = posixSecondsToUTCTime $ secondsToNominalDiffTime $ fromIntegral vLow / 1000
       , validityUpperBound = posixSecondsToUTCTime $ secondsToNominalDiffTime $ fromIntegral vLow / 1000
-      , redeemer = inputs
+      , redeemer = marloweTxInputsFromInputs inputs
       , output
       }
 


### PR DESCRIPTION
This PR fixes the type we use for the Redeemer in the Runtime for V1. It was incorrectly using `[Input]` when it needed to use `MarloweInput`.