### PR TITLE
Add kind annotations to `(Client|Server)HasAgency` constructors

### DIFF
--- a/marlowe-protocols/src/Network/Protocol/ChainSeek/Types.hs
+++ b/marlowe-protocols/src/Network/Protocol/ChainSeek/Types.hs
@@ -147,7 +147,7 @@ instance Protocol (ChainSeek query point tip) where
 
   data ServerHasAgency st where
     TokHandshake :: ServerHasAgency 'StHandshake
-    TokNext :: Tag query err result -> TokNextKind k -> ServerHasAgency ('StNext err result k)
+    TokNext :: Tag query err result -> TokNextKind k -> ServerHasAgency ('StNext err result k :: ChainSeek query point tip)
 
   data NobodyHasAgency st where
     TokFault :: NobodyHasAgency 'StFault

--- a/marlowe-protocols/src/Network/Protocol/Job/Types.hs
+++ b/marlowe-protocols/src/Network/Protocol/Job/Types.hs
@@ -130,10 +130,10 @@ instance Protocol (Job cmd) where
 
   data ClientHasAgency st where
     TokInit :: ClientHasAgency 'StInit
-    TokAwait :: Tag cmd status err result -> ClientHasAgency ('StAwait status err result)
+    TokAwait :: Tag cmd status err result -> ClientHasAgency ('StAwait status err result :: Job cmd)
 
   data ServerHasAgency st where
-    TokCmd :: Tag cmd status err result -> ServerHasAgency ('StCmd status err result)
+    TokCmd :: Tag cmd status err result -> ServerHasAgency ('StCmd status err result :: Job cmd)
     TokAttach :: Tag cmd status err result -> ServerHasAgency ('StAttach status err result)
 
   data NobodyHasAgency st where

--- a/marlowe-protocols/src/Network/Protocol/Query/Codec.hs
+++ b/marlowe-protocols/src/Network/Protocol/Query/Codec.hs
@@ -14,7 +14,6 @@ import Data.Type.Equality (type (:~:)(Refl))
 import Network.Protocol.Codec (DeserializeError, GetMessage, PutMessage, binaryCodec)
 import Network.Protocol.Query.Types
 import Network.TypedProtocol.Codec
-import Unsafe.Coerce (unsafeCoerce)
 
 codecQuery
   :: forall query m
@@ -32,20 +31,20 @@ codecQuery = binaryCodec putMsg getMsg
       ServerAgency (TokNext _ tag) -> \case
         MsgReject err -> do
           putWord8 0x02
-          putTag (coerceTag tag)
-          putErr (coerceTag tag) err
+          putTag tag
+          putErr tag err
         MsgNextPage results delimiter -> do
           putWord8 0x03
-          putTag (coerceTag tag)
-          putResult (coerceTag tag) results
+          putTag tag
+          putResult tag results
           case delimiter of
             Nothing -> putWord8 0x01
-            Just d  -> putDelimiter (coerceTag tag) d
+            Just d  -> putDelimiter tag d
       ClientAgency (TokPage tag) -> \case
         MsgRequestNext delimiter -> do
           putWord8 0x04
-          putTag (coerceTag tag)
-          putDelimiter (coerceTag tag) delimiter
+          putTag tag
+          putDelimiter tag delimiter
         MsgDone -> putWord8 0x05
 
     getMsg :: GetMessage (Query query)
@@ -60,14 +59,14 @@ codecQuery = binaryCodec putMsg getMsg
         0x02 -> case tok of
           ServerAgency (TokNext TokCanReject qtag) -> do
             SomeTag qtag' :: SomeTag query <- getTag
-            case tagEq (coerceTag qtag) qtag' of
+            case tagEq qtag qtag' of
               Nothing                 -> fail "decoded query tag does not match expected query tag"
               Just (Refl, Refl, Refl) -> SomeMessage . MsgReject <$> getErr qtag'
           _ -> fail "Invalid protocol state for MsgReject"
         0x03 -> case tok of
           ServerAgency (TokNext _ qtag) -> do
             SomeTag qtag' :: SomeTag query <- getTag
-            case tagEq (coerceTag qtag) qtag' of
+            case tagEq qtag qtag' of
               Nothing   -> fail "decoded query tag does not match expected query tag"
               Just (Refl, Refl, Refl) -> do
                 result <- getResult qtag'
@@ -81,7 +80,7 @@ codecQuery = binaryCodec putMsg getMsg
         0x04 -> case tok of
           ClientAgency (TokPage qtag) -> do
             SomeTag qtag' :: SomeTag query <- getTag
-            case tagEq (coerceTag qtag) qtag' of
+            case tagEq qtag qtag' of
               Nothing                 -> fail "decoded query tag does not match expected query tag"
               Just (Refl, Refl, Refl) -> SomeMessage . MsgRequestNext <$> getDelimiter qtag'
           _                            -> fail "Invalid protocol state for MsgRequestNext"
@@ -90,9 +89,3 @@ codecQuery = binaryCodec putMsg getMsg
           _                        -> fail "Invalid protocol state for MsgDone"
         _ -> fail $ "Invalid msg tag " <> show tag
 
-    -- Unfortunately, the poly-kinded query parameter doesn't play nicely with
-    -- the `PeerHasAgency` type and it gets confused, thinking that 'query1'
-    -- and 'query' are unrelated types. So we have to coerce them (they will
-    -- absolutely be the same type constructor though).
-    coerceTag :: forall query1 delimiter err results. Tag query1 delimiter err results -> Tag query delimiter err results
-    coerceTag = unsafeCoerce

--- a/marlowe-protocols/src/Network/Protocol/Query/Types.hs
+++ b/marlowe-protocols/src/Network/Protocol/Query/Types.hs
@@ -91,10 +91,10 @@ instance Protocol (Query query) where
 
   data ClientHasAgency st where
     TokInit :: ClientHasAgency 'StInit
-    TokPage :: Tag query delimiter err results -> ClientHasAgency ('StPage delimiter err results)
+    TokPage :: Tag query delimiter err results -> ClientHasAgency ('StPage delimiter err results :: Query query)
 
   data ServerHasAgency st where
-    TokNext :: TokNextKind k -> Tag query delimiter err results -> ServerHasAgency ('StNext k delimiter err results)
+    TokNext :: TokNextKind k -> Tag query delimiter err results -> ServerHasAgency ('StNext k delimiter err results :: Query query)
 
   data NobodyHasAgency st where
     TokDone :: NobodyHasAgency 'StDone


### PR DESCRIPTION
This allows us to drop `coerceTag` from `Codecs` modules.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
