### PR TITLE
Marlowe CLI and Marlowe Runtime on mainnet

### DIFF
--- a/marlowe-cli/src/Language/Marlowe/CLI/Command.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command.hs
@@ -159,5 +159,5 @@ versionOption :: String            -- ^ The tool version.
               -> O.Parser (a -> a) -- ^ The option parseCommand.
 versionOption version =
   O.infoOption
-    ("marlowe-cli " <> version)
+    ("marlowe-cli " <> version <> " «mainnet»")
     (O.long "version" <> O.help "Show version.")

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Contract.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Contract.hs
@@ -155,7 +155,7 @@ exportMarloweOptions :: O.Mod O.OptionFields NetworkId
                      -> O.Parser ContractCommand
 exportMarloweOptions network =
   Export
-    <$> O.option parseNetworkId                            (O.long "testnet-magic"  <> O.metavar "INTEGER"         <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value.")
+    <$> parseNetworkId network
     <*> (O.optional . O.option parseStakeAddressReference) (O.long "stake-address"  <> O.metavar "ADDRESS"                    <> O.help "Stake address, if any."                                                            )
     <*> (O.optional . O.option parseCurrencySymbol)        (O.long "roles-currency" <> O.metavar "CURRENCY_SYMBOL"            <> O.help "The currency symbol for roles, if any."                                            )
     <*> protocolVersionOpt
@@ -180,7 +180,7 @@ exportAddressOptions :: O.Mod O.OptionFields NetworkId
                      -> O.Parser ContractCommand
 exportAddressOptions network =
   ExportAddress
-    <$> O.option parseNetworkId                            (O.long "testnet-magic"  <> O.metavar "INTEGER" <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value.")
+    <$> parseNetworkId network
     <*> (O.optional . O.option parseStakeAddressReference) (O.long "stake-address"  <> O.metavar "ADDRESS"            <> O.help "Stake address, if any."                                                            )
 
 
@@ -198,7 +198,7 @@ exportValidatorOptions :: O.Mod O.OptionFields NetworkId
                        -> O.Parser ContractCommand
 exportValidatorOptions network =
   ExportValidator
-    <$> O.option parseNetworkId                            (O.long "testnet-magic"  <> O.metavar "INTEGER"     <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value.")
+    <$> parseNetworkId network
     <*> (O.optional . O.option parseStakeAddressReference) (O.long "stake-address"  <> O.metavar "ADDRESS"                <> O.help "Stake address, if any."                                                            )
     <*> protocolVersionOpt
     <*> (O.optional . O.strOption)                         (O.long "out-file"       <> O.metavar "OUTPUT_FILE"            <> O.help "JSON output file for validator."                                                   )

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Parse.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Parse.hs
@@ -111,8 +111,12 @@ import Plutus.V1.Ledger.ProtocolVersions (alonzoPV, vasilPV)
 
 
 -- | Parser for network ID.
-parseNetworkId :: O.ReadM NetworkId
-parseNetworkId = Testnet . NetworkMagic . toEnum <$> O.auto
+parseNetworkId :: O.Mod O.OptionFields NetworkId -> O.Parser NetworkId
+parseNetworkId network =
+  parseMainnet <|> parseTestnet
+    where
+      parseMainnet = O.flag' Mainnet (O.long "mainnet" <> O.help "Execute on mainnet.")
+      parseTestnet = O.option (Testnet . NetworkMagic . toEnum <$> O.auto) (O.long "testnet-magic" <> O.metavar "INTEGER" <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value.")
 
 
 -- | Parser for stake address reference.

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Role.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Role.hs
@@ -124,7 +124,7 @@ exportAddressOptions :: O.Mod O.OptionFields NetworkId
                      -> O.Parser RoleCommand
 exportAddressOptions network =
   ExportAddress
-    <$> O.option parseNetworkId                            (O.long "testnet-magic"  <> O.metavar "INTEGER" <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value.")
+    <$> parseNetworkId network
     <*> (O.optional . O.option parseStakeAddressReference) (O.long "stake-address"  <> O.metavar "ADDRESS"            <> O.help "Stake address, if any."                                                            )
 
 
@@ -142,7 +142,7 @@ exportValidatorOptions :: O.Mod O.OptionFields NetworkId
                        -> O.Parser RoleCommand
 exportValidatorOptions network =
   ExportValidator
-    <$> O.option parseNetworkId                            (O.long "testnet-magic"    <> O.metavar "INTEGER"     <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value.")
+    <$> parseNetworkId network
     <*> (O.optional . O.option parseStakeAddressReference) (O.long "stake-address"    <> O.metavar "ADDRESS"                <> O.help "Stake address, if any."                                                            )
     <*> protocolVersionOpt
     <*> (O.optional . O.strOption)                         (O.long "out-file"         <> O.metavar "OUTPUT_FILE"            <> O.help "JSON output file for validator."                                                   )

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Run.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Run.hs
@@ -33,8 +33,10 @@ import Cardano.Api
   , NetworkId(..)
   , StakeAddressReference(..)
   , TxIn
+  , serialiseToRawBytesHex
   )
 import Control.Monad.Except (MonadError, MonadIO, liftIO)
+import Control.Monad.Reader (MonadReader)
 import Data.Foldable (asum)
 import Data.Maybe (fromMaybe)
 import Language.Marlowe.CLI.Analyze (analyze)
@@ -52,6 +54,7 @@ import Language.Marlowe.CLI.Command.Parse
   , requiredSignersOpt
   , txBodyFileOpt
   )
+import Language.Marlowe.CLI.IO (getDefaultCostModel, getProtocolVersion)
 import Language.Marlowe.CLI.Run
   (autoRunTransaction, autoWithdrawFunds, initializeTransaction, prepareTransaction, runTransaction, withdrawFunds)
 import Language.Marlowe.CLI.Transaction (querySlotConfig)
@@ -63,8 +66,7 @@ import Plutus.V1.Ledger.Api (CurrencySymbol, POSIXTime(..), TokenName)
 
 import qualified Cardano.Api as Api (Value)
 import qualified Cardano.Api as C
-import Control.Monad.Reader (MonadReader)
-import Language.Marlowe.CLI.IO (getDefaultCostModel, getProtocolVersion)
+import qualified Data.ByteString.Char8 as BS8
 import qualified Options.Applicative as O
 
 
@@ -197,7 +199,7 @@ runRunCommand command =
         }
       marloweParams' = maybe defaultMarloweParams marloweParams $ rolesCurrency command
       stake'         = fromMaybe NoStakeAddress $ stake command
-      printTxId = liftIO . putStrLn . ("TxId " <>) . show
+      printTxId = liftIO . BS8.putStrLn . serialiseToRawBytesHex
       padTxOut (address, value) = (address, Nothing, value)
       outputs' = padTxOut <$> outputs command
     case command of

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Test.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Test.hs
@@ -82,7 +82,7 @@ scriptsOptions :: IsShelleyBasedEra era
                -> O.Parser (TestCommand era)
 scriptsOptions network socket =
   ScriptTests
-    <$> O.option parseNetworkId  (O.long "testnet-magic"  <> O.metavar "INTEGER"      <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value."                              )
+    <$> parseNetworkId network
     <*> O.strOption              (O.long "socket-path"    <> O.metavar "SOCKET_FILE"  <> socket  <> O.help "Location of the cardano-node socket file. Defaults to the CARDANO_NODE_SOCKET_PATH environment variable's value.")
     <*> O.strOption              (O.long "faucet-key"     <> O.metavar "SIGNING_FILE"            <> O.help "The file containing the signing key for the faucet."                                                             )
     <*> O.option parseAddress    (O.long "faucet-address" <> O.metavar "ADDRESS"                 <> O.help "The address of the faucet."                                                                                      )

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Transaction.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Transaction.hs
@@ -35,8 +35,10 @@ import Cardano.Api
   , NetworkId(..)
   , SlotNo
   , TxIn
+  , serialiseToRawBytesHex
   )
 import Control.Monad.Except (MonadError, MonadIO, liftIO)
+import Control.Monad.Reader.Class (MonadReader)
 import Data.Maybe (fromMaybe)
 import Language.Marlowe.CLI.Command.Parse
   ( parseAddress
@@ -56,7 +58,7 @@ import Language.Marlowe.CLI.Types
   (CliEnv, CliError, PrintStats(PrintStats), PublishingStrategy, SigningKeyFile, TxBodyFile(TxBodyFile))
 
 import qualified Cardano.Api as Api (Value)
-import Control.Monad.Reader.Class (MonadReader)
+import qualified Data.ByteString.Char8 as BS8
 import qualified Options.Applicative as O
 
 
@@ -188,7 +190,7 @@ runTransactionCommand command =
         , localNodeNetworkId       = network'
         , localNodeSocketPath      = socketPath command
         }
-      printTxId = liftIO . putStrLn . ("TxId " <>) . show
+      printTxId = liftIO . BS8.putStrLn . serialiseToRawBytesHex
       padTxOut (address, value) = (address, Nothing, value)
       outputs' = padTxOut <$> outputs command
     case command of

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Util.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Util.hs
@@ -294,7 +294,7 @@ cleanCommand network socket =
 cleanOptions :: IsShelleyBasedEra era => O.Mod O.OptionFields NetworkId -> O.Mod O.OptionFields FilePath -> O.Parser (UtilCommand era)
 cleanOptions network socket =
   Clean
-    <$> O.option parseNetworkId           (O.long "testnet-magic"   <> network           <> O.metavar "INTEGER"      <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value."                              )
+    <$> parseNetworkId network
     <*> O.strOption                       (O.long "socket-path"     <> socket            <> O.metavar "SOCKET_FILE"  <> O.help "Location of the cardano-node socket file. Defaults to the CARDANO_NODE_SOCKET_PATH environment variable's value.")
     <*> requiredSignersOpt
 
@@ -317,7 +317,7 @@ mintCommand network socket =
 mintOptions :: IsShelleyBasedEra era => O.Mod O.OptionFields NetworkId -> O.Mod O.OptionFields FilePath -> O.Parser (UtilCommand era)
 mintOptions network socket =
   Mint
-    <$> O.option parseNetworkId              (O.long "testnet-magic"   <> O.metavar "INTEGER"      <> network            <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value."                              )
+    <$> parseNetworkId network
     <*> O.strOption                          (O.long "socket-path"     <> O.metavar "SOCKET_FILE"  <> socket             <> O.help "Location of the cardano-node socket file. Defaults to the CARDANO_NODE_SOCKET_PATH environment variable's value.")
     <*> walletOpt                            (O.long "issuer"          <> O.metavar "ADDRESS:SIGNING_FILE"               <> O.help "Issuer wallet info")
     <*> tokenProviderOpt
@@ -355,7 +355,7 @@ burnCommand network socket =
 burnOptions :: IsShelleyBasedEra era => O.Mod O.OptionFields NetworkId -> O.Mod O.OptionFields FilePath -> O.Parser (UtilCommand era)
 burnOptions network socket =
   Burn
-    <$> O.option parseNetworkId              (O.long "testnet-magic"   <> O.metavar "INTEGER"      <> network            <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value."                              )
+    <$> parseNetworkId network
     <*> O.strOption                          (O.long "socket-path"     <> O.metavar "SOCKET_FILE"  <> socket             <> O.help "Location of the cardano-node socket file. Defaults to the CARDANO_NODE_SOCKET_PATH environment variable's value.")
     <*> walletOpt                            (O.long "issuer"          <> O.metavar "ADDRESS:SIGNING_FILE"               <> O.help "Issuer wallet info")
 
@@ -384,7 +384,7 @@ fundAddressCommand network socket =
 fundAddressOptions :: IsShelleyBasedEra era => O.Mod O.OptionFields NetworkId -> O.Mod O.OptionFields FilePath -> O.Parser (UtilCommand era)
 fundAddressOptions network socket =
   Fund
-    <$> O.option parseNetworkId            (O.long "testnet-magic"   <> O.metavar "INTEGER"     <> network               <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value."                              )
+    <$> parseNetworkId network
     <*> O.strOption                        (O.long "socket-path"     <> O.metavar "SOCKET_FILE" <> socket                <> O.help "Location of the cardano-node socket file. Defaults to the CARDANO_NODE_SOCKET_PATH environment variable's value.")
     <*> (lovelaceOpt <|> sendAllOpt)
     <*> txBodyFileOpt
@@ -412,7 +412,7 @@ selectCommand network socket =
 selectOptions :: IsShelleyBasedEra era => O.Mod O.OptionFields NetworkId -> O.Mod O.OptionFields FilePath -> O.Parser (UtilCommand era)
 selectOptions network socket =
   Output
-    <$> O.option parseNetworkId    (O.long "testnet-magic" <> O.metavar "INTEGER"     <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value."                               )
+    <$> parseNetworkId network
     <*> O.strOption                (O.long "socket-path"   <> O.metavar "SOCKET_FILE" <> socket  <> O.help "Location of the cardano-node socket file. Defaults to the CARDANO_NODE_SOCKET_PATH environment variable's value." )
     <*> parseOutputQuery
     <*> O.argument parseAddress    (                          O.metavar "ADDRESS"                <> O.help "The address."                                                                                                     )
@@ -461,7 +461,7 @@ slottingCommand network socket =
 slottingOptions :: O.Mod O.OptionFields NetworkId -> O.Mod O.OptionFields FilePath -> O.Parser (UtilCommand era)
 slottingOptions network socket =
   Slotting
-    <$> O.option parseNetworkId   (O.long "testnet-magic" <> O.metavar "INTEGER"     <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value."                              )
+    <$> parseNetworkId network
     <*> O.strOption               (O.long "socket-path"   <> O.metavar "SOCKET_FILE" <> socket  <> O.help "Location of the cardano-node socket file. Defaults to the CARDANO_NODE_SOCKET_PATH environment variable's value.")
     <*> (O.optional .O.strOption) (O.long "out-file"      <> O.metavar "FILE"                   <> O.help "Output file for slot configuration."                                                                             )
 
@@ -478,7 +478,7 @@ watchCommand network socket =
 watchOptions :: O.Mod O.OptionFields NetworkId -> O.Mod O.OptionFields FilePath -> O.Parser (UtilCommand era)
 watchOptions network socket =
   Watch
-    <$> O.option parseNetworkId    (O.long "testnet-magic" <> O.metavar "INTEGER"     <> network <> O.help "Network magic. Defaults to the CARDANO_TESTNET_MAGIC environment variable's value."                              )
+    <$> parseNetworkId network
     <*> O.strOption                (O.long "socket-path"   <> O.metavar "SOCKET_FILE" <> socket  <> O.help "Location of the cardano-node socket file. Defaults to the CARDANO_NODE_SOCKET_PATH environment variable's value.")
     <*> O.switch                   (O.long "all"                                                 <> O.help "Whether to also output non-Marlowe transactions."                                                                )
     <*> O.switch                   (O.long "cbor"                                                <> O.help "Whether to output CBOR instead of JSON."                                                                         )

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Util.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Util.hs
@@ -39,8 +39,15 @@ import Cardano.Api
   , TxMetadataInEra(TxMetadataNone)
   , TxMintValue(TxMintNone)
   , lovelaceToValue
+  , serialiseToRawBytesHex
   )
+import Control.Applicative ((<|>))
+import Control.Category ((>>>))
 import Control.Monad.Except (MonadError, MonadIO, liftIO)
+import Control.Monad.Reader (MonadReader)
+import Data.List.Split (splitOn)
+import Data.Maybe (fromMaybe)
+import GHC.Natural (Natural)
 import Language.Marlowe.CLI.Codec (decodeBech32, encodeBech32)
 import Language.Marlowe.CLI.Command.Parse
   ( parseAddress
@@ -59,13 +66,8 @@ import Language.Marlowe.CLI.Transaction (buildClean, buildFaucet, buildMinting, 
 import Language.Marlowe.CLI.Types (CliEnv, CliError, OutputQuery, OutputQueryResult, SigningKeyFile, TxBodyFile)
 import Plutus.V1.Ledger.Api (TokenName)
 
-import Control.Applicative ((<|>))
-import Control.Category ((>>>))
-import Control.Monad.Reader (MonadReader)
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.List.NonEmpty as L
-import Data.List.Split (splitOn)
-import Data.Maybe (fromMaybe)
-import GHC.Natural (Natural)
 import qualified Options.Applicative as O
 import qualified Options.Applicative.NonEmpty as O
 
@@ -187,7 +189,7 @@ runUtilCommand command =
         , localNodeNetworkId       = network'
         , localNodeSocketPath      = socketPath command
         }
-      printTxId = liftIO . putStrLn . ("TxId " <>) . show
+      printTxId = liftIO . BS8.putStrLn . serialiseToRawBytesHex
     case command of
       Clean{..}        -> buildClean
                             connection

--- a/marlowe-cli/src/Language/Marlowe/CLI/Run.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Run.hs
@@ -968,7 +968,7 @@ marloweAddressToCardanoAddress network address =
     address' <-
       liftCli
         $ toCardanoAddressInEra
-          (if network == mainnet then Mainnet else Testnet (NetworkMagic 2))
+          (if network == mainnet then Mainnet else Testnet (NetworkMagic 1))
           address
     address'' <-
       case address' of

--- a/marlowe-cli/src/Language/Marlowe/CLI/Transaction.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Transaction.hs
@@ -198,7 +198,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson.Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS (length)
-import qualified Data.ByteString.Char8 as BS8 (unpack)
+import qualified Data.ByteString.Char8 as BS8 (pack, putStrLn, unpack)
 import Data.Fixed (div')
 import Data.Foldable (Foldable(fold), for_)
 import Data.Function (on)
@@ -584,7 +584,7 @@ buildMinting connection signingKeyFile mintingAction metadataFile expires change
     _                      -> throwError "Metadata should file should contain a json object"
   (body, policy) <- buildMintingImpl connection mintingAction' metadata expires timeout (PrintStats True)
   doWithCardanoEra $ liftCliIO $ writeFileTextEnvelope bodyFile Nothing body
-  liftIO . putStrLn $ "PolicyID " <> show policy
+  liftIO . BS8.putStrLn $ serialiseToRawBytesHex policy
 
 nonAdaValue :: Value -> Value
 nonAdaValue value = value <> C.negateValue (C.lovelaceToValue (fromMaybe 0 $ C.valueToLovelace value))
@@ -1679,7 +1679,7 @@ selectUtxos connection address query =
       Nothing     -> queryUtxos connection address
       Just query' -> oqrMatching <$> selectUtxosImpl connection address query'
     liftIO
-      . mapM_ (print . fst)
+      . mapM_ (\(TxIn txId txIx, _) -> BS8.putStrLn $ serialiseToRawBytesHex txId <> "#" <> BS8.pack (show $ fromEnum txIx))
       . M.toList
       . C.unUTxO
       $ matching

--- a/marlowe-runtime/marlowe-tx/Main.hs
+++ b/marlowe-runtime/marlowe-tx/Main.hs
@@ -3,11 +3,9 @@
 module Main
   where
 
-import Cardano.Api (NetworkId(Mainnet))
 import qualified Colog
 import Control.Concurrent.STM (atomically)
 import Control.Exception (bracket, bracketOnError, throwIO)
-import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Lazy as LB
 import Data.Either (fromRight)
@@ -79,7 +77,6 @@ import Options.Applicative
   , strOption
   , value
   )
-import System.Exit (die)
 
 main :: IO ()
 main = run =<< getOptions
@@ -142,8 +139,6 @@ run Options{..} = withSocketsDo do
       protocolParameters <- queryChainSync GetProtocolParameters
       slotConfig <- queryChainSync GetSlotConfig
       networkId <- queryChainSync GetNetworkId
-      when (networkId == Mainnet) do
-        die "Mainnet support is currently disabled."
       let
         solveConstraints :: SolveConstraints
         solveConstraints = Constraints.solveConstraints


### PR DESCRIPTION
This implements `marlowe-cli` and `marlowe` functionality required to run on `mainnet`:
- A new `--mainnet` flag wherever `--testnet-magic` was previously required.
- Flag to locate and use reference scripts in `marlowe-cli run auto-execute`.

It also simplifies the output of some `marlowe-cli` commands, so that `sed` is not needed to parse output.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
