### PR TITLE
SCP-4488 - Fix collision in default marlowe-tx command port argument

### DIFF
--- a/marlowe-runtime/config/Language/Marlowe/Runtime/CLI/Option.hs
+++ b/marlowe-runtime/config/Language/Marlowe/Runtime/CLI/Option.hs
@@ -43,7 +43,7 @@ txHost :: CliOption OptionFields HostName
 txHost = host "tx" "TX" "127.0.0.1" "The hostname of the Marlowe Runtime transaction server."
 
 txCommandPort :: CliOption OptionFields PortNumber
-txCommandPort = port "tx-command" "TX_COMMAND" 3720 "The port number of the transaction server's job API."
+txCommandPort = port "tx-command" "TX_COMMAND" 3723 "The port number of the transaction server's job API."
 
 port :: String -> String -> PortNumber -> String -> CliOption OptionFields PortNumber
 port optPrefix envPrefix defaultValue description = CliOption

--- a/marlowe-runtime/marlowe-tx/Main.hs
+++ b/marlowe-runtime/marlowe-tx/Main.hs
@@ -225,7 +225,7 @@ getOptions = execParser $ info (helper <*> parser) infoMod
 
     portParser = option auto $ mconcat
       [ long "command-port"
-      , value 3720
+      , value 3723
       , metavar "PORT_NUMBER"
       , help "The port number to run the job server on."
       , showDefault


### PR DESCRIPTION
Changed default for `--command-port` from `3720` to `3723` to avoid clash with chain seek's command port.

Updated Marlowe Runtime Client default port to match too

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
