### PR TITLE
Scp 4569 slow utxo query

### DIFF
--- a/nix/dev/compose.nix
+++ b/nix/dev/compose.nix
@@ -98,7 +98,7 @@ let
       # TODO Connect volumes here to top-level volumes
       volumes = [
         "postgres:/var/lib/postgresql/data"
-        "./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:r"
+        "./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql"
         "./:/src"
         "/nix:/nix"
         "${symlinks}:/exec"

--- a/packages.nix
+++ b/packages.nix
@@ -1,7 +1,7 @@
 { system
 , packagesBySystem
 , inputs
-, networkNixName ? "preview"
+, networkNixName ? "preprod"
 }:
 let
   packages = packagesBySystem.${system};


### PR DESCRIPTION
Query was slow because it was filtering on the non-indexed `address` field. The index is on the MD5 hash of the address instead. Updated the `WHERE` clause of the query in question to take advantage of this, and added a comment to the file about this very non-obvious requirement for querying by address.