### PR TITLE
Added a create test with many utxos in the party addresses

### DIFF
--- a/marlowe-cli/flake.lock
+++ b/marlowe-cli/flake.lock
@@ -3119,13 +3119,12 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-vG8ve4NzWlhaNCItzT6k9JI4gvwG76eqEulraJ5hvng=",
-        "path": "/nix/store/ix53xr3bmadbjgl1pwhyipg17xj8a7ji-source",
+        "narHash": "sha256-efcYL3ORB96gbdtmrJwkrTEvLxlhsumBI2w5m9mZf5w=",
+        "path": "/nix/store/qlkb6sj0s4i0yxk98rs3qh24q930j8cq-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/ix53xr3bmadbjgl1pwhyipg17xj8a7ji-source",
+        "path": "/nix/store/qlkb6sj0s4i0yxk98rs3qh24q930j8cq-source",
         "type": "path"
       }
     },

--- a/marlowe-runtime/examples/create-many-utxos.ipynb
+++ b/marlowe-runtime/examples/create-many-utxos.ipynb
@@ -97,7 +97,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "e32278fd9df35ae67e3851b86eea5f355e6912ca\n"
+      "29b88a702ce12bc5d01f06deb346b99de6228a79\n"
      ]
     }
    ],
@@ -151,7 +151,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "addr_test1vq2a4cdym9mn38nf894p5sjqurns4ehjm3pt5t8l4djcnzqjzztcr\n"
+      "addr_test1vqzfwa5e8uvwj7kxz97kz3fzmxnrrpw4l7x02x5z7rauwdqv8gezt\n"
      ]
     }
    ],
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "ced2a30e-b2ba-435a-9199-bcfa0d6a8cf4",
    "metadata": {},
    "outputs": [
@@ -198,14 +198,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--testnet-magic 2\n"
+      "--testnet-magic 1\n"
      ]
     }
    ],
    "source": [
-    "export CARDANO_NODE_SOCKET_PATH=/tmp/preview.socket\n",
-    "export CARDANO_TESTNET_MAGIC=2\n",
-    "MAGIC=(--testnet-magic 2)\n",
+    "export CARDANO_NODE_SOCKET_PATH=/tmp/preprod.socket\n",
+    "export CARDANO_TESTNET_MAGIC=1\n",
+    "MAGIC=(--testnet-magic 1)\n",
     "echo \"${MAGIC[@]}\""
    ]
   },
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "eb29caeb-c563-4e7d-922a-b5350642cc0f",
    "metadata": {},
    "outputs": [
@@ -246,11 +246,11 @@
       "{\n",
       "    \"marlowe\": {\n",
       "        \"hash\": \"6a9391d6aa51af28dd876ebb5565b69d1e83e5ac7861506bd29b56b0\",\n",
-      "        \"txIn\": \"087f21f109a997193421a81886ea8c6397d336d19e696457b9c5c7aefdc31873#1\"\n",
+      "        \"txIn\": \"d1e488d70850fc36ef6971a65d1f45e2a7a433e4080e4c5c580d0b23094a955e#1\"\n",
       "    },\n",
       "    \"payout\": {\n",
       "        \"hash\": \"49076eab20243dc9462511fb98a9cfb719f86e9692288139b7c91df3\",\n",
-      "        \"txIn\": \"087f21f109a997193421a81886ea8c6397d336d19e696457b9c5c7aefdc31873#2\"\n",
+      "        \"txIn\": \"d1e488d70850fc36ef6971a65d1f45e2a7a433e4080e4c5c580d0b23094a955e#2\"\n",
       "    }\n",
       "}\n"
      ]
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "009fed78-8410-4894-b904-d6ea92982d70",
    "metadata": {},
    "outputs": [],
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "0de60d98-b79e-43fc-8c7d-fd494c76390d",
    "metadata": {},
    "outputs": [
@@ -305,7 +305,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n"
+      "addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\n"
      ]
     }
    ],
@@ -328,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "ff90fa3f-1422-4632-abb7-19c5e5b5d2ed",
    "metadata": {},
    "outputs": [
@@ -336,9 +336,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"901e0dd34ce83ee5fe9ac7ee9c3cd541a6f9fb50816cf77e1f6b69e7e9c9d278\"\n",
-      "TxId \"d2da99fecb533030a2f3b1e367534a46b8f7031dcdd2a7d14b489ea9f232548c\"\n",
-      "TxId \"28d0b542da9d895693e5f4f1ca4c84ec7cfb9f7dac52c96683c4e01e7a27e212\"\n"
+      "TxId \"306f4f6bed4d061fd659f2eb7e922f0b7aa5da0eeddadab50aae0ac951627901\"\n",
+      "TxId \"6be5dfb310ad084988fc52e1bb2fd328f955af5a771b4dd4d2dc928e3101ff50\"\n",
+      "TxId \"45752a27db8d80480f433675778b97bfa8aaf6c531589c7a0f13345145876aff\"\n"
      ]
     }
    ],
@@ -373,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "359d2b9b-9bc3-4688-9689-9ef2c69cd382",
    "metadata": {},
    "outputs": [],
@@ -392,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "c4297420-6c47-4716-bbb3-c5bb0be2ef9a",
    "metadata": {},
    "outputs": [
@@ -400,7 +400,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n"
+      "addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\n"
      ]
     }
    ],
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "77bc9000-d2e3-4996-a2ae-a7d0c625aa70",
    "metadata": {},
    "outputs": [
@@ -431,9 +431,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"a3998f765792b3bf1072d6d44c1ed7ed203a4f8ad8009ea50c6ee053af9c70e6\"\n",
-      "TxId \"f5dbc7da24999a8a15bae201a5fb0589739f5d17ae70dc4fad0b8fa8b75eda4f\"\n",
-      "TxId \"511ced5ba47ac824da39fdd859114375ee9c9b109f6040c365e369489cbacb29\"\n"
+      "TxId \"a4a687abfb4a5eae5b7aa7b0a6b254d0e3c012b464b7a600fc7db4df1f2e4de9\"\n",
+      "TxId \"951408cd902f5fb249bb9c2a5926bfe17a4cef7034c0c508fefa296d9e54083d\"\n",
+      "TxId \"4dbf4856e02f2f236380a5dbde5232db81915113b0d4c63d589cc47f2d976dca\"\n"
      ]
     }
    ],
@@ -470,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "15b80716-4545-4558-825f-9d0dda82f8d5",
    "metadata": {},
    "outputs": [],
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "id": "359b6f47-e0d1-4f84-8812-b96cfa361c2d",
    "metadata": {},
    "outputs": [
@@ -489,7 +489,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1667227307000\n"
+      "1667313899000\n"
      ]
     }
    ],
@@ -516,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "id": "c5845b3d-12cf-47f0-a53c-0da3e4fe89f2",
    "metadata": {
     "tags": []
@@ -536,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "id": "ece6fd44-d1ea-44b6-a8e4-240c4549417c",
    "metadata": {},
    "outputs": [
@@ -544,7 +544,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"accruedInterest\":0,\"collateralAmount\":0,\"contractId\":\"0\",\"contractPerformance\":\"PF\",\"contractRole\":\"RPA\",\"contractType\":\"PAM\",\"cycleAnchorDateOfInterestPayment\":\"2023-01-01T00:00:00\",\"cycleOfInterestPayment\":\"P1YL1\",\"dayCountConvention\":\"30E360\",\"enableSettlement\":false,\"initialExchangeDate\":\"2023-01-01T00:00:00\",\"interestCalculationBase\":\"NT\",\"maturityDate\":\"2024-01-01T00:00:00\",\"nominalInterestRate\":0.02,\"notionalPrincipal\":100,\"penaltyType\":\"O\",\"prepaymentEffect\":\"N\",\"scheduleConfig\":{\"businessDayConvention\":\"NULL\",\"calendar\":\"NC\",\"endOfMonthConvention\":\"EOM\"},\"statusDate\":\"2022-10-31T00:00:00\"}\n"
+      "{\"accruedInterest\":0,\"collateralAmount\":0,\"contractId\":\"0\",\"contractPerformance\":\"PF\",\"contractRole\":\"RPA\",\"contractType\":\"PAM\",\"cycleAnchorDateOfInterestPayment\":\"2023-01-01T00:00:00\",\"cycleOfInterestPayment\":\"P1YL1\",\"dayCountConvention\":\"30E360\",\"enableSettlement\":false,\"initialExchangeDate\":\"2023-01-01T00:00:00\",\"interestCalculationBase\":\"NT\",\"maturityDate\":\"2024-01-01T00:00:00\",\"nominalInterestRate\":0.02,\"notionalPrincipal\":100,\"penaltyType\":\"O\",\"prepaymentEffect\":\"N\",\"scheduleConfig\":{\"businessDayConvention\":\"NULL\",\"calendar\":\"NC\",\"endOfMonthConvention\":\"EOM\"},\"statusDate\":\"2022-11-01T00:00:00\"}\n"
      ]
     }
    ],
@@ -586,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "id": "028339ed-6d5e-4e71-9895-3a965a0252c9",
    "metadata": {},
    "outputs": [],
@@ -610,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "id": "d131f130-aca6-4a31-9890-761a1827f5d8",
    "metadata": {},
    "outputs": [],
@@ -631,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "id": "661bb16a-2739-4354-a796-bbaedf39f698",
    "metadata": {},
    "outputs": [
@@ -639,7 +639,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "timeout: 1667227907000\n",
+      "timeout: 1667314499000\n",
       "timeout_continuation: close\n",
       "when:\n",
       "- case:\n",
@@ -647,66 +647,66 @@
       "      negate:\n",
       "        negate: 100000000\n",
       "    into_account:\n",
-      "      address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
+      "      address: addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\n",
       "    of_token:\n",
       "      currency_symbol: ''\n",
       "      token_name: ''\n",
       "    party:\n",
-      "      address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
+      "      address: addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\n",
       "  then:\n",
       "    from_account:\n",
-      "      address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
+      "      address: addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\n",
       "    pay: 100000000\n",
       "    then:\n",
-      "      timeout: 1667228207000\n",
+      "      timeout: 1667314799000\n",
       "      timeout_continuation: close\n",
       "      when:\n",
       "      - case:\n",
       "          deposits: 2000000\n",
       "          into_account:\n",
-      "            address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
+      "            address: addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\n",
       "          of_token:\n",
       "            currency_symbol: ''\n",
       "            token_name: ''\n",
       "          party:\n",
-      "            address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
+      "            address: addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\n",
       "        then:\n",
       "          from_account:\n",
-      "            address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
+      "            address: addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\n",
       "          pay: 2000000\n",
       "          then:\n",
-      "            timeout: 1667228207000\n",
+      "            timeout: 1667314799000\n",
       "            timeout_continuation: close\n",
       "            when:\n",
       "            - case:\n",
       "                deposits: 100000000\n",
       "                into_account:\n",
-      "                  address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
+      "                  address: addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\n",
       "                of_token:\n",
       "                  currency_symbol: ''\n",
       "                  token_name: ''\n",
       "                party:\n",
-      "                  address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
+      "                  address: addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\n",
       "              then:\n",
       "                from_account:\n",
-      "                  address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
+      "                  address: addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\n",
       "                pay: 100000000\n",
       "                then: close\n",
       "                to:\n",
       "                  party:\n",
-      "                    address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
+      "                    address: addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\n",
       "                token:\n",
       "                  currency_symbol: ''\n",
       "                  token_name: ''\n",
       "          to:\n",
       "            party:\n",
-      "              address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
+      "              address: addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\n",
       "          token:\n",
       "            currency_symbol: ''\n",
       "            token_name: ''\n",
       "    to:\n",
       "      party:\n",
-      "        address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
+      "        address: addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\n",
       "    token:\n",
       "      currency_symbol: ''\n",
       "      token_name: ''\n"
@@ -743,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "id": "b0c60ede-d8c6-47f9-adcd-d3245ef60467",
    "metadata": {},
    "outputs": [
@@ -753,10 +753,9 @@
      "text": [
       "                           TxHash                                 TxIx        Amount\n",
       "--------------------------------------------------------------------------------------\n",
-      "28d0b542da9d895693e5f4f1ca4c84ec7cfb9f7dac52c96683c4e01e7a27e212     1        70000000 lovelace + TxOutDatumNone\n",
-      "856c37eacf8d3cd9091e5277c238fad7b20223af23ad4cd5dc82cc2abf20e886     1        250000000 lovelace + TxOutDatumNone\n",
-      "901e0dd34ce83ee5fe9ac7ee9c3cd541a6f9fb50816cf77e1f6b69e7e9c9d278     1        250000000 lovelace + TxOutDatumNone\n",
-      "d2da99fecb533030a2f3b1e367534a46b8f7031dcdd2a7d14b489ea9f232548c     1        140000000 lovelace + TxOutDatumNone\n"
+      "306f4f6bed4d061fd659f2eb7e922f0b7aa5da0eeddadab50aae0ac951627901     1        250000000 lovelace + TxOutDatumNone\n",
+      "45752a27db8d80480f433675778b97bfa8aaf6c531589c7a0f13345145876aff     1        70000000 lovelace + TxOutDatumNone\n",
+      "6be5dfb310ad084988fc52e1bb2fd328f955af5a771b4dd4d2dc928e3101ff50     1        140000000 lovelace + TxOutDatumNone\n"
      ]
     }
    ],
@@ -774,7 +773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "id": "142661e5-a5b3-4e48-9d02-d5aca344d2e2",
    "metadata": {},
    "outputs": [
@@ -782,7 +781,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CONTRACT_ID = 26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3#1\n"
+      "CONTRACT_ID = f06e4b760f2d9578c8088ea5289ba6276e68ae3cbaf5ad27bcfc77dc413890db#1\n"
      ]
     }
    ],
@@ -809,7 +808,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "id": "5d4c94bc-d747-47c6-be60-55656a3ee6ca",
    "metadata": {},
    "outputs": [],
@@ -830,7 +829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "id": "04ff93e3-b751-440a-b310-12ebe095401a",
    "metadata": {},
    "outputs": [
@@ -838,7 +837,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"{\\\"blockHeaderHash\\\":\\\"a1cd017668e7a4f8b06904bec8c9b81341254e09d7fbdc22ab893a78961556f9\\\",\\\"blockNo\\\":333672,\\\"slotNo\\\":7224134}\"\n"
+      "\"{\\\"blockHeaderHash\\\":\\\"f729f57b3bd99dd1d55a5a65b8c74f459dadae784dd55536444770dd2c2cdd2e\\\",\\\"blockNo\\\":224384,\\\"slotNo\\\":11630746}\"\n"
      ]
     }
    ],
@@ -856,7 +855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "id": "0e4ceeb0-350f-464b-86ea-e36b98ec06ff",
    "metadata": {},
    "outputs": [
@@ -864,7 +863,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3#1\n"
+      "f06e4b760f2d9578c8088ea5289ba6276e68ae3cbaf5ad27bcfc77dc413890db#1\n"
      ]
     }
    ],
@@ -874,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "id": "f02d9dbb-91a5-4290-ac3b-0d32030cddff",
    "metadata": {},
    "outputs": [
@@ -882,43 +881,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[93mtransaction 26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3 (creation)\n",
-      "\u001b[0mContractId:      26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3#1\n",
-      "SlotNo:          7224134\n",
-      "BlockNo:         333672\n",
-      "BlockId:         a1cd017668e7a4f8b06904bec8c9b81341254e09d7fbdc22ab893a78961556f9\n",
+      "\u001b[93mtransaction f06e4b760f2d9578c8088ea5289ba6276e68ae3cbaf5ad27bcfc77dc413890db (creation)\n",
+      "\u001b[0mContractId:      f06e4b760f2d9578c8088ea5289ba6276e68ae3cbaf5ad27bcfc77dc413890db#1\n",
+      "SlotNo:          11630746\n",
+      "BlockNo:         224384\n",
+      "BlockId:         f729f57b3bd99dd1d55a5a65b8c74f459dadae784dd55536444770dd2c2cdd2e\n",
       "ScriptAddress:   addr_test1wp4f8ywk4fg672xasahtk4t9k6w3aql943uxz5rt62d4dvqu3c6jv\n",
       "Marlowe Version: 1\n",
       "\n",
       "    When [\n",
       "      (Case\n",
-      "         (Deposit Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\" Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\"\n",
+      "         (Deposit Address \"addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\" Address \"addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\"\n",
       "            (Token \"\" \"\")\n",
       "            (NegValue\n",
       "               (NegValue\n",
       "                  (Constant 100000000))))\n",
-      "         (Pay Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\"\n",
-      "            (Party Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\")\n",
+      "         (Pay Address \"addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\"\n",
+      "            (Party Address \"addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\")\n",
       "            (Token \"\" \"\")\n",
       "            (Constant 100000000)\n",
       "            (When [\n",
       "               (Case\n",
-      "                  (Deposit Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\" Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\"\n",
+      "                  (Deposit Address \"addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\" Address \"addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\"\n",
       "                     (Token \"\" \"\")\n",
       "                     (Constant 2000000))\n",
-      "                  (Pay Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\"\n",
-      "                     (Party Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\")\n",
+      "                  (Pay Address \"addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\"\n",
+      "                     (Party Address \"addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\")\n",
       "                     (Token \"\" \"\")\n",
       "                     (Constant 2000000)\n",
       "                     (When [\n",
       "                        (Case\n",
-      "                           (Deposit Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\" Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\"\n",
+      "                           (Deposit Address \"addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\" Address \"addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\"\n",
       "                              (Token \"\" \"\")\n",
       "                              (Constant 100000000))\n",
-      "                           (Pay Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\"\n",
-      "                              (Party Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\")\n",
+      "                           (Pay Address \"addr_test1vrzx2ys48s6k03f5hq0mc4vuwuuxq2sj3p8gsnk47z27qdqzjjmup\"\n",
+      "                              (Party Address \"addr_test1vpwu7nklk38f3tp4yr759lssakgwhtmyprhaexlvd3aj9xs7ud88k\")\n",
       "                              (Token \"\" \"\")\n",
-      "                              (Constant 100000000) Close))] 1667228207000 Close)))] 1667228207000 Close)))] 1667227907000 Close\n",
+      "                              (Constant 100000000) Close))] 1667314799000 Close)))] 1667314799000 Close)))] 1667314499000 Close\n",
       "\n"
      ]
     }
@@ -937,7 +936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 31,
    "id": "808a16fb-9133-4544-a60f-6e9fdf7f6cae",
    "metadata": {},
    "outputs": [
@@ -956,7 +955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 32,
    "id": "f9820b1e-590f-498d-b843-b258eaebf404",
    "metadata": {},
    "outputs": [
@@ -966,7 +965,7 @@
      "text": [
       "                           TxHash                                 TxIx        Amount\n",
       "--------------------------------------------------------------------------------------\n",
-      "26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3     1        3000000 lovelace + TxOutDatumHash ScriptDataInBabbageEra \"d0826d8d19d49186b726560633ab36020c0c7799058518b6dd896efbf6e83e46\"\n"
+      "f06e4b760f2d9578c8088ea5289ba6276e68ae3cbaf5ad27bcfc77dc413890db     1        3000000 lovelace + TxOutDatumHash ScriptDataInBabbageEra \"0e1ed828c4d19f65a42450d19985bccc9607f38855a193ffcc22b4f4335c4218\"\n"
      ]
     }
    ],
@@ -992,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 33,
    "id": "eea2d290-46e0-4a5c-a587-f0dd4afda600",
    "metadata": {},
    "outputs": [
@@ -1000,7 +999,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3#1\n"
+      "f06e4b760f2d9578c8088ea5289ba6276e68ae3cbaf5ad27bcfc77dc413890db#1\n"
      ]
     }
    ],
@@ -1010,7 +1009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 34,
    "id": "cca2e9c5-d78b-4207-b599-feca36afb4c6",
    "metadata": {},
    "outputs": [],
@@ -1028,7 +1027,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 35,
    "id": "303c1567-db4f-4659-a032-31706072ba15",
    "metadata": {},
    "outputs": [
@@ -1036,7 +1035,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"1d3e7d02738273ea36f5eeb2c3141adbc0ebed0332e8aa8c65ba50a71bb0595a\"\n"
+      "TxId \"37f24fecf0eb568310c4217889488a93a45988617dea79de841448acfff9b85e\"\n"
      ]
     }
    ],
@@ -1050,7 +1049,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 36,
    "id": "3084ac48-3e9f-4399-aba8-a5fa487006c0",
    "metadata": {},
    "outputs": [
@@ -1058,7 +1057,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"ec4a5dc9cedd96c8e828eb2ecb908c87d0bc66740940f6e90b8618a01737fecf\"\n"
+      "TxId \"ff600ef8ecf61b6a606a6e063d4988e8e4508c24cde1ec3a3d89a82aa4a460c9\"\n"
      ]
     }
    ],
@@ -1080,7 +1079,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 37,
    "id": "a300a576-a800-4fdd-9d45-bc6cc3c901a8",
    "metadata": {},
    "outputs": [
@@ -1088,7 +1087,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"a92a7c87ff9bbdbca5c3900e5b613d64ee63f6ee83d3b07c8b54346262dd7c91\"\n"
+      "TxId \"73ef9f42e55663ad3ecd22afb6c97b51bcfcaf15e9ee7b5efc0c9aeb95ce0107\"\n"
      ]
     }
    ],
@@ -1113,7 +1112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 38,
    "id": "586f7b36",
    "metadata": {},
    "outputs": [

--- a/marlowe-runtime/examples/create-many-utxos.ipynb
+++ b/marlowe-runtime/examples/create-many-utxos.ipynb
@@ -60,7 +60,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "marlowe-cli 0.0.9.0\n"
+      "marlowe-cli 0.0.10.0\n"
      ]
     }
    ],
@@ -97,7 +97,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "595e48a82babf64fab7ffcedb22cda4203b8e751\n"
+      "e32278fd9df35ae67e3851b86eea5f355e6912ca\n"
      ]
     }
    ],
@@ -151,7 +151,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "addr_test1vq9prvx8ufwutkwxx9cmmuuajaqmjqwujqlp9d8pvg6gupczgtm9j\n"
+      "addr_test1vq2a4cdym9mn38nf894p5sjqurns4ehjm3pt5t8l4djcnzqjzztcr\n"
      ]
     }
    ],
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "id": "009fed78-8410-4894-b904-d6ea92982d70",
    "metadata": {},
    "outputs": [],
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "id": "0de60d98-b79e-43fc-8c7d-fd494c76390d",
    "metadata": {},
    "outputs": [
@@ -305,7 +305,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n"
+      "addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n"
      ]
     }
    ],
@@ -328,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "id": "ff90fa3f-1422-4632-abb7-19c5e5b5d2ed",
    "metadata": {},
    "outputs": [
@@ -336,7 +336,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"7a1c653f19092f381cc0607b2bf451551aeb3ca60498edc09c35048f165915eb\"\n"
+      "TxId \"901e0dd34ce83ee5fe9ac7ee9c3cd541a6f9fb50816cf77e1f6b69e7e9c9d278\"\n",
+      "TxId \"d2da99fecb533030a2f3b1e367534a46b8f7031dcdd2a7d14b489ea9f232548c\"\n",
+      "TxId \"28d0b542da9d895693e5f4f1ca4c84ec7cfb9f7dac52c96683c4e01e7a27e212\"\n"
      ]
     }
    ],
@@ -352,7 +354,8 @@
     "  --submit 600 \\\n",
     "  --lovelace 140000000 \\\n",
     "  --source-wallet-credentials \"$FAUCET_ADDR:$FAUCET_SKEY\" \\\n",
-    "  \"$PARTY_ADDR\"marlowe-cli util fund-address \\\n",
+    "  \"$PARTY_ADDR\"\n",
+    "  marlowe-cli util fund-address \\\n",
     "  --out-file /dev/null \\\n",
     "  --submit 600 \\\n",
     "  --lovelace 70000000 \\\n",
@@ -370,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "id": "359d2b9b-9bc3-4688-9689-9ef2c69cd382",
    "metadata": {},
    "outputs": [],
@@ -389,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "id": "c4297420-6c47-4716-bbb3-c5bb0be2ef9a",
    "metadata": {},
    "outputs": [
@@ -397,7 +400,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n"
+      "addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n"
      ]
     }
    ],
@@ -420,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 19,
    "id": "77bc9000-d2e3-4996-a2ae-a7d0c625aa70",
    "metadata": {},
    "outputs": [
@@ -428,7 +431,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"646d5be767a3aa06d13ca73007a130e9a1a09a8b1755b2d9f7bfbcd89de16554\"\n"
+      "TxId \"a3998f765792b3bf1072d6d44c1ed7ed203a4f8ad8009ea50c6ee053af9c70e6\"\n",
+      "TxId \"f5dbc7da24999a8a15bae201a5fb0589739f5d17ae70dc4fad0b8fa8b75eda4f\"\n",
+      "TxId \"511ced5ba47ac824da39fdd859114375ee9c9b109f6040c365e369489cbacb29\"\n"
      ]
     }
    ],
@@ -444,7 +449,8 @@
     "  --submit 600  \\\n",
     "  --lovelace 180000000 \\\n",
     "  --source-wallet-credentials \"$FAUCET_ADDR:$FAUCET_SKEY\" \\\n",
-    "  \"$COUNTERPARTY_ADDR\"marlowe-cli util fund-address \\\n",
+    "  \"$COUNTERPARTY_ADDR\"\n",
+    "  marlowe-cli util fund-address \\\n",
     "  --out-file /dev/null \\\n",
     "  --submit 600  \\\n",
     "  --lovelace 90000000 \\\n",
@@ -464,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 20,
    "id": "15b80716-4545-4558-825f-9d0dda82f8d5",
    "metadata": {},
    "outputs": [],
@@ -475,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 21,
    "id": "359b6f47-e0d1-4f84-8812-b96cfa361c2d",
    "metadata": {},
    "outputs": [
@@ -483,7 +489,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1666209157000\n"
+      "1667227307000\n"
      ]
     }
    ],
@@ -510,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 22,
    "id": "c5845b3d-12cf-47f0-a53c-0da3e4fe89f2",
    "metadata": {
     "tags": []
@@ -530,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 23,
    "id": "ece6fd44-d1ea-44b6-a8e4-240c4549417c",
    "metadata": {},
    "outputs": [
@@ -538,7 +544,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"accruedInterest\":0,\"collateralAmount\":0,\"contractId\":\"0\",\"contractPerformance\":\"PF\",\"contractRole\":\"RPA\",\"contractType\":\"PAM\",\"cycleAnchorDateOfInterestPayment\":\"2023-01-01T00:00:00\",\"cycleOfInterestPayment\":\"P1YL1\",\"dayCountConvention\":\"30E360\",\"enableSettlement\":false,\"initialExchangeDate\":\"2023-01-01T00:00:00\",\"interestCalculationBase\":\"NT\",\"maturityDate\":\"2024-01-01T00:00:00\",\"nominalInterestRate\":0.02,\"notionalPrincipal\":100,\"penaltyType\":\"O\",\"prepaymentEffect\":\"N\",\"scheduleConfig\":{\"businessDayConvention\":\"NULL\",\"calendar\":\"NC\",\"endOfMonthConvention\":\"EOM\"},\"statusDate\":\"2022-10-19T00:00:00\"}\n"
+      "{\"accruedInterest\":0,\"collateralAmount\":0,\"contractId\":\"0\",\"contractPerformance\":\"PF\",\"contractRole\":\"RPA\",\"contractType\":\"PAM\",\"cycleAnchorDateOfInterestPayment\":\"2023-01-01T00:00:00\",\"cycleOfInterestPayment\":\"P1YL1\",\"dayCountConvention\":\"30E360\",\"enableSettlement\":false,\"initialExchangeDate\":\"2023-01-01T00:00:00\",\"interestCalculationBase\":\"NT\",\"maturityDate\":\"2024-01-01T00:00:00\",\"nominalInterestRate\":0.02,\"notionalPrincipal\":100,\"penaltyType\":\"O\",\"prepaymentEffect\":\"N\",\"scheduleConfig\":{\"businessDayConvention\":\"NULL\",\"calendar\":\"NC\",\"endOfMonthConvention\":\"EOM\"},\"statusDate\":\"2022-10-31T00:00:00\"}\n"
      ]
     }
    ],
@@ -580,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 24,
    "id": "028339ed-6d5e-4e71-9895-3a965a0252c9",
    "metadata": {},
    "outputs": [],
@@ -604,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 25,
    "id": "d131f130-aca6-4a31-9890-761a1827f5d8",
    "metadata": {},
    "outputs": [],
@@ -625,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 26,
    "id": "661bb16a-2739-4354-a796-bbaedf39f698",
    "metadata": {},
    "outputs": [
@@ -633,7 +639,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "timeout: 1666209757000\n",
+      "timeout: 1667227907000\n",
       "timeout_continuation: close\n",
       "when:\n",
       "- case:\n",
@@ -641,66 +647,66 @@
       "      negate:\n",
       "        negate: 100000000\n",
       "    into_account:\n",
-      "      address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "      address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
       "    of_token:\n",
       "      currency_symbol: ''\n",
       "      token_name: ''\n",
       "    party:\n",
-      "      address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "      address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
       "  then:\n",
       "    from_account:\n",
-      "      address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "      address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
       "    pay: 100000000\n",
       "    then:\n",
-      "      timeout: 1666210057000\n",
+      "      timeout: 1667228207000\n",
       "      timeout_continuation: close\n",
       "      when:\n",
       "      - case:\n",
       "          deposits: 2000000\n",
       "          into_account:\n",
-      "            address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "            address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
       "          of_token:\n",
       "            currency_symbol: ''\n",
       "            token_name: ''\n",
       "          party:\n",
-      "            address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "            address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
       "        then:\n",
       "          from_account:\n",
-      "            address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "            address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
       "          pay: 2000000\n",
       "          then:\n",
-      "            timeout: 1666210057000\n",
+      "            timeout: 1667228207000\n",
       "            timeout_continuation: close\n",
       "            when:\n",
       "            - case:\n",
       "                deposits: 100000000\n",
       "                into_account:\n",
-      "                  address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "                  address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
       "                of_token:\n",
       "                  currency_symbol: ''\n",
       "                  token_name: ''\n",
       "                party:\n",
-      "                  address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "                  address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
       "              then:\n",
       "                from_account:\n",
-      "                  address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "                  address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
       "                pay: 100000000\n",
       "                then: close\n",
       "                to:\n",
       "                  party:\n",
-      "                    address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "                    address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
       "                token:\n",
       "                  currency_symbol: ''\n",
       "                  token_name: ''\n",
       "          to:\n",
       "            party:\n",
-      "              address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "              address: addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\n",
       "          token:\n",
       "            currency_symbol: ''\n",
       "            token_name: ''\n",
       "    to:\n",
       "      party:\n",
-      "        address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "        address: addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\n",
       "    token:\n",
       "      currency_symbol: ''\n",
       "      token_name: ''\n"
@@ -737,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 27,
    "id": "b0c60ede-d8c6-47f9-adcd-d3245ef60467",
    "metadata": {},
    "outputs": [
@@ -747,7 +753,10 @@
      "text": [
       "                           TxHash                                 TxIx        Amount\n",
       "--------------------------------------------------------------------------------------\n",
-      "7a1c653f19092f381cc0607b2bf451551aeb3ca60498edc09c35048f165915eb     1        250000000 lovelace + TxOutDatumNone\n"
+      "28d0b542da9d895693e5f4f1ca4c84ec7cfb9f7dac52c96683c4e01e7a27e212     1        70000000 lovelace + TxOutDatumNone\n",
+      "856c37eacf8d3cd9091e5277c238fad7b20223af23ad4cd5dc82cc2abf20e886     1        250000000 lovelace + TxOutDatumNone\n",
+      "901e0dd34ce83ee5fe9ac7ee9c3cd541a6f9fb50816cf77e1f6b69e7e9c9d278     1        250000000 lovelace + TxOutDatumNone\n",
+      "d2da99fecb533030a2f3b1e367534a46b8f7031dcdd2a7d14b489ea9f232548c     1        140000000 lovelace + TxOutDatumNone\n"
      ]
     }
    ],
@@ -765,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 28,
    "id": "142661e5-a5b3-4e48-9d02-d5aca344d2e2",
    "metadata": {},
    "outputs": [
@@ -773,7 +782,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CONTRACT_ID = af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d#1\n"
+      "CONTRACT_ID = 26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3#1\n"
      ]
     }
    ],
@@ -800,7 +809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 29,
    "id": "5d4c94bc-d747-47c6-be60-55656a3ee6ca",
    "metadata": {},
    "outputs": [],
@@ -821,7 +830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 30,
    "id": "04ff93e3-b751-440a-b310-12ebe095401a",
    "metadata": {},
    "outputs": [
@@ -829,7 +838,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"{\\\"blockHeaderHash\\\":\\\"73b8cbf80472f3ece26541b2a92d8bd3a2c7492654834d00e528bef4df07ef25\\\",\\\"blockNo\\\":286706,\\\"slotNo\\\":6205964}\"\n"
+      "\"{\\\"blockHeaderHash\\\":\\\"a1cd017668e7a4f8b06904bec8c9b81341254e09d7fbdc22ab893a78961556f9\\\",\\\"blockNo\\\":333672,\\\"slotNo\\\":7224134}\"\n"
      ]
     }
    ],
@@ -847,7 +856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 31,
    "id": "0e4ceeb0-350f-464b-86ea-e36b98ec06ff",
    "metadata": {},
    "outputs": [
@@ -855,7 +864,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d#1\n"
+      "26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3#1\n"
      ]
     }
    ],
@@ -865,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 32,
    "id": "f02d9dbb-91a5-4290-ac3b-0d32030cddff",
    "metadata": {},
    "outputs": [
@@ -873,43 +882,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[93mtransaction af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d (creation)\n",
-      "\u001b[0mContractId:      af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d#1\n",
-      "SlotNo:          6205964\n",
-      "BlockNo:         286706\n",
-      "BlockId:         73b8cbf80472f3ece26541b2a92d8bd3a2c7492654834d00e528bef4df07ef25\n",
+      "\u001b[93mtransaction 26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3 (creation)\n",
+      "\u001b[0mContractId:      26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3#1\n",
+      "SlotNo:          7224134\n",
+      "BlockNo:         333672\n",
+      "BlockId:         a1cd017668e7a4f8b06904bec8c9b81341254e09d7fbdc22ab893a78961556f9\n",
       "ScriptAddress:   addr_test1wp4f8ywk4fg672xasahtk4t9k6w3aql943uxz5rt62d4dvqu3c6jv\n",
       "Marlowe Version: 1\n",
       "\n",
       "    When [\n",
       "      (Case\n",
-      "         (Deposit Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\" Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\"\n",
+      "         (Deposit Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\" Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\"\n",
       "            (Token \"\" \"\")\n",
       "            (NegValue\n",
       "               (NegValue\n",
       "                  (Constant 100000000))))\n",
-      "         (Pay Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\"\n",
-      "            (Party Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\")\n",
+      "         (Pay Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\"\n",
+      "            (Party Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\")\n",
       "            (Token \"\" \"\")\n",
       "            (Constant 100000000)\n",
       "            (When [\n",
       "               (Case\n",
-      "                  (Deposit Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\" Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\"\n",
+      "                  (Deposit Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\" Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\"\n",
       "                     (Token \"\" \"\")\n",
       "                     (Constant 2000000))\n",
-      "                  (Pay Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\"\n",
-      "                     (Party Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\")\n",
+      "                  (Pay Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\"\n",
+      "                     (Party Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\")\n",
       "                     (Token \"\" \"\")\n",
       "                     (Constant 2000000)\n",
       "                     (When [\n",
       "                        (Case\n",
-      "                           (Deposit Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\" Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\"\n",
+      "                           (Deposit Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\" Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\"\n",
       "                              (Token \"\" \"\")\n",
       "                              (Constant 100000000))\n",
-      "                           (Pay Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\"\n",
-      "                              (Party Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\")\n",
+      "                           (Pay Address \"addr_test1vz44qd5d3mukz02eyy83wyfhmu2p5ypmflxy25eayhr8vmcnpxcdk\"\n",
+      "                              (Party Address \"addr_test1vqgpqpz4225s77wj4rlys8schzu6q093x5w4e0pk2pg4j6c39cvyd\")\n",
       "                              (Token \"\" \"\")\n",
-      "                              (Constant 100000000) Close))] 1666210057000 Close)))] 1666210057000 Close)))] 1666209757000 Close\n",
+      "                              (Constant 100000000) Close))] 1667228207000 Close)))] 1667228207000 Close)))] 1667227907000 Close\n",
       "\n"
      ]
     }
@@ -928,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 33,
    "id": "808a16fb-9133-4544-a60f-6e9fdf7f6cae",
    "metadata": {},
    "outputs": [
@@ -947,7 +956,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 34,
    "id": "f9820b1e-590f-498d-b843-b258eaebf404",
    "metadata": {},
    "outputs": [
@@ -957,7 +966,7 @@
      "text": [
       "                           TxHash                                 TxIx        Amount\n",
       "--------------------------------------------------------------------------------------\n",
-      "af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d     1        3000000 lovelace + TxOutDatumHash ScriptDataInBabbageEra \"1fefe6165f363741f05af50d073991a802e74d64e75db3f38b1b00107c39e4c4\"\n"
+      "26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3     1        3000000 lovelace + TxOutDatumHash ScriptDataInBabbageEra \"d0826d8d19d49186b726560633ab36020c0c7799058518b6dd896efbf6e83e46\"\n"
      ]
     }
    ],
@@ -983,7 +992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 35,
    "id": "eea2d290-46e0-4a5c-a587-f0dd4afda600",
    "metadata": {},
    "outputs": [
@@ -991,7 +1000,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d#1\n"
+      "26d23f825c57bb6c59298524029264f07682090dfcea7a5345bbe0fe3c2752a3#1\n"
      ]
     }
    ],
@@ -1001,7 +1010,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 36,
    "id": "cca2e9c5-d78b-4207-b599-feca36afb4c6",
    "metadata": {},
    "outputs": [],
@@ -1019,7 +1028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 37,
    "id": "303c1567-db4f-4659-a032-31706072ba15",
    "metadata": {},
    "outputs": [
@@ -1027,7 +1036,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"8f47e5d702071510f72f70a439904ea8fa94de3b03475ff24c858f5879b41384\"\n"
+      "TxId \"1d3e7d02738273ea36f5eeb2c3141adbc0ebed0332e8aa8c65ba50a71bb0595a\"\n"
      ]
     }
    ],
@@ -1041,7 +1050,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 38,
    "id": "3084ac48-3e9f-4399-aba8-a5fa487006c0",
    "metadata": {},
    "outputs": [
@@ -1049,7 +1058,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"b18c930a90d352d34ed466c0b234e94f7811cd20e1faa8ef022e7c7f7cd81ce4\"\n"
+      "TxId \"ec4a5dc9cedd96c8e828eb2ecb908c87d0bc66740940f6e90b8618a01737fecf\"\n"
      ]
     }
    ],
@@ -1071,7 +1080,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 39,
    "id": "a300a576-a800-4fdd-9d45-bc6cc3c901a8",
    "metadata": {},
    "outputs": [
@@ -1079,7 +1088,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TxId \"67a0c138916cb43ea3dfa61dee961bd09b953ba2fbf8f696b489ea2c42d59353\"\n"
+      "TxId \"a92a7c87ff9bbdbca5c3900e5b613d64ee63f6ee83d3b07c8b54346262dd7c91\"\n"
      ]
     }
    ],
@@ -1104,7 +1113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 40,
    "id": "586f7b36",
    "metadata": {},
    "outputs": [
@@ -1120,6 +1129,14 @@
    "source": [
     "cardano-cli query utxo \"${MAGIC[@]}\" --address \"$PARTY_ADDR\" --address \"$COUNTERPARTY_ADDR\""
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30db996c-66fd-4df7-9705-498883ba3de0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1132,7 +1149,7 @@
    "codemirror_mode": "shell",
    "file_extension": ".sh",
    "mimetype": "text/x-sh",
-   "name": "/nix/store/znkypmyvykawwg71xawqzb98qbllijv8-bash-5.1-p16/bin/bash"
+   "name": "/nix/store/l0wlqpbsvh1pgvhcdhw7qkka3d31si7k-bash-5.1-p8/bin/bash"
   }
  },
  "nbformat": 4,

--- a/marlowe-runtime/examples/create-many-utxos.ipynb
+++ b/marlowe-runtime/examples/create-many-utxos.ipynb
@@ -1,0 +1,1140 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c2b997ff-7487-4181-a96d-83057ca11994",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!/usr/bin/env bash"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29ad9b87-6812-4d1b-888b-c255e9be9eae",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: red; font-weight: bold\">Use the following command to launch a server for this notebook:</span>\n",
+    "\n",
+    "```bash\n",
+    "git clone git@github.com:input-output-hk/marlowe-cardano.git\n",
+    "cd marlowe-cardano/marlowe-runtime/\n",
+    "nix run ../marlowe-cli\n",
+    "```\n",
+    "\n",
+    "Then navigate to the `examples/` folder in Jupyter and open this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff12ef20-4800-40fc-bf1a-b48def801ee9",
+   "metadata": {},
+   "source": [
+    "# Demonstrating the Marlowe Transaction Creation Component of Marlowe Runtime"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4002252-fe9f-40e4-a371-d4d6b57316de",
+   "metadata": {},
+   "source": [
+    "## Preliminaries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dab2352b-0021-4998-9107-c5cc32d3734c",
+   "metadata": {},
+   "source": [
+    "Record version numbers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4832053a-541d-4acd-a781-e7b31a3d28e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "marlowe-cli 0.0.9.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe-cli --version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e7651166-5c42-4a2b-8447-3407440f7b5a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cardano-cli 1.35.3 - linux-x86_64 - ghc-8.10\n",
+      "git rev 0000000000000000000000000000000000000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "cardano-cli --version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0434d927-022f-41f6-b60f-091ebe85cfc4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "595e48a82babf64fab7ffcedb22cda4203b8e751\n"
+     ]
+    }
+   ],
+   "source": [
+    "git rev-parse HEAD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fb67751-bbb3-4e07-a9c7-b509502903c7",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Setup the faucet."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c1053b7-899c-4df1-94bc-626300568286",
+   "metadata": {},
+   "source": [
+    "Set the location of keys."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7eba74b8-fb39-4a07-9080-211d46f9132a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TREASURY=treasury"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5caee3c-c91e-49b8-aeb2-84b3170128d6",
+   "metadata": {},
+   "source": [
+    "Set the faucet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "054727ec-d1d3-4fdd-811f-95561dc807c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "addr_test1vq9prvx8ufwutkwxx9cmmuuajaqmjqwujqlp9d8pvg6gupczgtm9j\n"
+     ]
+    }
+   ],
+   "source": [
+    "FAUCET_SKEY=$TREASURY/payment.skey\n",
+    "FAUCET_ADDR=$(cat $TREASURY/payment.testnet.address)\n",
+    "echo \"$FAUCET_ADDR\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2894720b-50a2-4830-9a5d-e65b8e7c7dad",
+   "metadata": {},
+   "source": [
+    "### Select network"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "720ae956-275a-4b64-8460-cff5630104b4",
+   "metadata": {},
+   "source": [
+    "In a separate terminal, set up a tunnel to the Marlowe Runtime development server:\n",
+    "```bash\n",
+    "rm /tmp/preview.socket\n",
+    "ssh -NT \\\n",
+    "  -L/tmp/preview.socket:/data/networks/preview/node.socket \\\n",
+    "  -L 3717:127.0.0.1:23717 \\\n",
+    "  -L 3718:127.0.0.1:23718 \\\n",
+    "  -L 3719:127.0.0.1:23719 \\\n",
+    "  -L 3721:127.0.0.1:23721 \\\n",
+    "  -L 3723:127.0.0.1:23723 \\\n",
+    "  54.202.238.5                                              \n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ced2a30e-b2ba-435a-9199-bcfa0d6a8cf4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--testnet-magic 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "export CARDANO_NODE_SOCKET_PATH=/tmp/preview.socket\n",
+    "export CARDANO_TESTNET_MAGIC=2\n",
+    "MAGIC=(--testnet-magic 2)\n",
+    "echo \"${MAGIC[@]}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6649b7a2-3f9e-4dd4-bde7-11699c6bf27f",
+   "metadata": {},
+   "source": [
+    "### Check that the reference script has been published"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f88e700-a21f-4fd4-b785-35f39d767e49",
+   "metadata": {},
+   "source": [
+    "Check that the Marlowe semantics validator was published."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "eb29caeb-c563-4e7d-922a-b5350642cc0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Searching for reference script at address: addr_test1vrw0tuh8l95thdqr65dmpcfqnmcw0en7v7vhgegck7gzqgswa07sw\n",
+      "\n",
+      "Expected reference script hash: \"6a9391d6aa51af28dd876ebb5565b69d1e83e5ac7861506bd29b56b0\"\n",
+      "\n",
+      "Searching for reference script at address: addr_test1vpa36uuyf95kxpcleldsncedlhjru6vdmh2vnpkdrsz4u6cll9zas\n",
+      "\n",
+      "Expected reference script hash: \"49076eab20243dc9462511fb98a9cfb719f86e9692288139b7c91df3\"\n",
+      "{\n",
+      "    \"marlowe\": {\n",
+      "        \"hash\": \"6a9391d6aa51af28dd876ebb5565b69d1e83e5ac7861506bd29b56b0\",\n",
+      "        \"txIn\": \"087f21f109a997193421a81886ea8c6397d336d19e696457b9c5c7aefdc31873#1\"\n",
+      "    },\n",
+      "    \"payout\": {\n",
+      "        \"hash\": \"49076eab20243dc9462511fb98a9cfb719f86e9692288139b7c91df3\",\n",
+      "        \"txIn\": \"087f21f109a997193421a81886ea8c6397d336d19e696457b9c5c7aefdc31873#2\"\n",
+      "    }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe-cli transaction find-published"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ae0e907-2c31-4b85-926d-c62dc9cafc49",
+   "metadata": {},
+   "source": [
+    "### Participants"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea318fc6-f1dc-46a8-a4e7-83ee23a42ec3",
+   "metadata": {},
+   "source": [
+    "#### The Party"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "009fed78-8410-4894-b904-d6ea92982d70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PARTY_SKEY=\"$TREASURY/john-fletcher.skey\"\n",
+    "PARTY_VKEY=\"$TREASURY/john-fletcher.vkey\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df56d582-919c-438f-986a-a9a3fffc40c7",
+   "metadata": {},
+   "source": [
+    "Create the first party's keys, if necessary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0de60d98-b79e-43fc-8c7d-fd494c76390d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n"
+     ]
+    }
+   ],
+   "source": [
+    "if [[ ! -e \"$PARTY_SKEY\" ]]\n",
+    "then\n",
+    "  cardano-cli address key-gen --signing-key-file \"$PARTY_SKEY\" --verification-key-file \"$PARTY_VKEY\"\n",
+    "fi\n",
+    "PARTY_ADDR=$(cardano-cli address build \"${MAGIC[@]}\" --payment-verification-key-file \"$PARTY_VKEY\")\n",
+    "echo \"$PARTY_ADDR\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17b4396a-a8ac-4976-bda4-968daaaa190e",
+   "metadata": {},
+   "source": [
+    "Fund the address."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ff90fa3f-1422-4632-abb7-19c5e5b5d2ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TxId \"7a1c653f19092f381cc0607b2bf451551aeb3ca60498edc09c35048f165915eb\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe-cli util fund-address \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600 \\\n",
+    "  --lovelace 250000000 \\\n",
+    "  --source-wallet-credentials \"$FAUCET_ADDR:$FAUCET_SKEY\" \\\n",
+    "  \"$PARTY_ADDR\"\n",
+    "  marlowe-cli util fund-address \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600 \\\n",
+    "  --lovelace 140000000 \\\n",
+    "  --source-wallet-credentials \"$FAUCET_ADDR:$FAUCET_SKEY\" \\\n",
+    "  \"$PARTY_ADDR\"marlowe-cli util fund-address \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600 \\\n",
+    "  --lovelace 70000000 \\\n",
+    "  --source-wallet-credentials \"$FAUCET_ADDR:$FAUCET_SKEY\" \\\n",
+    "  \"$PARTY_ADDR\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "beac2b0a-83c9-4f13-a1b2-d4ae12795bc7",
+   "metadata": {},
+   "source": [
+    "#### The Counterparty"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "359d2b9b-9bc3-4688-9689-9ef2c69cd382",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "COUNTERPARTY_SKEY=\"$TREASURY/thomas-kyd.skey\"\n",
+    "COUNTERPARTY_VKEY=\"$TREASURY/thomas-kyd.vkey\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc9ff64b-fc5b-4308-8b6c-9208985b3600",
+   "metadata": {},
+   "source": [
+    "Create the second party's keys, if necessary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c4297420-6c47-4716-bbb3-c5bb0be2ef9a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n"
+     ]
+    }
+   ],
+   "source": [
+    "if [[ ! -e \"$COUNTERPARTY_SKEY\" ]]\n",
+    "then\n",
+    "  cardano-cli address key-gen --signing-key-file \"$COUNTERPARTY_SKEY\" --verification-key-file \"$COUNTERPARTY_VKEY\"\n",
+    "fi\n",
+    "COUNTERPARTY_ADDR=$(cardano-cli address build \"${MAGIC[@]}\" --payment-verification-key-file \"$COUNTERPARTY_VKEY\")\n",
+    "echo \"$COUNTERPARTY_ADDR\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0556be66-9ca7-4e91-9c85-bd885311c611",
+   "metadata": {},
+   "source": [
+    "Fund the address."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "77bc9000-d2e3-4996-a2ae-a7d0c625aa70",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TxId \"646d5be767a3aa06d13ca73007a130e9a1a09a8b1755b2d9f7bfbcd89de16554\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe-cli util fund-address \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600  \\\n",
+    "  --lovelace 250000000 \\\n",
+    "  --source-wallet-credentials \"$FAUCET_ADDR:$FAUCET_SKEY\" \\\n",
+    "  \"$COUNTERPARTY_ADDR\"\n",
+    "  marlowe-cli util fund-address \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600  \\\n",
+    "  --lovelace 180000000 \\\n",
+    "  --source-wallet-credentials \"$FAUCET_ADDR:$FAUCET_SKEY\" \\\n",
+    "  \"$COUNTERPARTY_ADDR\"marlowe-cli util fund-address \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600  \\\n",
+    "  --lovelace 90000000 \\\n",
+    "  --source-wallet-credentials \"$FAUCET_ADDR:$FAUCET_SKEY\" \\\n",
+    "  \"$COUNTERPARTY_ADDR\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89743793-9a3a-4077-8d1d-9bcada0321d3",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Time computations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "15b80716-4545-4558-825f-9d0dda82f8d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SECOND=1000\n",
+    "MINUTE=$((60 * SECOND))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "359b6f47-e0d1-4f84-8812-b96cfa361c2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1666209157000\n"
+     ]
+    }
+   ],
+   "source": [
+    "NOW=\"$(($(date -u +%s) * SECOND))\"\n",
+    "echo \"$NOW\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb417b36-effb-4fc2-ae81-b7fce917aa7b",
+   "metadata": {},
+   "source": [
+    "## The Contract"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b04afd25-7baa-46ef-b4e5-549402d14cd7",
+   "metadata": {},
+   "source": [
+    "We set the parameters for the ACTUS PAM contract."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "c5845b3d-12cf-47f0-a53c-0da3e4fe89f2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "MINIMUM_ADA=3000000\n",
+    "\n",
+    "#FIXED_POINT=1000000\n",
+    "PRINCIPAL=100\n",
+    "INTEREST_RATE=0.02\n",
+    "\n",
+    "STATUS_DATE=$(date -d \"$(date -u -R -d @$((NOW/1000)))\" +\"%Y-%m-%dT00:00:00\")\n",
+    "INITIAL_EXCHANGE_DATE=$(date -d \"$(date -u -R -d @$((NOW/1000))) + 1 year\" +\"%Y-01-01T00:00:00\")\n",
+    "MATURITY_DATE=$(date -d \"$(date -u -R -d @$((NOW/1000))) + 2 year\" +\"%Y-01-01T00:00:00\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "ece6fd44-d1ea-44b6-a8e4-240c4549417c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"accruedInterest\":0,\"collateralAmount\":0,\"contractId\":\"0\",\"contractPerformance\":\"PF\",\"contractRole\":\"RPA\",\"contractType\":\"PAM\",\"cycleAnchorDateOfInterestPayment\":\"2023-01-01T00:00:00\",\"cycleOfInterestPayment\":\"P1YL1\",\"dayCountConvention\":\"30E360\",\"enableSettlement\":false,\"initialExchangeDate\":\"2023-01-01T00:00:00\",\"interestCalculationBase\":\"NT\",\"maturityDate\":\"2024-01-01T00:00:00\",\"nominalInterestRate\":0.02,\"notionalPrincipal\":100,\"penaltyType\":\"O\",\"prepaymentEffect\":\"N\",\"scheduleConfig\":{\"businessDayConvention\":\"NULL\",\"calendar\":\"NC\",\"endOfMonthConvention\":\"EOM\"},\"statusDate\":\"2022-10-19T00:00:00\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "yaml2json << EOI > create.actus\n",
+    "scheduleConfig:\n",
+    "  businessDayConvention: \"NULL\"\n",
+    "  endOfMonthConvention: \"EOM\"\n",
+    "  calendar: \"NC\"\n",
+    "maturityDate: \"$MATURITY_DATE\"\n",
+    "contractId: \"0\"\n",
+    "enableSettlement: false\n",
+    "initialExchangeDate: \"$INITIAL_EXCHANGE_DATE\"\n",
+    "contractRole: \"RPA\"\n",
+    "penaltyType: \"O\"\n",
+    "cycleAnchorDateOfInterestPayment: \"$INITIAL_EXCHANGE_DATE\"\n",
+    "contractType: \"PAM\"\n",
+    "notionalPrincipal: $PRINCIPAL\n",
+    "contractPerformance: \"PF\"\n",
+    "collateralAmount: 0\n",
+    "dayCountConvention: \"30E360\"\n",
+    "accruedInterest: 0\n",
+    "statusDate: \"$STATUS_DATE\"\n",
+    "cycleOfInterestPayment: \"P1YL1\"\n",
+    "prepaymentEffect: \"N\"\n",
+    "nominalInterestRate: $INTEREST_RATE\n",
+    "interestCalculationBase: \"NT\"\n",
+    "EOI\n",
+    "cat create.actus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d58d8071-9907-4d2c-b686-48139d7841ca",
+   "metadata": {},
+   "source": [
+    "Create the contract."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "028339ed-6d5e-4e71-9895-3a965a0252c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marlowe-cli template actus \\\n",
+    "  --minimum-ada \"$MINIMUM_ADA\" \\\n",
+    "  --party \"$PARTY_ADDR\" \\\n",
+    "  --counter-party \"$COUNTERPARTY_ADDR\" \\\n",
+    "  --actus-terms-file  create.actus \\\n",
+    "  --out-contract-file create-1.contract \\\n",
+    "  --out-state-file /dev/null"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70b7c5d0-19c6-4ef6-a991-287b501e42fc",
+   "metadata": {},
+   "source": [
+    "Since we are testing, we don't really want to wait months or years for timeouts, so we edit the contract file to change the maturity date to 15 minutes from now and the initial deposit to 10 minutes from now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "d131f130-aca6-4a31-9890-761a1827f5d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sed -i \\\n",
+    "  -e \"s/$(jq '.timeout' create-1.contract)/$((NOW + 10 * MINUTE))/\" \\\n",
+    "  -e \"s/$(($(date -d \"$MATURITY_DATE\" -u +%s) * SECOND))/$((NOW + 15 * MINUTE))/\" \\\n",
+    "  create-1.contract"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc6d76dd-d7f0-4a83-ad1e-affd955e98a6",
+   "metadata": {},
+   "source": [
+    "View the contract."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "661bb16a-2739-4354-a796-bbaedf39f698",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "timeout: 1666209757000\n",
+      "timeout_continuation: close\n",
+      "when:\n",
+      "- case:\n",
+      "    deposits:\n",
+      "      negate:\n",
+      "        negate: 100000000\n",
+      "    into_account:\n",
+      "      address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "    of_token:\n",
+      "      currency_symbol: ''\n",
+      "      token_name: ''\n",
+      "    party:\n",
+      "      address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "  then:\n",
+      "    from_account:\n",
+      "      address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "    pay: 100000000\n",
+      "    then:\n",
+      "      timeout: 1666210057000\n",
+      "      timeout_continuation: close\n",
+      "      when:\n",
+      "      - case:\n",
+      "          deposits: 2000000\n",
+      "          into_account:\n",
+      "            address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "          of_token:\n",
+      "            currency_symbol: ''\n",
+      "            token_name: ''\n",
+      "          party:\n",
+      "            address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "        then:\n",
+      "          from_account:\n",
+      "            address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "          pay: 2000000\n",
+      "          then:\n",
+      "            timeout: 1666210057000\n",
+      "            timeout_continuation: close\n",
+      "            when:\n",
+      "            - case:\n",
+      "                deposits: 100000000\n",
+      "                into_account:\n",
+      "                  address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "                of_token:\n",
+      "                  currency_symbol: ''\n",
+      "                  token_name: ''\n",
+      "                party:\n",
+      "                  address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "              then:\n",
+      "                from_account:\n",
+      "                  address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "                pay: 100000000\n",
+      "                then: close\n",
+      "                to:\n",
+      "                  party:\n",
+      "                    address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "                token:\n",
+      "                  currency_symbol: ''\n",
+      "                  token_name: ''\n",
+      "          to:\n",
+      "            party:\n",
+      "              address: addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\n",
+      "          token:\n",
+      "            currency_symbol: ''\n",
+      "            token_name: ''\n",
+      "    to:\n",
+      "      party:\n",
+      "        address: addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\n",
+      "    token:\n",
+      "      currency_symbol: ''\n",
+      "      token_name: ''\n"
+     ]
+    }
+   ],
+   "source": [
+    "json2yaml create-1.contract"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1548c6e-3288-4a7e-90f4-6439edeb22ca",
+   "metadata": {},
+   "source": [
+    "## Run the Contract"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2eb9ff2-86b8-437e-aa04-a1a38cebea9a",
+   "metadata": {},
+   "source": [
+    "### Transaction 1. Create the contract"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faafcccf-d07c-4f8e-9ff8-a654e76e8ff7",
+   "metadata": {},
+   "source": [
+    "See what UTxOs the transaction-creation will have available to select from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "b0c60ede-d8c6-47f9-adcd-d3245ef60467",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                           TxHash                                 TxIx        Amount\n",
+      "--------------------------------------------------------------------------------------\n",
+      "7a1c653f19092f381cc0607b2bf451551aeb3ca60498edc09c35048f165915eb     1        250000000 lovelace + TxOutDatumNone\n"
+     ]
+    }
+   ],
+   "source": [
+    "cardano-cli query utxo \"${MAGIC[@]}\" --address \"$PARTY_ADDR\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab570c22-0af1-4168-9269-ebefce6bfa6d",
+   "metadata": {},
+   "source": [
+    "Build the transaction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "142661e5-a5b3-4e48-9d02-d5aca344d2e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CONTRACT_ID = af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d#1\n"
+     ]
+    }
+   ],
+   "source": [
+    "CONTRACT_ID=$(\n",
+    "marlowe create \\\n",
+    "  --core-file create-1.contract \\\n",
+    "  --min-utxo \"$MINIMUM_ADA\" \\\n",
+    "  --change-address \"$PARTY_ADDR\" \\\n",
+    "  --address \"$PARTY_ADDR\" \\\n",
+    "  --manual-sign create-1.txbody \\\n",
+    "| sed -e 's/^.*\"\\([^\\\\]*\\)\\\\.*$/\\1/' \\\n",
+    ")\n",
+    "echo \"CONTRACT_ID = $CONTRACT_ID\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b31ec973-5b0f-4fb7-bdca-c266bd66fdc1",
+   "metadata": {},
+   "source": [
+    "Sign the transaction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "5d4c94bc-d747-47c6-be60-55656a3ee6ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cardano-cli transaction sign \\\n",
+    "  --tx-body-file create-1.txbody \\\n",
+    "  --out-file     create-1.tx \\\n",
+    "  --signing-key-file \"$PARTY_SKEY\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bebb0d27-0a99-4f3d-ab06-09b627ee514e",
+   "metadata": {},
+   "source": [
+    "Submit the transaction using Marlowe Runtime."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "04ff93e3-b751-440a-b310-12ebe095401a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"{\\\"blockHeaderHash\\\":\\\"73b8cbf80472f3ece26541b2a92d8bd3a2c7492654834d00e528bef4df07ef25\\\",\\\"blockNo\\\":286706,\\\"slotNo\\\":6205964}\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe submit create-1.tx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bf9d006-26c4-49d9-9488-8d07021b043a",
+   "metadata": {},
+   "source": [
+    "Watch the contract."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "0e4ceeb0-350f-464b-86ea-e36b98ec06ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d#1\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe add \"$CONTRACT_ID\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "f02d9dbb-91a5-4290-ac3b-0d32030cddff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[93mtransaction af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d (creation)\n",
+      "\u001b[0mContractId:      af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d#1\n",
+      "SlotNo:          6205964\n",
+      "BlockNo:         286706\n",
+      "BlockId:         73b8cbf80472f3ece26541b2a92d8bd3a2c7492654834d00e528bef4df07ef25\n",
+      "ScriptAddress:   addr_test1wp4f8ywk4fg672xasahtk4t9k6w3aql943uxz5rt62d4dvqu3c6jv\n",
+      "Marlowe Version: 1\n",
+      "\n",
+      "    When [\n",
+      "      (Case\n",
+      "         (Deposit Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\" Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\"\n",
+      "            (Token \"\" \"\")\n",
+      "            (NegValue\n",
+      "               (NegValue\n",
+      "                  (Constant 100000000))))\n",
+      "         (Pay Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\"\n",
+      "            (Party Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\")\n",
+      "            (Token \"\" \"\")\n",
+      "            (Constant 100000000)\n",
+      "            (When [\n",
+      "               (Case\n",
+      "                  (Deposit Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\" Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\"\n",
+      "                     (Token \"\" \"\")\n",
+      "                     (Constant 2000000))\n",
+      "                  (Pay Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\"\n",
+      "                     (Party Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\")\n",
+      "                     (Token \"\" \"\")\n",
+      "                     (Constant 2000000)\n",
+      "                     (When [\n",
+      "                        (Case\n",
+      "                           (Deposit Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\" Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\"\n",
+      "                              (Token \"\" \"\")\n",
+      "                              (Constant 100000000))\n",
+      "                           (Pay Address \"addr_test1vr7n0zzth5zycuh972w7rdmh48qur4f3wu6ntn2m2h30dlcvltuy5\"\n",
+      "                              (Party Address \"addr_test1vqwt2xlr4d8yk4qws675exlqy6pdhq2s76wrehkjggkvr0cerfe8r\")\n",
+      "                              (Token \"\" \"\")\n",
+      "                              (Constant 100000000) Close))] 1666210057000 Close)))] 1666210057000 Close)))] 1666209757000 Close\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe log --show-contract \"$CONTRACT_ID\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b63f5847-141e-4378-96e2-5683f0c54e52",
+   "metadata": {},
+   "source": [
+    "View the contract's UTxO."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "808a16fb-9133-4544-a60f-6e9fdf7f6cae",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "addr_test1wp4f8ywk4fg672xasahtk4t9k6w3aql943uxz5rt62d4dvqu3c6jv\n"
+     ]
+    }
+   ],
+   "source": [
+    "CONTRACT_ADDRESS=$(marlowe-cli contract address)\n",
+    "echo \"$CONTRACT_ADDRESS\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "f9820b1e-590f-498d-b843-b258eaebf404",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                           TxHash                                 TxIx        Amount\n",
+      "--------------------------------------------------------------------------------------\n",
+      "af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d     1        3000000 lovelace + TxOutDatumHash ScriptDataInBabbageEra \"1fefe6165f363741f05af50d073991a802e74d64e75db3f38b1b00107c39e4c4\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "cardano-cli query utxo \"${MAGIC[@]}\" --address \"$CONTRACT_ADDRESS\" | sed -n -e \"1,2p;/${CONTRACT_ID//#*/}/p\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0ccaa90-d5d4-49b5-870c-d6429ed64ae0",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86585e47-22db-46db-94a6-80b4a00b2147",
+   "metadata": {},
+   "source": [
+    "Remove the contract from history tracking."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "eea2d290-46e0-4a5c-a587-f0dd4afda600",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "af0d5d2fb5b4089968b61176a4f5be72a085e6a9c73f2de5e695deb92df5f55d#1\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe rm \"$CONTRACT_ID\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "cca2e9c5-d78b-4207-b599-feca36afb4c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marlowe ls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6916f2a-426a-4c31-8499-610f83df1d7c",
+   "metadata": {},
+   "source": [
+    "Consolidate the UTxOs at the addresses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "303c1567-db4f-4659-a032-31706072ba15",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TxId \"8f47e5d702071510f72f70a439904ea8fa94de3b03475ff24c858f5879b41384\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe-cli util clean \\\n",
+    "  --change-address \"$PARTY_ADDR\" \\\n",
+    "  --required-signer \"$PARTY_SKEY\" \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "3084ac48-3e9f-4399-aba8-a5fa487006c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TxId \"b18c930a90d352d34ed466c0b234e94f7811cd20e1faa8ef022e7c7f7cd81ce4\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe-cli util clean \\\n",
+    "  --change-address \"$COUNTERPARTY_ADDR\" \\\n",
+    "  --required-signer \"$COUNTERPARTY_SKEY\" \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ddc612f-57ca-4e17-96f2-658baa3ef7e8",
+   "metadata": {},
+   "source": [
+    "Send the funds back to the faucet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "a300a576-a800-4fdd-9d45-bc6cc3c901a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TxId \"67a0c138916cb43ea3dfa61dee961bd09b953ba2fbf8f696b489ea2c42d59353\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "marlowe-cli transaction simple \\\n",
+    "  --tx-in \"$(marlowe-cli util select --lovelace-only 1 \"$PARTY_ADDR\" | sed -n -e 's/^TxIn \"\\(.*\\)\" (TxIx \\(.*\\))$/\\1#\\2/;1p')\" \\\n",
+    "  --tx-in \"$(marlowe-cli util select --lovelace-only 1 \"$COUNTERPARTY_ADDR\" | sed -n -e 's/^TxIn \"\\(.*\\)\" (TxIx \\(.*\\))$/\\1#\\2/;1p')\" \\\n",
+    "  --required-signer \"$PARTY_SKEY\" \\\n",
+    "  --required-signer \"$COUNTERPARTY_SKEY\" \\\n",
+    "  --change-address \"$FAUCET_ADDR\" \\\n",
+    "  --out-file /dev/null \\\n",
+    "  --submit 600"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "927fa5b5-92d2-4133-9a28-dcce900ee190",
+   "metadata": {},
+   "source": [
+    "See that the funds have been returned to the faucet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "586f7b36",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                           TxHash                                 TxIx        Amount\n",
+      "--------------------------------------------------------------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "cardano-cli query utxo \"${MAGIC[@]}\" --address \"$PARTY_ADDR\" --address \"$COUNTERPARTY_ADDR\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Bash - Marlowe",
+   "language": "bash",
+   "name": "bash_marlowe"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "/nix/store/znkypmyvykawwg71xawqzb98qbllijv8-bash-5.1-p16/bin/bash"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is more than one utxo in each but all with ADA only.

The test script was made from a duplicate of the `create` Jupyter notebook with some modifications.
We can add a script to run several together if we want too like `marlowe-cli/examples` has.