### PR TITLE
Patched Fix CVE-2021-33503

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -30,4 +30,4 @@ requests==2.24.0
 six==1.15.0
 snowballstemmer==2.0.0
 sphinxcontrib-websupport==1.2.2
-urllib3==1.25.9
+urllib3==1.26.5


### PR DESCRIPTION
When provided with a URL containing many `@` characters in the authority component the authority regular expression exhibits catastrophic backtracking causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect.


CVE-2021-33503
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
