### PR TITLE
Async Components for Runtime

### DIFF
--- a/async-components/LICENSE
+++ b/async-components/LICENSE
@@ -1,0 +1,53 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/async-components/NOTICE
+++ b/async-components/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/async-components/async-components.cabal
+++ b/async-components/async-components.cabal
@@ -1,0 +1,56 @@
+cabal-version: 2.4
+name: async-components
+version: 0.0.0.0
+synopsis:
+  Async components for building concurrent server processes.
+bug-reports: https://github.com/input-output-hk/marlowe-cardano/issues
+license: Apache-2.0
+author: Jamie Bertram
+maintainer: jamie.bertram@iohk.io
+stability: experimental
+category: Language
+license-files:
+  LICENSE
+  NOTICE
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/marlowe-cardano
+  subdir: async-components
+
+library
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  default-extensions:
+    BlockArguments
+    DeriveAnyClass
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    ExplicitForAll
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    NamedFieldPuns
+    NumericUnderscores
+    OverloadedStrings
+    RecordWildCards
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TupleSections
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities
+  exposed-modules:
+    Control.Concurrent.Component
+  build-depends:
+      base >= 4.9 && < 5
+    , lifted-async
+    , monad-control
+    , stm
+    , transformers-base

--- a/async-components/src/Control/Concurrent/Component.hs
+++ b/async-components/src/Control/Concurrent/Component.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Control.Concurrent.Component
+  where
+
+import Control.Applicative (liftA2)
+import Control.Arrow
+import Control.Category
+import Control.Concurrent.Async.Lifted (Async, Concurrently(..), waitCatchSTM, withAsync)
+import Control.Concurrent.STM
+import Control.Monad (join)
+import Control.Monad.Base (MonadBase(liftBase))
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.Trans.Control (MonadBaseControl(StM))
+import Prelude hiding ((.))
+
+newtype Component m a b = Component { unComponent :: a -> STM (Concurrently m (), b) }
+  deriving Functor
+
+instance MonadBaseControl IO m => Applicative (Component m a) where
+  pure = Component . pure . pure . pure
+  cf <*> cx = Component $ (liftA2 . liftA2) (<*>) (unComponent cf) (unComponent cx)
+
+instance MonadBaseControl IO m => Monad (Component m a) where
+  c >>= k = Component \a -> do
+    (run1, x) <- unComponent c a
+    (run2, b) <- unComponent (k x) a
+    pure (run1 <> run2, b)
+
+instance MonadBaseControl IO m => Category (Component m) where
+  id = Component \a -> pure (pure (), a)
+  cbc . cab = Component \a -> do
+    (run1, b) <- unComponent cab a
+    (run2, c) <- unComponent cbc b
+    pure (run1 <> run2, c)
+
+instance MonadBaseControl IO m => Arrow (Component m) where
+  arr f = Component \a -> pure (pure (), f a)
+  c1 *** c2 = Component \(a, b) -> do
+    (run1, c) <- unComponent c1 a
+    (run2, d) <- unComponent c2 b
+    pure (run1 <> run2, (c, d))
+  c1 &&& c2 = Component \a -> do
+    (run1, b) <- unComponent c1 a
+    (run2, c) <- unComponent c2 a
+    pure (run1 <> run2, (b, c))
+  first c = Component \(a, d) -> fmap (,d) <$> unComponent c a
+  second c = Component \(d, a) -> fmap (d,) <$> unComponent c a
+
+instance MonadBaseControl IO m => ArrowChoice (Component m) where
+  c1 +++ c2 = Component $ either
+    ((fmap . fmap) Left . unComponent c1)
+    ((fmap . fmap) Right . unComponent c2)
+  c1 ||| c2 = Component $ either (unComponent c1) (unComponent c2)
+  left c = Component $ either
+    ((fmap . fmap) Left . unComponent c)
+    (pure . pure . Right)
+  right c = Component $ either
+    (pure . pure . Left)
+    ((fmap . fmap) Right . unComponent c)
+
+instance MonadBaseControl IO m => ArrowApply (Component m) where
+  app = Component $ uncurry unComponent
+
+instance MonadBaseControl IO m => ArrowLoop (Component m) where
+  loop c = Component \a -> mdo
+    (run, (b, d)) <- unComponent c (a, d)
+    pure (run, b)
+
+supervisor :: (MonadBaseControl IO m, MonadIO m) => Component m a b -> Component m a (STM b)
+supervisor c = Component \a -> do
+  (Concurrently run, b) <- unComponent c a
+  outputVar <- newTVar b
+  let
+    runWithRetry run' = withAsync run' \async -> join $ liftIO $ atomically do
+      result <- waitCatchSTM async
+      case result of
+        Left _ -> do
+          (Concurrently run'', b') <- unComponent c a
+          writeTVar outputVar b'
+          pure $ runWithRetry run''
+        Right _ -> pure $ pure ()
+  pure (Concurrently $ runWithRetry run, readTVar outputVar)
+
+supervisor_ :: (MonadBaseControl IO m, MonadIO m) => Component m a () -> Component m a ()
+supervisor_ c = Component \a -> do
+  (Concurrently run, _) <- unComponent c a
+  let
+    runWithRetry run' = withAsync run' \async -> join $ liftIO $ atomically do
+      result <- waitCatchSTM async
+      case result of
+        Left _ -> do
+          (Concurrently run'', _) <- unComponent c a
+          pure $ runWithRetry run''
+        Right _ -> pure $ pure ()
+  pure (Concurrently $ runWithRetry run, ())
+
+runComponent :: Component m a b -> a -> STM (m (), b)
+runComponent c a = do
+  (run, b) <- unComponent c a
+  pure (runConcurrently run, b)
+
+withComponent :: MonadBaseControl IO m => Component m a b -> a -> (b -> Async (StM m ()) -> m c) -> m c
+withComponent c a f = do
+  (Concurrently run, b) <- liftBase $ atomically $ unComponent c a
+  withAsync run $ f b
+
+component :: (a -> STM b) -> (a -> b -> m ()) -> Component m a b
+component initialize run = Component \a -> do
+  b <- initialize a
+  pure (Concurrently $ run a b, b)

--- a/async-components/src/Control/Concurrent/Component.hs
+++ b/async-components/src/Control/Concurrent/Component.hs
@@ -117,6 +117,9 @@ withComponent_ c a = withComponent c a . const
 component :: (a -> STM (m (), b)) -> Component m a b
 component run = Component $ (fmap . B.first) Concurrently . run
 
+component_ :: (a -> m ()) -> Component m a ()
+component_ = component . fmap (pure . (,()))
+
 serverComponent
   :: forall m a b
    . MonadBaseControl IO m
@@ -125,7 +128,7 @@ serverComponent
   -> m ()
   -> (a -> m b)
   -> Component m a ()
-serverComponent worker onWorkerError onWorkerTerminated accept = component \a ->
+serverComponent worker onWorkerError onWorkerTerminated accept = component_ \a ->
   let
     run :: m ()
     run = do
@@ -140,4 +143,4 @@ serverComponent worker onWorkerError onWorkerTerminated accept = component \a ->
             Left (Right ())  -> onWorkerTerminated
           wait aserver
  in
-    pure (run, ())
+    run

--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,7 @@ index-state: 2022-10-29T00:00:00Z
 -- with-compiler: ghc-8.10.7
 
 packages:
+  async-components
   marlowe
   marlowe-actus
   marlowe-chain-sync

--- a/marlowe-chain-sync/app/Main.hs
+++ b/marlowe-chain-sync/app/Main.hs
@@ -17,8 +17,7 @@ import Cardano.Api.Byron (toByronRequiresNetworkMagic)
 import qualified Cardano.Chain.Genesis as Byron
 import Cardano.Crypto (abstractHashToBytes, decodeAbstractHash)
 import Control.Concurrent.Component
-import Control.Concurrent.STM (atomically, modifyTVar, newTVarIO, readTVar)
-import Control.Exception (bracket, bracketOnError, finally, throwIO)
+import Control.Exception (bracket, bracketOnError, throwIO)
 import Control.Monad ((<=<))
 import Control.Monad.Trans.Except (ExceptT(ExceptT), runExceptT, withExceptT)
 import Data.String (IsString(fromString))

--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -73,7 +73,7 @@ library
   build-depends:
       base >= 4.9 && < 5
     , aeson
-    , async
+    , async-components
     , base16
     , binary
     , bytestring
@@ -121,6 +121,7 @@ executable chainseekd
   build-depends:
       base >= 4.9 && < 5
     , aeson
+    , async-components
     , base16
     , bytestring
     , cardano-api

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync.hs
@@ -20,8 +20,7 @@ import Language.Marlowe.Runtime.ChainSync.JobServer
 import Language.Marlowe.Runtime.ChainSync.NodeClient (CostModel, NodeClient(..), NodeClientDependencies(..), nodeClient)
 import Language.Marlowe.Runtime.ChainSync.QueryServer
   (ChainSyncQueryServerDependencies(..), RunQueryServer, chainSyncQueryServer)
-import Language.Marlowe.Runtime.ChainSync.Server
-  (ChainSyncServerDependencies(..), RunChainSeekServer, chainSyncServer)
+import Language.Marlowe.Runtime.ChainSync.Server (ChainSyncServerDependencies(..), RunChainSeekServer, chainSyncServer)
 import Language.Marlowe.Runtime.ChainSync.Store (ChainStore(..), ChainStoreDependencies(..), chainStore)
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (AcquireFailure)
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client (SubmitResult)

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync.hs
@@ -1,31 +1,28 @@
+{-# LANGUAGE Arrows #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Language.Marlowe.Runtime.ChainSync
-  ( ChainSync(..)
-  , ChainSyncDependencies(..)
-  , mkChainSync
+  ( ChainSyncDependencies(..)
+  , chainSync
   ) where
 
 import Cardano.Api (CardanoEra, CardanoMode, LocalNodeClientProtocolsInMode, Tx, TxValidationErrorInMode)
 import qualified Cardano.Api as Cardano
-import Control.Concurrent.Async (concurrently_)
-import Control.Concurrent.STM (STM)
-import Control.Monad (unless)
+import Control.Concurrent.Component
 import Data.Time (NominalDiffTime)
-import Language.Marlowe.Runtime.ChainSync.Database (CommitGenesisBlock(..), DatabaseQueries(..), GetGenesisBlock(..))
+import Language.Marlowe.Runtime.ChainSync.Database (DatabaseQueries(..))
 import Language.Marlowe.Runtime.ChainSync.Genesis (GenesisBlock)
 import Language.Marlowe.Runtime.ChainSync.JobServer
-  (ChainSyncJobServer(..), ChainSyncJobServerDependencies(..), RunJobServer, mkChainSyncJobServer)
-import Language.Marlowe.Runtime.ChainSync.NodeClient
-  (CostModel, NodeClient(..), NodeClientDependencies(..), mkNodeClient)
+  (ChainSyncJobServerDependencies(..), RunJobServer, chainSyncJobServer)
+import Language.Marlowe.Runtime.ChainSync.NodeClient (CostModel, NodeClient(..), NodeClientDependencies(..), nodeClient)
 import Language.Marlowe.Runtime.ChainSync.QueryServer
-  (ChainSyncQueryServer(..), ChainSyncQueryServerDependencies(..), RunQueryServer, mkChainSyncQueryServer)
+  (ChainSyncQueryServerDependencies(..), RunQueryServer, chainSyncQueryServer)
 import Language.Marlowe.Runtime.ChainSync.Server
-  (ChainSyncServer(..), ChainSyncServerDependencies(..), RunChainSeekServer, mkChainSyncServer)
-import Language.Marlowe.Runtime.ChainSync.Store (ChainStore(..), ChainStoreDependencies(..), mkChainStore)
+  (ChainSyncServerDependencies(..), RunChainSeekServer, chainSyncServer)
+import Language.Marlowe.Runtime.ChainSync.Store (ChainStore(..), ChainStoreDependencies(..), chainStore)
 import Ouroboros.Network.Protocol.LocalStateQuery.Type (AcquireFailure)
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client (SubmitResult)
 
@@ -51,26 +48,12 @@ data ChainSyncDependencies = ChainSyncDependencies
       -> IO (SubmitResult (TxValidationErrorInMode CardanoMode))
   }
 
-newtype ChainSync = ChainSync { runChainSync :: IO () }
-
-mkChainSync :: ChainSyncDependencies -> STM ChainSync
-mkChainSync ChainSyncDependencies{..} = do
+chainSync :: Component IO ChainSyncDependencies ()
+chainSync = proc ChainSyncDependencies{..} -> do
   let DatabaseQueries{..} = databaseQueries
-  NodeClient{..} <- mkNodeClient NodeClientDependencies{..}
+  NodeClient{..} <- nodeClient -< NodeClientDependencies{..}
   let rateLimit = persistRateLimit
-  ChainStore{..} <- mkChainStore ChainStoreDependencies{..}
-  ChainSyncServer{..} <- mkChainSyncServer ChainSyncServerDependencies{..}
-  ChainSyncQueryServer{..} <- mkChainSyncQueryServer ChainSyncQueryServerDependencies{..}
-  ChainSyncJobServer{..} <- mkChainSyncJobServer ChainSyncJobServerDependencies{..}
-  pure $ ChainSync do
-    mDbGenesisBlock <- runGetGenesisBlock getGenesisBlock
-    case mDbGenesisBlock of
-      Just dbGenesisBlock -> unless (dbGenesisBlock == genesisBlock) do
-        fail "Existing genesis block does not match computed genesis block"
-      Nothing -> runCommitGenesisBlock commitGenesisBlock genesisBlock
-
-    runNodeClient
-      `concurrently_` runChainStore
-      `concurrently_` runChainSyncServer
-      `concurrently_` runChainSyncQueryServer
-      `concurrently_` runChainSyncJobServer
+  ChainStore{..} <- chainStore -< ChainStoreDependencies{..}
+  chainSyncServer -< ChainSyncServerDependencies{..}
+  chainSyncQueryServer -< ChainSyncQueryServerDependencies{..}
+  chainSyncJobServer -< ChainSyncJobServerDependencies{..}

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/JobServer.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/JobServer.hs
@@ -9,10 +9,7 @@ module Language.Marlowe.Runtime.ChainSync.JobServer
   where
 
 import Cardano.Api (CardanoEra(..), CardanoMode, ScriptDataSupportedInEra(..), Tx, TxValidationErrorInMode)
-import Control.Concurrent.Async (Concurrently(..))
-import Control.Concurrent.STM (STM, atomically)
-import Control.Exception (SomeException, catch)
-import Data.Void (Void)
+import Control.Concurrent.Component
 import Language.Marlowe.Runtime.ChainSync.Api (ChainSyncCommand(..))
 import Network.Protocol.Driver (RunServer(..))
 import Network.Protocol.Job.Server
@@ -30,22 +27,14 @@ data ChainSyncJobServerDependencies = ChainSyncJobServerDependencies
       -> IO (SubmitResult (TxValidationErrorInMode CardanoMode))
   }
 
-newtype ChainSyncJobServer = ChainSyncJobServer
-  { runChainSyncJobServer :: IO Void
-  }
-
-mkChainSyncJobServer :: ChainSyncJobServerDependencies -> STM ChainSyncJobServer
-mkChainSyncJobServer ChainSyncJobServerDependencies{..} = do
-  let
-    runChainSyncJobServer = do
+chainSyncJobServer :: Component IO ChainSyncJobServerDependencies ()
+chainSyncJobServer = serverComponent
+  worker
+  (hPutStrLn stderr . ("Job worker crashed with exception: " <>) . show)
+  (hPutStrLn stderr "Job client terminated normally")
+  \ChainSyncJobServerDependencies{..} -> do
       runJobServer <- acceptRunJobServer
-      Worker{..} <- atomically $ mkWorker WorkerDependencies {..}
-      runConcurrently $
-        Concurrently (runWorker `catch` catchWorker) *> Concurrently runChainSyncJobServer
-  pure $ ChainSyncJobServer { runChainSyncJobServer }
-
-catchWorker :: SomeException -> IO ()
-catchWorker = hPutStrLn stderr . ("Job worker crashed with exception: " <>) . show
+      pure WorkerDependencies {..}
 
 data WorkerDependencies = WorkerDependencies
   { runJobServer      :: RunJobServer IO
@@ -56,17 +45,11 @@ data WorkerDependencies = WorkerDependencies
       -> IO (SubmitResult (TxValidationErrorInMode CardanoMode))
   }
 
-newtype Worker = Worker
-  { runWorker :: IO ()
-  }
-
-mkWorker :: WorkerDependencies -> STM Worker
-mkWorker WorkerDependencies{..} =
+worker :: Component IO WorkerDependencies ()
+worker = component \WorkerDependencies{..} ->
   let
     RunServer run = runJobServer
-  in
-    pure Worker { runWorker = run server }
-  where
+
     server :: JobServer ChainSyncCommand IO ()
     server = liftCommandHandler $ flip either (\case) \case
       SubmitTx era tx -> ((),) <$> do
@@ -78,3 +61,5 @@ mkWorker WorkerDependencies{..} =
         pure case result of
           SubmitFail err -> Left $ show err
           SubmitSuccess -> Right ()
+  in
+    pure (run server, ())

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/JobServer.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/JobServer.hs
@@ -46,7 +46,7 @@ data WorkerDependencies = WorkerDependencies
   }
 
 worker :: Component IO WorkerDependencies ()
-worker = component \WorkerDependencies{..} ->
+worker = component_ \WorkerDependencies{..} -> do
   let
     RunServer run = runJobServer
 
@@ -61,5 +61,4 @@ worker = component \WorkerDependencies{..} ->
         pure case result of
           SubmitFail err -> Left $ show err
           SubmitSuccess -> Right ()
-  in
-    pure (run server, ())
+  run server

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
@@ -22,9 +22,7 @@ import Cardano.Api
   , toEraInMode
   )
 import qualified Cardano.Api as Cardano
-import Control.Concurrent.Async (Concurrently(Concurrently, runConcurrently))
-import Control.Concurrent.STM (STM, atomically)
-import Control.Exception (SomeException, catch)
+import Control.Concurrent.Component
 import Control.Monad.Trans.Except (ExceptT(ExceptT), except, runExceptT, throwE, withExceptT)
 import Data.Bifunctor (bimap, first)
 import Data.Void (Void, absurd)
@@ -49,22 +47,14 @@ data ChainSyncQueryServerDependencies = ChainSyncQueryServerDependencies
   , getUTxOs :: !(Database.GetUTxOs IO)
   }
 
-newtype ChainSyncQueryServer = ChainSyncQueryServer
-  { runChainSyncQueryServer :: IO Void
-  }
-
-mkChainSyncQueryServer :: ChainSyncQueryServerDependencies -> STM ChainSyncQueryServer
-mkChainSyncQueryServer ChainSyncQueryServerDependencies{..} = do
-  let
-    runChainSyncQueryServer = do
+chainSyncQueryServer :: Component IO ChainSyncQueryServerDependencies ()
+chainSyncQueryServer = serverComponent
+  worker
+  (hPutStrLn stderr . ("Query worker crashed with exception: " <>) . show)
+  (hPutStrLn stderr "Query client terminated normally")
+  \ChainSyncQueryServerDependencies{..} -> do
       runQueryServer <- acceptRunQueryServer
-      Worker{..} <- atomically $ mkWorker WorkerDependencies {..}
-      runConcurrently $
-        Concurrently (runWorker `catch` catchWorker) *> Concurrently runChainSyncQueryServer
-  pure $ ChainSyncQueryServer { runChainSyncQueryServer }
-
-catchWorker :: SomeException -> IO ()
-catchWorker = hPutStrLn stderr . ("Query worker crashed with exception: " <>) . show
+      pure WorkerDependencies {..}
 
 data WorkerDependencies = WorkerDependencies
   { runQueryServer      :: RunQueryServer IO
@@ -76,18 +66,11 @@ data WorkerDependencies = WorkerDependencies
   , getUTxOs :: !(Database.GetUTxOs IO)
   }
 
-newtype Worker = Worker
-  { runWorker :: IO ()
-  }
-
-mkWorker :: WorkerDependencies -> STM Worker
-mkWorker WorkerDependencies{..} =
+worker :: Component IO WorkerDependencies ()
+worker = component \WorkerDependencies{..} ->
   let
     RunServer run = runQueryServer
-  in
-    pure Worker { runWorker = run server }
 
-  where
     server :: QueryServer ChainSyncQuery IO ()
     server = QueryServer $ pure $ ServerStInit \case
       GetSlotConfig        -> queryGenesisParameters extractSlotConfig
@@ -139,3 +122,5 @@ mkWorker WorkerDependencies{..} =
       withExceptT (const ()) $ except result
 
     extractSlotConfig GenesisParameters{..} = SlotConfig protocolParamSystemStart protocolParamSlotLength
+  in
+    pure (run server, ())

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
@@ -67,7 +67,7 @@ data WorkerDependencies = WorkerDependencies
   }
 
 worker :: Component IO WorkerDependencies ()
-worker = component \WorkerDependencies{..} ->
+worker = component_ \WorkerDependencies{..} -> do
   let
     RunServer run = runQueryServer
 
@@ -122,5 +122,4 @@ worker = component \WorkerDependencies{..} ->
       withExceptT (const ()) $ except result
 
     extractSlotConfig GenesisParameters{..} = SlotConfig protocolParamSystemStart protocolParamSlotLength
-  in
-    pure (run server, ())
+  run server

--- a/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Server.hs
+++ b/marlowe-chain-sync/src/Language/Marlowe/Runtime/ChainSync/Server.hs
@@ -55,7 +55,7 @@ data WorkerDependencies = WorkerDependencies
   }
 
 worker :: Component IO WorkerDependencies ()
-worker = component \WorkerDependencies{..} -> do
+worker = component_ \WorkerDependencies{..} -> do
   let
     RunServer runServer = runChainSeekServer
     runWorker = void $ runServer server
@@ -95,4 +95,4 @@ worker = component \WorkerDependencies{..} -> do
       , recvMsgDone = pure ()
       }
 
-  pure (runWorker, ())
+  runWorker

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -281,7 +281,6 @@ executable marlowe
       aeson
     , base >= 4.9 && < 5
     , ansi-terminal
-    , async
     , base16
     , bytestring
     , cardano-api
@@ -333,7 +332,7 @@ executable marlowe-history
   build-depends:
       base >= 4.9 && < 5
     , ansi-terminal
-    , async
+    , async-components
     , base16
     , containers
     , marlowe
@@ -359,7 +358,7 @@ executable marlowe-discovery
   build-depends:
       base >= 4.9 && < 5
     , ansi-terminal
-    , async
+    , async-components
     , base16
     , containers
     , marlowe
@@ -384,7 +383,6 @@ executable marlowe-tx
     Paths_marlowe_runtime
   build-depends:
       ansi-terminal
-    , async
     , base >= 4.9 && < 5
     , base16
     , bytestring

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -104,6 +104,7 @@ library
       base >= 4.9 && < 5
     , aeson
     , async
+    , async-components
     , base16
     , binary
     , cardano-api

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -211,6 +211,7 @@ library web-server
       base >= 4.9 && < 5
     , aeson
     , async
+    , async-components
     , bytestring
     , cardano-api
     , containers
@@ -417,6 +418,7 @@ executable marlowe-web-server
     Paths_marlowe_runtime
   build-depends:
       base >= 4.9 && < 5
+    , async-components
     , bytestring
     , eventuo11y-json
     , exceptions

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -384,6 +384,7 @@ executable marlowe-tx
   build-depends:
       ansi-terminal
     , base >= 4.9 && < 5
+    , async-components
     , base16
     , bytestring
     , cardano-api
@@ -448,6 +449,7 @@ test-suite marlowe-runtime-test
   build-depends:
       base >= 4.9 && < 5
     , async
+    , async-components
     , bytestring
     , cardano-api
     , cardano-api:gen

--- a/marlowe-runtime/src/Language/Marlowe/Runtime/History.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/History.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Arrows #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecursiveDo #-}
@@ -6,17 +7,14 @@
 module Language.Marlowe.Runtime.History
   where
 
-import Control.Concurrent.Async (Concurrently(..))
-import Control.Concurrent.STM (STM)
-import Data.Foldable (asum)
+import Control.Concurrent.Component
 import Language.Marlowe.Runtime.ChainSync.Api (RuntimeChainSeekClient, SlotConfig)
 import Language.Marlowe.Runtime.History.FollowerSupervisor
 import Language.Marlowe.Runtime.History.JobServer
 import Language.Marlowe.Runtime.History.QueryServer
 import Language.Marlowe.Runtime.History.Store
-  (HistoryQueries, HistoryStore(..), HistoryStoreDependencies(..), mkHistoryStore)
-import Language.Marlowe.Runtime.History.SyncServer
-  (HistorySyncServer(..), HistorySyncServerDependencies(..), RunSyncServer, mkHistorySyncServer)
+  (HistoryQueries, HistoryStore(..), HistoryStoreDependencies(..), historyStore)
+import Language.Marlowe.Runtime.History.SyncServer (HistorySyncServerDependencies(..), RunSyncServer, historySyncServer)
 import Numeric.Natural (Natural)
 
 data HistoryDependencies = HistoryDependencies
@@ -30,23 +28,10 @@ data HistoryDependencies = HistoryDependencies
   , historyQueries       :: HistoryQueries IO
   }
 
-newtype History = History
-  { runHistory :: IO ()
-  }
-
-mkHistory :: HistoryDependencies -> STM History
-mkHistory HistoryDependencies{..} = do
-  FollowerSupervisor{..} <- mkFollowerSupervisor FollowerSupervisorDependencies{..}
-  HistoryJobServer{..} <- mkHistoryJobServer HistoryJobServerDependencies{..}
-  HistoryQueryServer{..} <- mkHistoryQueryServer HistoryQueryServerDependencies{..}
-  HistoryStore{..} <- mkHistoryStore HistoryStoreDependencies{..}
-  HistorySyncServer{..} <- mkHistorySyncServer HistorySyncServerDependencies{..}
-  pure History
-    { runHistory = runConcurrently $ asum $ Concurrently <$>
-        [ runFollowerSupervisor
-        , runHistoryJobServer
-        , runHistoryQueryServer
-        , runHistoryStore
-        , runHistorySyncServer
-        ]
-    }
+history :: Component IO HistoryDependencies ()
+history = proc HistoryDependencies{..} -> do
+  FollowerSupervisor{..} <- followerSupervisor -< FollowerSupervisorDependencies{..}
+  historyJobServer -< HistoryJobServerDependencies{..}
+  historyQueryServer -< HistoryQueryServerDependencies{..}
+  HistoryStore{..} <- historyStore -< HistoryStoreDependencies{..}
+  historySyncServer -< HistorySyncServerDependencies{..}

--- a/marlowe-runtime/web-server-app/Main.hs
+++ b/marlowe-runtime/web-server-app/Main.hs
@@ -9,7 +9,7 @@
 module Main
   where
 
-import Control.Concurrent.STM (atomically)
+import Control.Concurrent.Component (runComponent_)
 import Control.Exception (throwIO)
 import Language.Marlowe.Protocol.HeaderSync.Client (marloweHeaderSyncClientPeer)
 import Language.Marlowe.Protocol.HeaderSync.Codec (codecMarloweHeaderSync)
@@ -31,8 +31,7 @@ main = hSetBuffering stdout LineBuffering
   >> hSetBuffering stderr LineBuffering
   >> getOptions
   >>= optionsToServerDependencies
-  >>= atomically . mkServer
-  >>= runServer
+  >>= runComponent_ server
 
 optionsToServerDependencies :: Options -> IO (ServerDependencies JSONRef)
 optionsToServerDependencies Options{..} = do

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/HistoryClient.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/HistoryClient.hs
@@ -6,6 +6,8 @@
 module Language.Marlowe.Runtime.Web.Server.HistoryClient
   where
 
+import Control.Arrow (arr)
+import Control.Concurrent.Component
 import Control.Concurrent.STM (STM, atomically)
 import Control.Error (note)
 import Data.List (sortOn)
@@ -76,8 +78,8 @@ data HistoryClient r = HistoryClient
   , loadTransactions :: LoadTransactions r IO -- ^ Load transactions for a contract from the indexer.
   }
 
-mkHistoryClient :: HistoryClientDependencies r -> STM (HistoryClient r)
-mkHistoryClient HistoryClientDependencies{..} = pure HistoryClient
+historyClient :: Component IO (HistoryClientDependencies r) (HistoryClient r)
+historyClient = arr \HistoryClientDependencies{..} -> HistoryClient
   { loadContract = \mods contractId -> do
       result <- runMarloweSyncClient $ loadContractClient (modifyEventBackend mods eventBackend) contractId
       case result of

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
@@ -4,6 +4,7 @@ module Language.Marlowe.Runtime.Web.Server.TxClient
   where
 
 import Cardano.Api (BabbageEra)
+import Control.Concurrent.Component
 import Control.Concurrent.STM (STM, atomically, modifyTVar, newTVar, readTVar)
 import Data.Foldable (for_)
 import qualified Data.Map as Map
@@ -39,10 +40,10 @@ data TxClient = TxClient
   , getTempContracts :: STM [TempContract]
   }
 
-mkTxClient :: TxClientDependencies -> STM TxClient
-mkTxClient TxClientDependencies{..} = do
+txClient :: Component IO TxClientDependencies TxClient
+txClient = component \TxClientDependencies{..} -> do
   tempContracts <- newTVar mempty
-  pure TxClient
+  pure $ pure TxClient
     { createContract = \stakeCredential version addresses roles metadata minUTxODeposit contract -> do
         response <- runTxJobClient
           $ liftCommand

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/async-components.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/async-components.nix
@@ -1,0 +1,47 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "async-components"; version = "0.0.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jamie.bertram@iohk.io";
+      author = "Jamie Bertram";
+      homepage = "";
+      url = "";
+      synopsis = "Async components for building concurrent server processes.";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."lifted-async" or (errorHandler.buildDepError "lifted-async"))
+          (hsPkgs."monad-control" or (errorHandler.buildDepError "monad-control"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."transformers-base" or (errorHandler.buildDepError "transformers-base"))
+          ];
+        buildable = true;
+        modules = [ "Control/Concurrent/Component" ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../async-components; }

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
@@ -35,7 +35,7 @@
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-          (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
           (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
@@ -95,6 +95,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -171,6 +171,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
@@ -381,6 +382,7 @@
         "marlowe-web-server" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."eventuo11y-json" or (errorHandler.buildDepError "eventuo11y-json"))
             (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -36,6 +36,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
           (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
@@ -237,7 +238,6 @@
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
@@ -300,7 +300,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
@@ -325,7 +325,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
@@ -349,8 +349,8 @@
         "marlowe-tx" = {
           depends = [
             (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
@@ -407,6 +407,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -830,6 +830,7 @@
         small-steps = ./.plan.nix/small-steps.nix;
         plutus-script-utils = ./.plan.nix/plutus-script-utils.nix;
         marlowe-protocols-test = ./.plan.nix/marlowe-protocols-test.nix;
+        async-components = ./.plan.nix/async-components.nix;
         ouroboros-network-framework = ./.plan.nix/ouroboros-network-framework.nix;
         orphans-deriving-via = ./.plan.nix/orphans-deriving-via.nix;
         marlowe-chain-sync = ./.plan.nix/marlowe-chain-sync.nix;
@@ -996,6 +997,7 @@
             flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
             };
           "marlowe-protocols-test" = { flags = {}; };
+          "async-components" = { flags = {}; };
           "ouroboros-network-framework" = { flags = {}; };
           "orphans-deriving-via" = {
             flags = { "development" = lib.mkOverride 900 false; };
@@ -1446,6 +1448,7 @@
           "natural-arithmetic".components.library.planned = lib.mkOverride 900 true;
           "secp256k1-haskell".components.library.planned = lib.mkOverride 900 true;
           "bech32".components.library.planned = lib.mkOverride 900 true;
+          "async-components".components.library.planned = lib.mkOverride 900 true;
           "ghc".components.library.planned = lib.mkOverride 900 true;
           "th-expand-syns".components.library.planned = lib.mkOverride 900 true;
           "postgresql-syntax".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/async-components.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/async-components.nix
@@ -1,0 +1,47 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "async-components"; version = "0.0.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jamie.bertram@iohk.io";
+      author = "Jamie Bertram";
+      homepage = "";
+      url = "";
+      synopsis = "Async components for building concurrent server processes.";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = ".";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."lifted-async" or (errorHandler.buildDepError "lifted-async"))
+          (hsPkgs."monad-control" or (errorHandler.buildDepError "monad-control"))
+          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."transformers-base" or (errorHandler.buildDepError "transformers-base"))
+          ];
+        buildable = true;
+        modules = [ "Control/Concurrent/Component" ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../async-components; }

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
@@ -35,7 +35,7 @@
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-          (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
           (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
@@ -95,6 +95,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -171,6 +171,7 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
@@ -381,6 +382,7 @@
         "marlowe-web-server" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."eventuo11y-json" or (errorHandler.buildDepError "eventuo11y-json"))
             (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -36,6 +36,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."async" or (errorHandler.buildDepError "async"))
+          (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
           (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
           (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
@@ -237,7 +238,6 @@
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
@@ -300,7 +300,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
@@ -325,7 +325,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
@@ -349,8 +349,8 @@
         "marlowe-tx" = {
           depends = [
             (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
@@ -407,6 +407,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."async-components" or (errorHandler.buildDepError "async-components"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."cardano-api".components.sublibs.gen or (errorHandler.buildDepError "cardano-api:gen"))

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -835,6 +835,7 @@
         small-steps = ./.plan.nix/small-steps.nix;
         plutus-script-utils = ./.plan.nix/plutus-script-utils.nix;
         marlowe-protocols-test = ./.plan.nix/marlowe-protocols-test.nix;
+        async-components = ./.plan.nix/async-components.nix;
         ouroboros-network-framework = ./.plan.nix/ouroboros-network-framework.nix;
         orphans-deriving-via = ./.plan.nix/orphans-deriving-via.nix;
         marlowe-chain-sync = ./.plan.nix/marlowe-chain-sync.nix;
@@ -1001,6 +1002,7 @@
             flags = { "defer-plugin-errors" = lib.mkOverride 900 false; };
             };
           "marlowe-protocols-test" = { flags = {}; };
+          "async-components" = { flags = {}; };
           "ouroboros-network-framework" = { flags = {}; };
           "orphans-deriving-via" = {
             flags = { "development" = lib.mkOverride 900 false; };
@@ -1453,6 +1455,7 @@
           "natural-arithmetic".components.library.planned = lib.mkOverride 900 true;
           "secp256k1-haskell".components.library.planned = lib.mkOverride 900 true;
           "bech32".components.library.planned = lib.mkOverride 900 true;
+          "async-components".components.library.planned = lib.mkOverride 900 true;
           "ghc".components.library.planned = lib.mkOverride 900 true;
           "th-expand-syns".components.library.planned = lib.mkOverride 900 true;
           "postgresql-syntax".components.library.planned = lib.mkOverride 900 true;


### PR DESCRIPTION
This refactor formalizes the pattern used in the runtime projects for concurrent programming into a `Component` abstraction.

`Components` use the `Arrow` interface to declare dependencies, and the concurrent composition of the worker threads is abstracted in typeclass instances. Here is an example change:

```hs
-- before
mkMyComponent :: MyComponentDependencies -> STM MyComponent
mkMyComponent MyComponentDependencies{..} = do
  ComponentA{..} <- mkComponentA ComponentADependencies{..}
  ComponentB{..} <- mkComponentB ComponentBDependencies{..}
  ComponentC{..} <- mkComponentC ComponentCDependencies{..}
  pure MyComponent
    { runMyComponent = mapConcurrently_ id
        [ runComponentA
        , runComponentB
        , runComponentC
        ]
    }

-- after
myComponent :: Component IO MyComponentDependencies ()
myComponent = proc MyComponentDependencies{..} -> do -- Arrow syntax
  ComponentA{..} <- componentA -< ComponentADependencies{..}
  ComponentB{..} <- componentB -< ComponentBDependencies{..}
  componentC -< ComponentCDependencies{..}
```

It is also not limited to IO - `Components` work with any `m` that is an instance of `MonadBaseControl IO` (implemented via `lifted-async`)