### PR TITLE
SCP-4566 Clarified relationship between redeemer and input in spec.

### DIFF
--- a/marlowe/specification/marlowe-cardano-specification.md
+++ b/marlowe/specification/marlowe-cardano-specification.md
@@ -183,7 +183,7 @@ The input present in the redeemer and script context is the input provided to th
 ```haskell
 marloweInput ∪ txInfoValidRange (scriptContextTxInfo scriptContext) ∪ txInfoData (scriptContextTxInfo scriptContext) ≅ transactionInput
 ```
-This is a congruence because `marloweInput` contains the input (perhaps including the Merkle hash of the contract's continuation) and `txInfoValidRange` of the script context contains the validity interval for the transaction, whereas `transactionInput` contains both. Additionally, any continued contract is present in `txInfoData` of the script context, whereas it is directly present in any `MerkleizedInput` of `transactionInput`. Also note that the script context may, in principle, contain an open, closed, or half-open/half-closed time interval, but Marlowe semantics requires a closed time interval.
+This is a congruence because `marloweInput` contains the input (perhaps including the Merkle hash of the contract's continuation) and the `txInfoValidRange` of the script context contains the validity interval for the transaction, whereas the `transactionInput` contains both. Any merkleized contract continuation is present in the `txInfoData` of the script context, whereas it is directly present in any `MerkleizedInput` of `transactionInput`. Also note that the script context may, in principle, contain an open, closed, or half-open/half-closed time interval, but Marlowe semantics requires a closed time interval.
 
 
 #### *Constraint 1.* Typed validation

--- a/marlowe/specification/marlowe-cardano-specification.md
+++ b/marlowe/specification/marlowe-cardano-specification.md
@@ -177,6 +177,15 @@ Furthermore, let `marloweValidatorHash :: ValidatorHash` be the hash of the Marl
 The validation fails (via returning `False` for `validationResult` or via the throwing of an error) if any of the following constraints does not hold. Fundamentally, all failures in Plutus are calls to `error` and all successes are returns of `()`. The typed Plutus validators obscure this distinction slightly by using `Bool` as the return type.
 
 
+#### *Constraint 0.* Input to contract
+
+The input present in the redeemer and script context is the input provided to the semantics computation.
+```haskell
+marloweInput ∪ txInfoValidRange (scriptContextTxInfo scriptContext) ∪ txInfoData (scriptContextTxInfo scriptContext) ≅ transactionInput
+```
+This is a congruence because `marloweInput` contains the input (perhaps including the Merkle hash of the contract's continuation) and `txInfoValidRange` of the script context contains the validity interval for the transaction, whereas `transactionInput` contains both. Additionally, any continued contract is present in `txInfoData` of the script context, whereas it is directly present in any `MerkleizedInput` of `transactionInput`. Also note that the script context may, in principle, contain an open, closed, or half-open/half-closed time interval, but Marlowe semantics requires a closed time interval.
+
+
 #### *Constraint 1.* Typed validation
 
 The datum, redeemer, and script context deserialize to the correct types.
@@ -184,7 +193,7 @@ The datum, redeemer, and script context deserialize to the correct types.
 Let `datum :: BuiltinData` and `redeemer :: BuiltinData` be the datum and redeemer in the script witness for spending the Marlowe UTxO, and let `scriptContext' :: BuiltinData` be the script context data.
 ```haskell
 fromBuiltinData datum          ≡ (Just marloweData   :: Maybe MarloweData)
-fromBuiltinData redeemer       ≡ (Just markloweInput :: Maybe MarloweInput)
+fromBuiltinData redeemer       ≡ (Just marloweInput :: Maybe MarloweInput)
 fromBuiltinData scriptContext' ≡ (Just scriptContext :: Maybe ScriptContext)
 ```
 


### PR DESCRIPTION
Added a "Constraint 0" to the Marlowe-Cardano specification, clarifying that the redeemer and script context map to the semantics input.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
