### PR TITLE
SCP-4427 write integration tests for marlowe add and rm bash scripts

### DIFF
--- a/marlowe-runtime/integration-tests/add/empty_history.sh
+++ b/marlowe-runtime/integration-tests/add/empty_history.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+echo "Marlowe Runtime Tests: marlowe add with empty history"
+
+echo "Test Scneario set up steps:"
+
+echo "Confirm marlowe run executable is installed"
+marlowe --help
+
+echo "set env variables"
+export CARDANO_NODE_SOCKET_PATH=/tmp/preview.socket
+export CARDANO_TESTNET_MAGIC=2
+MAGIC=(--testnet-magic 2)
+echo "${MAGIC[@]}"
+
+VALID_CONTRACT_ID=06b5a9fe7e9868648671333ee1a5ece61af9019b12251b68f1e9fc01cd7a12b2#1
+INVALID_CONTRACT_ID=06b5a9fe7e9868648671333ee1a5ece61af9019b12251b68f1e9fc01cd7a12b2
+MISSING_CONTRACT_ID=
+EMPTY_STRING_CONTRACT_ID=""
+marlowe rm --all
+
+echo "Test Scnario set up done"
+
+marlowe ls
+
+
+echo "Scenario: Adding a valid contract id to an empty history"
+
+marlowe add $VALID_CONTRACT_ID
+
+echo "Expect to see only $VALID_CONTRACT_ID managed in history"
+marlowe ls
+
+marlowe rm $VALID_CONTRACT_ID
+
+marlowe ls
+
+echo "Scenario: Adding an invalid contract id to an empty history"
+
+echo "Expect to see an error: Invalid UTXO - expected format: <hex-tx-id>#<tx-out-ix>"
+marlowe add $INVALID_CONTRACT_ID
+
+echo "Expect to see an error: Invalid UTXO - expected format: <hex-tx-id>#<tx-out-ix>"
+marlowe add $MISSING_CONTRACT_ID
+
+echo "Expect to see an error: Invalid UTXO - expected format: <hex-tx-id>#<tx-out-ix>"
+marlowe add $EMPTY_STRING_CONTRACT_ID

--- a/marlowe-runtime/integration-tests/add/non_empty_history.sh
+++ b/marlowe-runtime/integration-tests/add/non_empty_history.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+echo "Marlowe Runtime Tests: marlowe add with non empty history"
+
+echo "Test Scneario set up steps:"
+
+echo "Confirm marlowe run executable is installed"
+marlowe --help
+
+echo "set env variables"
+export CARDANO_NODE_SOCKET_PATH=/tmp/preview.socket
+export CARDANO_TESTNET_MAGIC=2
+MAGIC=(--testnet-magic 2)
+echo "${MAGIC[@]}"
+
+EXISTING_CONTRACT_ID=06b5a9fe7e9868648671333ee1a5ece61af9019b12251b68f1e9fc01cd7a12b2#1
+NEW_CONTRACT_ID=02811e36c6cdac4721b53f718c4a1406e09ef0d985f9ad6b7fd676769e2f866c#1
+INVALID_CONTRACT_ID=06b5a9fe7e9868648671333ee1a5ece61af9019b12251b68f1e9fc01cd7a12b2
+MISSING_CONTRACT_ID=
+
+marlowe rm $EXISTING_CONTRACT_ID
+marlowe rm $NEW_CONTRACT_ID
+marlowe add $EXISTING_CONTRACT_ID
+
+marlowe ls
+echo "Test Scnario set up done"
+
+echo "Scenario: Adding a new contract id when an existing contract is managed in history"
+marlowe add $NEW_CONTRACT_ID
+
+echo "Expect to see $EXISTING_CONTRACT_ID and $NEW_CONTRACT_ID in history"
+marlowe ls
+
+echo "Scenario: Adding an already managed contract id to history should raise an error"
+
+echo "Expect to see an error: 'Contract already managed in history"
+marlowe add $EXISTING_CONTRACT_ID
+
+echo "Expect to see $EXISTING_CONTRACT_ID and $NEW_CONTRACT_ID in history"
+marlowe ls
+
+echo "Expect to see an error: 'Contract already managed in history"
+marlowe add $NEW_CONTRACT_ID
+
+echo "Expect to see $EXISTING_CONTRACT_ID and $NEW_CONTRACT_ID in history"
+marlowe ls

--- a/marlowe-runtime/integration-tests/rm/empty_history.sh
+++ b/marlowe-runtime/integration-tests/rm/empty_history.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+echo "Marlowe Runtime Tests: marlowe rm with empty history"
+
+echo "Test Scneario set up steps:"
+
+echo "Confirm marlowe run executable is installed"
+marlowe --help
+
+git rev-parse HEAD
+
+export CARDANO_NODE_SOCKET_PATH=/tmp/node.socket
+export CARDANO_TESTNET_MAGIC=2
+MAGIC=(--testnet-magic 2)
+echo "${MAGIC[@]}"
+
+VALID_CONTRACT_ID=06b5a9fe7e9868648671333ee1a5ece61af9019b12251b68f1e9fc01cd7a12b2#1
+INVALID_CONTRACT_ID=06b5a9fe7e9868648671333ee1a5ece61af9019b12251b68f1e9fc01cd7a12b2
+MISSING_CONTRACT_ID=
+EMPTY_STRING_CONTRACT_ID=""
+echo "Test Scnario set up done"
+
+# marlowe rm --all not implemented yet
+
+echo "Scenario: Removing non existent contract"
+
+echo "Expect to see error: 'Contract ID: $VALID_CONTRACT_ID is not managed in history'"
+marlowe rm $VALID_CONTRACT_ID
+
+echo "Expect to see no contracts managed in history"
+marlowe ls

--- a/marlowe-runtime/integration-tests/rm/non_empty_history.sh
+++ b/marlowe-runtime/integration-tests/rm/non_empty_history.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+echo "Marlowe Runtime Tests: marlowe rm with non empty history"
+
+echo "Test Scneario set up steps:"
+
+echo "Confirm marlowe run executable is installed"
+marlowe --help
+
+git rev-parse HEAD
+
+export CARDANO_NODE_SOCKET_PATH=/tmp/node.socket
+export CARDANO_TESTNET_MAGIC=2
+MAGIC=(--testnet-magic 2)
+echo "${MAGIC[@]}"
+
+OLD_CONTRACT_ID=06b5a9fe7e9868648671333ee1a5ece61af9019b12251b68f1e9fc01cd7a12b2#1
+NEW_CONTRACT_ID=02811e36c6cdac4721b53f718c4a1406e09ef0d985f9ad6b7fd676769e2f866c#1
+echo "Test Scnario set up done"
+
+echo "Scenario: Removing one contract from list of contracts"
+marlowe add $OLD_CONTRACT_ID
+marlowe add $NEW_CONTRACT_ID
+
+marlowe rm $OLD_CONTRACT_ID
+
+echo "Expect to see $NEW_CONTRACT_ID only"
+marlowe ls
+
+# TODO: Implement --all flag
+# marlowe rm --all
+marlowe add $OLD_CONTRACT_ID 
+marlowe rm $NEW_CONTRACT_ID
+
+# TODO: Implement --all flag
+# marlowe rm --all
+marlowe add $OLD_CONTRACT_ID 
+marlowe rm $OLD_CONTRACT_ID


### PR DESCRIPTION
Implements basic integration tests for `add` and `rm` marlowe runtime commands as bash scripts.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] Reviewer requested
