### PR TITLE
Give ChainSeek Client agency on Wait

### DIFF
--- a/dev-shell.nix
+++ b/dev-shell.nix
@@ -95,6 +95,8 @@ let
     pkgs.docker-compose
     pkgs.sqitchPg
     pkgs.postgresql
+    pkgs.json2yaml
+    pkgs.yaml2json
   ]);
 
   defaultShellHook = ''

--- a/marlowe-chain-sync/api/Language/Marlowe/Runtime/ChainSync/Api.hs
+++ b/marlowe-chain-sync/api/Language/Marlowe/Runtime/ChainSync/Api.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -146,7 +145,6 @@ import GHC.Natural (Natural)
 import Network.Protocol.ChainSeek.Client
 import Network.Protocol.ChainSeek.Codec
 import Network.Protocol.ChainSeek.Server
-import Network.Protocol.ChainSeek.TH (mkSchemaVersion)
 import Network.Protocol.ChainSeek.Types
 import Network.Protocol.Job.Types (CommandToJSON)
 import qualified Network.Protocol.Job.Types as Job
@@ -628,7 +626,8 @@ data Move err result where
   -- | Advances to the tip block. Waits if already at the tip.
   AdvanceToTip :: Move Void ()
 
-mkSchemaVersion "moveSchema" ''Move
+moveSchema :: SchemaVersion
+moveSchema = SchemaVersion "move_unsafe"
 
 deriving instance Show (Move err result)
 deriving instance Eq (Move err result)

--- a/marlowe-chain-sync/example-client/FollowingUTxOs.hs
+++ b/marlowe-chain-sync/example-client/FollowingUTxOs.hs
@@ -25,7 +25,7 @@ client = ChainSeekClient stInit
           (TxOutRef "0a3eecbba8c47b5d941a4a06b3661a664c7290c071212365bb0fbc2e8ccd4112" 0, [])
           $ uncons hist
       putStrLn $ "Waiting for UTxO to be consumed: " <> show txOut
-      pure $ SendMsgQueryNext (FindConsumingTx txOut) (stNext txOut hist') $ pure $ stNext txOut hist'
+      pure $ SendMsgQueryNext (FindConsumingTx txOut) (stNext txOut hist')
 
     stNext txOut hist = ClientStNext
       { recvMsgQueryRejected = \err _ -> case err of
@@ -44,4 +44,5 @@ client = ChainSeekClient stInit
       , recvMsgRollBackward = \_ _ -> do
           putStr "Rolling back"
           stIdle hist
+      , recvMsgWait = pure $ SendMsgCancel $ SendMsgDone ()
       }

--- a/marlowe-chain-sync/example-client/SkippingBlocks.hs
+++ b/marlowe-chain-sync/example-client/SkippingBlocks.hs
@@ -1,6 +1,8 @@
 module SkippingBlocks
   where
 
+import Control.Concurrent (threadDelay)
+import Data.Functor (($>))
 import Data.Void (absurd)
 import Language.Marlowe.Runtime.ChainSync.Api
 
@@ -19,12 +21,13 @@ client = ChainSeekClient stInit
 
     stIdle stepSize = do
       putStrLn $ "Advancing " <> show stepSize <> " block(s)"
-      pure $ SendMsgQueryNext (AdvanceBlocks stepSize) stNext $ pure stNext
+      pure $ SendMsgQueryNext (AdvanceBlocks stepSize) stNext
 
     stNext = ClientStNext
       { recvMsgQueryRejected = absurd
       , recvMsgRollForward = const handleNewPoint
       , recvMsgRollBackward = handleNewPoint
+      , recvMsgWait = threadDelay 1_000_000 $> SendMsgPoll stNext
       }
 
     handleNewPoint point tip = do

--- a/marlowe-protocols-test/src/Test/Network/Protocol/ChainSeek.hs
+++ b/marlowe-protocols-test/src/Test/Network/Protocol/ChainSeek.hs
@@ -21,13 +21,17 @@ data ServerStIdleScript q point tip (m :: * -> *) a where
   Do :: m () -> ServerStIdleScript q point tip m a -> ServerStIdleScript q point tip m a
   Halt :: a -> ServerStIdleScript q point tip m a
   ExpectDone :: a -> ServerStIdleScript q point tip m a
-  ExpectQuery :: q err result -> ServerStNextScript q point tip 'StCanAwait err result m a -> ServerStIdleScript q point tip m a
+  ExpectQuery :: q err result -> ServerStNextScript q point tip err result m a -> ServerStIdleScript q point tip m a
 
-data ServerStNextScript q point tip k err result m a where
-  RejectQuery :: err -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip k err result m a
-  RollForward :: result -> point -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip k err result m a
-  RollBackward :: point -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip k err result m a
-  Wait :: ServerStNextScript q point tip 'StMustReply err result m a -> ServerStNextScript q point tip 'StCanAwait err result m a
+data ServerStNextScript q point tip err result m a where
+  RejectQuery :: err -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip err result m a
+  RollForward :: result -> point -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip err result m a
+  RollBackward :: point -> tip -> ServerStIdleScript q point tip m a -> ServerStNextScript q point tip err result m a
+  Wait :: ServerStPollScript q point tip err result m a -> ServerStNextScript q point tip err result m a
+
+data ServerStPollScript q point tip err result m a where
+  ExpectPoll :: ServerStNextScript q point tip err result m a -> ServerStPollScript q point tip err result m a
+  ExpectCancel :: ServerStIdleScript q point tip m a -> ServerStPollScript q point tip err result m a
 
 runClientWithScript
   :: forall q point tip m a b
@@ -52,33 +56,46 @@ runClientWithScript showQuery assertQueryEq script ChainSeekClient{..} = do
       Halt a -> \_ -> pure (a, Nothing)
       ExpectDone a -> \case
         SendMsgDone b -> pure (a, Just b)
-        SendMsgQueryNext move _ _ -> liftIO do
+        SendMsgQueryNext move _ -> liftIO do
           expectationFailure $ "Expected MsgDone, got MsgQueryNext (" <> showQuery move <> ")"
           undefined
       ExpectQuery move script' -> \case
         SendMsgDone _ -> liftIO do
           expectationFailure $ "Expected MsgQueryNext (" <> showQuery move <> "), got MsgDone"
           undefined
-        SendMsgQueryNext move' next waitNext -> do
+        SendMsgQueryNext move' next -> do
           let tag = tagFromQuery move
           let tag' = tagFromQuery move'
           case tagEq tag tag' of
             Just (Refl, Refl) -> do
               liftIO $ move' `assertQueryEq` move
-              runNext next waitNext script'
+              runNext next script'
             Nothing -> do
               liftIO $ expectationFailure $ "Expected " <> showQuery move <> ", got " <> showQuery move'
               undefined
 
     runNext
       :: ClientStNext q err result point tip m b
-      -> m (ClientStNext q err result point tip m b)
-      -> ServerStNextScript q point tip k err result m a
+      -> ServerStNextScript q point tip err result m a
       -> m (a, Maybe b)
-    runNext ClientStNext{..} waitNext = \case
+    runNext ClientStNext{..} = \case
       RejectQuery err tip script' -> runIdle script' =<< recvMsgQueryRejected err tip
       RollForward result point tip script' -> runIdle script' =<< recvMsgRollForward result point tip
       RollBackward point tip script' -> runIdle script' =<< recvMsgRollBackward point tip
-      Wait script' -> do
-        next' <- waitNext
-        runNext next' (pure next') script'
+      Wait script' -> runPoll script' =<< recvMsgWait
+
+    runPoll
+      :: ServerStPollScript q point tip err result m a
+      -> ClientStPoll q err result point tip m b
+      -> m (a, Maybe b)
+    runPoll = \case
+      ExpectPoll script' -> \case
+        SendMsgPoll next -> runNext next script'
+        SendMsgCancel _ -> liftIO do
+          expectationFailure "Expected MsgPoll, got MsgCancel"
+          undefined
+      ExpectCancel script' -> \case
+        SendMsgCancel idle -> runIdle script' idle
+        SendMsgPoll _ -> liftIO do
+          expectationFailure "Expected MsgCancel, got MsgPoll"
+          undefined

--- a/marlowe-protocols/src/Network/Protocol/Job/Types.hs
+++ b/marlowe-protocols/src/Network/Protocol/Job/Types.hs
@@ -165,7 +165,7 @@ instance CommandToJSON cmd => MessageToJSON (Job cmd) where
       MsgDetach -> "detach"
     ServerAgency (TokCmd tag)-> \case
       MsgFail err -> object [ "fail" .= errToJSON tag err ]
-      MsgSucceed result -> object [ "reject" .= resultToJSON tag result ]
+      MsgSucceed result -> object [ "succeed" .= resultToJSON tag result ]
       MsgAwait status jobId -> object
         [ "await" .= object
             [ "status" .= statusToJSON tag status

--- a/marlowe-runtime/marlowe-tx/Logging.hs
+++ b/marlowe-runtime/marlowe-tx/Logging.hs
@@ -108,13 +108,21 @@ getLoadMarloweContextSelectorConfig = \case
     }
 
 buildTxFieldConfig :: FieldConfig BuildTxField
-buildTxFieldConfig = error "not implemented"
+buildTxFieldConfig = FieldConfig
+  { fieldKey = \case
+      Constraints _ _ -> "constraints"
+      ResultingTxBody _ -> "tx-body"
+  , fieldDefaultEnabled = const True
+  , toSomeJSON = \case
+      Constraints MarloweV1 constraints -> SomeJSON $ show constraints
+      ResultingTxBody txBody -> SomeJSON $ show txBody
+  }
 
 chainSeekConfig :: SocketDriverConfigOptions
 chainSeekConfig = SocketDriverConfigOptions
   { enableConnected = True
   , enableDisconnected = True
-  , enableServerDriverEvent = False
+  , enableServerDriverEvent = True
   }
 
 chainSyncJobConfig :: SocketDriverConfigOptions


### PR DESCRIPTION
Instead of the server holding agency and pushing updates to the client, the client gets agency and has to poll for updates when it is told to wait. This simplifies the job of the server, and it also gives the client the option to exit the protocol instead of wait.