### PR TITLE
SCP-4824 Enhanced Metadata Support

### DIFF
--- a/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
+++ b/marlowe-runtime/src/Language/Marlowe/Runtime/Core/Api.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -99,13 +100,14 @@ instance IsMarloweVersion 'V1 where
   marloweVersion = MarloweV1
 
 data Transaction v = Transaction
-  { transactionId      :: TxId
-  , contractId         :: ContractId
-  , blockHeader        :: BlockHeader
+  { transactionId :: TxId
+  , contractId :: ContractId
+  , metadata :: Chain.TransactionMetadata
+  , blockHeader :: BlockHeader
   , validityLowerBound :: UTCTime
   , validityUpperBound :: UTCTime
-  , redeemer           :: Redeemer v
-  , output             :: TransactionOutput v
+  , redeemer :: Redeemer v
+  , output :: TransactionOutput v
   } deriving Generic
 
 deriving instance Show (Transaction 'V1)
@@ -116,6 +118,7 @@ instance Binary (Transaction 'V1) where
   put Transaction{..} = do
     put transactionId
     put contractId
+    put metadata
     put blockHeader
     putUTCTime validityLowerBound
     putUTCTime validityUpperBound
@@ -123,6 +126,7 @@ instance Binary (Transaction 'V1) where
     put output
   get = Transaction
     <$> get
+    <*> get
     <*> get
     <*> get
     <*> getUTCTime

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
@@ -675,6 +675,7 @@ checkRollbackToCreationWithInputs = do
             { steps = Map.singleton block2
                 [ ApplyTransaction Transaction
                     { transactionId = let Chain.Transaction{..} = applyInputsTx in txId
+                    , metadata = mempty
                     , contractId = testContractId
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
@@ -717,6 +718,7 @@ checkRollbackToCreationClosed = do
                 [ ApplyTransaction Transaction
                     { transactionId = let Chain.Transaction{..} = closeTx in txId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -747,6 +749,7 @@ checkRollbackToTransaction = do
                 [ ApplyTransaction Transaction
                     { transactionId = let Chain.Transaction{..} = applyInputsTx in txId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -770,6 +773,7 @@ checkRollbackToTransaction = do
                 [ ApplyTransaction Transaction
                     { transactionId = close2TxId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block3
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -796,6 +800,7 @@ checkCloseTransaction = do
                 [ ApplyTransaction Transaction
                     { transactionId = let Chain.Transaction{..} = closeTx in txId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -822,6 +827,7 @@ checkNonCloseTransaction = do
                 [ ApplyTransaction Transaction
                     { transactionId = let Chain.Transaction{..} = applyInputsTx in txId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -852,6 +858,7 @@ checkPayoutOpenRedeemedBefore = do
                 [ ApplyTransaction Transaction
                     { transactionId = let Chain.Transaction{..} = applyInputsTx in txId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -890,6 +897,7 @@ checkPayoutOpenRedeemedBefore = do
                 [ ApplyTransaction Transaction
                     { transactionId = close2TxId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block4
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -933,6 +941,7 @@ checkPayoutOpenRedeemedAfter = do
                 [ ApplyTransaction Transaction
                     { transactionId = let Chain.Transaction{..} = applyInputsTx in txId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -956,6 +965,7 @@ checkPayoutOpenRedeemedAfter = do
                 [ ApplyTransaction Transaction
                     { transactionId = close2TxId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block3
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -997,6 +1007,7 @@ checkPayoutOpenRedeemedTogether = do
                 [ ApplyTransaction Transaction
                     { transactionId = let Chain.Transaction{..} = applyInputsTx in txId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
@@ -1025,6 +1036,7 @@ checkPayoutOpenRedeemedTogether = do
                 , ApplyTransaction Transaction
                     { transactionId = close2TxId
                     , contractId = testContractId
+                    , metadata = mempty
                     , blockHeader = block3
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
@@ -344,6 +344,7 @@ genApplyInputsV1 payoutAddress blockHeader contractId TransactionScriptOutput{..
     output <- applyInputsV1 address payoutAddress vLow vHigh transactionId inputs datum
     pure $ ApplyInputs MarloweV1 $ Transaction
       { contractId
+      , metadata = mempty
       , transactionId
       , blockHeader
       , validityLowerBound = posixSecondsToUTCTime $ secondsToNominalDiffTime $ fromIntegral vLow / 1000

--- a/marlowe-runtime/tx-api/Language/Marlowe/Runtime/Transaction/Api.hs
+++ b/marlowe-runtime/tx-api/Language/Marlowe/Runtime/Transaction/Api.hs
@@ -164,6 +164,7 @@ instance IsCardanoEra era => Binary (ContractCreated era 'V1) where
 data InputsApplied era v = InputsApplied
   { version :: MarloweVersion v
   , contractId :: ContractId
+  , metadata :: TransactionMetadata
   , input :: TransactionScriptOutput v
   , output :: Maybe (TransactionScriptOutput v)
   , invalidBefore :: UTCTime
@@ -178,6 +179,7 @@ deriving instance Eq (InputsApplied BabbageEra 'V1)
 instance IsCardanoEra era => Binary (InputsApplied era 'V1) where
   put InputsApplied{..} = do
     put contractId
+    put metadata
     put input
     put output
     putUTCTime invalidBefore
@@ -187,6 +189,7 @@ instance IsCardanoEra era => Binary (InputsApplied era 'V1) where
   get = do
     let version = MarloweV1
     contractId <- get
+    metadata <- get
     input <- get
     output <- get
     invalidBefore <- getUTCTime

--- a/marlowe-runtime/tx-api/Language/Marlowe/Runtime/Transaction/Api.hs
+++ b/marlowe-runtime/tx-api/Language/Marlowe/Runtime/Transaction/Api.hs
@@ -240,6 +240,8 @@ data MarloweTxCommand status err result where
     -- ^ The wallet addresses to use when constructing the transaction
     -> ContractId
     -- ^ The ID of the contract to apply the inputs to.
+    -> TransactionMetadata
+    -- ^ Optional metadata to attach to the transaction
     -> Maybe UTCTime
     -- ^ The "invalid before" bound of the validity interval. If omitted, this
     -- is computed from the contract.
@@ -290,10 +292,11 @@ instance CommandToJSON MarloweTxCommand where
           , "version" .= version
           ]
       ]
-    ApplyInputs MarloweV1 walletAddresses contractId invalidBefore invalidHereafter redeemer -> object
+    ApplyInputs MarloweV1 walletAddresses contractId metadata invalidBefore invalidHereafter redeemer -> object
       [ "apply-inputs" .= object
           [ "wallet-addresses" .= walletAddresses
           , "contract-id" .= contractId
+          , "metadata" .= metadata
           , "invalid-before" .= invalidBefore
           , "invalid-hereafter" .= invalidHereafter
           , "redeemer" .= toJSON redeemer
@@ -340,7 +343,7 @@ instance Command MarloweTxCommand where
 
   tagFromCommand = \case
     Create _ version _ _ _ _ _ -> TagCreate version
-    ApplyInputs version _ _ _ _ _ -> TagApplyInputs version
+    ApplyInputs version _ _ _ _ _ _ -> TagApplyInputs version
     Withdraw version _ _ _        -> TagWithdraw version
     Submit _                -> TagSubmit
 
@@ -395,9 +398,10 @@ instance Command MarloweTxCommand where
       put metadata
       put minAda
       putContract version contract
-    ApplyInputs version walletAddresses contractId invalidBefore invalidHereafter redeemer -> do
+    ApplyInputs version walletAddresses contractId metadata invalidBefore invalidHereafter redeemer -> do
       put walletAddresses
       put contractId
+      put metadata
       maybe (putWord8 0) (\t -> putWord8 1 *> putUTCTime t) invalidBefore
       maybe (putWord8 0) (\t -> putWord8 1 *> putUTCTime t) invalidHereafter
       putRedeemer version redeemer
@@ -420,6 +424,7 @@ instance Command MarloweTxCommand where
     TagApplyInputs version -> do
       walletAddresses <- get
       contractId <- get
+      metadata <- get
       invalidBefore <- getWord8 >>= \case
         0 -> pure Nothing
         1 -> Just <$> getUTCTime
@@ -429,7 +434,7 @@ instance Command MarloweTxCommand where
         1 -> Just <$> getUTCTime
         t -> fail $ "Invalid Maybe tag: " <> show t
       redeemer <- getRedeemer version
-      pure $ ApplyInputs version walletAddresses contractId invalidBefore invalidHereafter redeemer
+      pure $ ApplyInputs version walletAddresses contractId metadata invalidBefore invalidHereafter redeemer
 
     TagWithdraw version -> do
       walletAddresses <- get

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Server.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Server.hs
@@ -193,7 +193,7 @@ worker = component_ \WorkerDependencies{..} -> do
                 metadata
                 minAda
                 contract
-            ApplyInputs version addresses contractId invalidBefore invalidHereafter redeemer ->
+            ApplyInputs version addresses contractId metadata invalidBefore invalidHereafter redeemer ->
               withSubEvent ev ExecApplyInputs \ev' -> withMarloweVersion version $ execApplyInputs
                 ev'
                 getTip
@@ -205,6 +205,7 @@ worker = component_ \WorkerDependencies{..} -> do
                 version
                 addresses
                 contractId
+                metadata
                 invalidBefore
                 invalidHereafter
                 redeemer
@@ -316,6 +317,7 @@ execApplyInputs
   -> MarloweVersion v
   -> WalletAddresses
   -> ContractId
+  -> TransactionMetadata
   -> Maybe UTCTime
   -> Maybe UTCTime
   -> Redeemer v
@@ -331,6 +333,7 @@ execApplyInputs
   version
   addresses
   contractId
+  metadata
   invalidBefore'
   invalidHereafter'
   inputs = execExceptT do
@@ -349,6 +352,7 @@ execApplyInputs
         version
         scriptOutput'
         tipSlot
+        metadata
         invalidBefore'
         invalidHereafter'
         inputs

--- a/marlowe-runtime/web-server-test/Spec.hs
+++ b/marlowe-runtime/web-server-test/Spec.hs
@@ -51,6 +51,7 @@ instance Arbitrary Web.TxHeader where
     <*> arbitrary
     <*> arbitrary
     <*> arbitrary
+    <*> arbitrary
 
 instance Arbitrary Web.ContractState where
   arbitrary = Web.ContractState
@@ -72,6 +73,7 @@ instance Arbitrary Web.ContractState where
 instance Arbitrary Web.Tx where
   arbitrary = Web.Tx
     <$> arbitrary
+    <*> arbitrary
     <*> arbitrary
     <*> arbitrary
     <*> arbitrary

--- a/marlowe-runtime/web-server-test/Spec.hs
+++ b/marlowe-runtime/web-server-test/Spec.hs
@@ -107,6 +107,7 @@ instance Arbitrary Web.PostTransactionsRequest where
     <*> arbitrary
     <*> arbitrary
     <*> arbitrary
+    <*> arbitrary
   shrink = genericShrink
 
 instance Arbitrary Web.CreateTxBody where

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/DTO.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/DTO.hs
@@ -293,6 +293,7 @@ instance ToDTO TxRecord where
     Web.Tx
       { contractId = toDTO contractId
       , transactionId = toDTO transactionId
+      , metadata = toDTO metadata
       , status = Web.Confirmed
       , block = Just $ toDTO blockHeader
       , inputUtxo = toDTO $ utxo input
@@ -373,6 +374,7 @@ instance IsCardanoEra era => ToDTOWithTxStatus (Tx.InputsApplied era v) where
     Web.Tx
       { contractId = toDTO contractId
       , transactionId = toDTO $ fromCardanoTxId $ getTxId txBody
+      , metadata = toDTO metadata
       , status = toDTO status
       , block = Nothing
       , inputUtxo = toDTO $ utxo input
@@ -403,6 +405,7 @@ instance ToDTO SomeTransaction where
     Web.TxHeader
       { contractId = toDTO contractId
       , transactionId = toDTO transactionId
+      , metadata = toDTO metadata
       , status = Web.Confirmed
       , block = Just $ toDTO blockHeader
       , utxo = toDTO . utxo <$> scriptOutput output

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/Monad.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/Monad.hs
@@ -91,9 +91,9 @@ createContract stakeCredential version addresses roles metadata minUTxODeposit c
 
 -- | Apply inputs to a contract.
 applyInputs :: ApplyInputs (AppM r)
-applyInputs version addresses contractId invalidBefore invalidHereafter inputs = do
+applyInputs version addresses contractId metadata invalidBefore invalidHereafter inputs = do
   apply <- asks _applyInputs
-  liftIO $ apply version addresses contractId invalidBefore invalidHereafter inputs
+  liftIO $ apply version addresses contractId metadata invalidBefore invalidHereafter inputs
 
 -- | Submit a contract creation transaction to the node
 submitContract :: ContractId -> Submit r (AppM r)

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
@@ -134,7 +134,8 @@ post eb contractId req@PostTransactionsRequest{..} changeAddressDTO mAddresses m
   extraAddresses <- Set.fromList <$> fromDTOThrow err400 (maybe [] unCommaList mAddresses)
   collateralUtxos <- Set.fromList <$> fromDTOThrow err400 (maybe [] unCommaList mCollateralUtxos)
   contractId' <- fromDTOThrow err400 contractId
-  applyInputs v WalletAddresses{..} contractId' invalidBefore invalidHereafter inputs >>= \case
+  metadata' <- fromDTOThrow err400 metadata
+  applyInputs v WalletAddresses{..} contractId' metadata' invalidBefore invalidHereafter inputs >>= \case
     Left err -> do
       addField ev $ PostError $ show err
       case err of

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
@@ -111,6 +111,7 @@ toTxHeader :: Tx -> TxHeader
 toTxHeader Tx{..} = TxHeader
   { contractId
   , transactionId
+  , metadata
   , status
   , block
   , utxo = outputUtxo

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
@@ -82,6 +82,7 @@ type ApplyInputs m
    . MarloweVersion v
   -> WalletAddresses
   -> ContractId
+  -> TransactionMetadata
   -> Maybe UTCTime
   -> Maybe UTCTime
   -> Redeemer v
@@ -191,10 +192,10 @@ txClient = component \TxClientDependencies{..} -> do
           $ Map.insert contractId
           $ TempTx version Unsigned creation
         pure response
-    , applyInputs = \version addresses contractId invalidBefore invalidHereafter inputs -> do
+    , applyInputs = \version addresses contractId metadata invalidBefore invalidHereafter inputs -> do
         response <- runTxJobClient
           $ liftCommand
-          $ ApplyInputs version addresses contractId invalidBefore invalidHereafter inputs
+          $ ApplyInputs version addresses contractId metadata invalidBefore invalidHereafter inputs
         for_ response \application@InputsApplied{txBody} -> do
           let txId = fromCardanoTxId $ getTxId txBody
           let tempTx = TempTx version Unsigned application

--- a/marlowe-runtime/web/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime/web/Language/Marlowe/Runtime/Web/Types.hs
@@ -512,6 +512,7 @@ uriToJSON = String . T.pack . show
 
 data PostTransactionsRequest = PostTransactionsRequest
   { version :: MarloweVersion
+  , metadata :: Map Word64 Metadata
   , invalidBefore :: Maybe UTCTime
   , invalidHereafter :: Maybe UTCTime
   , inputs :: [Semantics.Input]

--- a/marlowe-runtime/web/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime/web/Language/Marlowe/Runtime/Web/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -256,6 +257,7 @@ instance ToSchema Metadata where
 data TxHeader = TxHeader
   { contractId :: TxOutRef
   , transactionId :: TxId
+  , metadata :: Map Word64 Metadata
   , status :: TxStatus
   , block :: Maybe BlockHeader
   , utxo :: Maybe TxOutRef
@@ -267,6 +269,7 @@ instance ToSchema TxHeader
 data Tx = Tx
   { contractId :: TxOutRef
   , transactionId :: TxId
+  , metadata :: Map Word64 Metadata
   , status :: TxStatus
   , block :: Maybe BlockHeader
   , inputUtxo :: TxOutRef

--- a/marlowe-scaling/src/Language/Marlowe/Runtime/Client/Build.hs
+++ b/marlowe-scaling/src/Language/Marlowe/Runtime/Client/Build.hs
@@ -1,5 +1,3 @@
-
-
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -77,7 +75,7 @@ buildApplication
   -> Client (Either String (ContractId, C.TxBody C.BabbageEra))
 buildApplication version' contractId' redeemer lower upper =
   build show (\InputsApplied{..} -> (contractId, txBody))
-    $ \w -> ApplyInputs version' w contractId' (utcTime <$> lower) (utcTime <$> upper) redeemer
+    $ \w -> ApplyInputs version' w contractId' mempty (utcTime <$> lower) (utcTime <$> upper) redeemer
 
 
 buildWithdrawal


### PR DESCRIPTION
- [x] adds support for transaction metadata in `apply` commands in CLI and `POST /contracts/{contract-id}/transactions` in REST server
- [x] adds transaction metadata to `tx-header` and `tx` DTOs in REST API.