### PR TITLE
SCP-4762 Erroneous `TEApplyNoMatchError` when applying inputs in Marlowe Runtime

### DIFF
--- a/marlowe-runtime/doc/marlowe-tx.md
+++ b/marlowe-runtime/doc/marlowe-tx.md
@@ -9,8 +9,7 @@ Usage: marlowe-tx [--chain-seek-port-number PORT_NUMBER]
                   [--chain-seek-query-port-number PORT_NUMBER] 
                   [--chain-seek-command-port-number PORT_NUMBER] 
                   [--chain-seek-host HOST_NAME] [--command-port PORT_NUMBER] 
-                  [-h|--host HOST_NAME] [--history-sync-port PORT_NUMBER] 
-                  [--history-host HOST_NAME] [--log-level LOG_LEVEL | --silent]
+                  [-h|--host HOST_NAME]
 
   Marlowe runtime transaction creation server
 
@@ -33,12 +32,4 @@ Available options:
                            (default: 3723)
   -h,--host HOST_NAME      The host name to run the tx server on.
                            (default: "127.0.0.1")
-  --history-sync-port PORT_NUMBER
-                           The port number of the history sync server.
-                           (default: 3719)
-  --history-host HOST_NAME The host name of the history server.
-                           (default: "127.0.0.1")
-  --log-level LOG_LEVEL    Log everything up including the given level:
-                           [DEBUG|INFO|WARNING|ERROR]
-  --silent                 Suppress all logs.
 ```

--- a/marlowe-runtime/history-api/Language/Marlowe/Runtime/History/Api.hs
+++ b/marlowe-runtime/history-api/Language/Marlowe/Runtime/History/Api.hs
@@ -7,17 +7,26 @@
 module Language.Marlowe.Runtime.History.Api
   where
 
+import Cardano.Api (CardanoMode, EraHistory(EraHistory))
+import Control.Error (note, runMaybeT)
+import Control.Error.Util (hoistMaybe)
+import Control.Monad (when)
+import Control.Monad.Trans.Class (lift)
 import Data.Aeson (ToJSON, Value(..), object, toJSON, (.=))
+import Data.Bifunctor (first)
 import Data.Binary (Binary, get, getWord8, put, putWord8)
 import qualified Data.ByteString.Lazy as LBS
+import Data.Foldable (find, for_)
 import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Set (Set)
 import Data.Type.Equality (type (:~:)(Refl))
 import Data.Void (Void, absurd)
 import GHC.Generics (Generic)
-import Language.Marlowe.Runtime.ChainSync.Api (ScriptHash, TxError, TxId, TxOutRef, UTxOError)
+import Language.Marlowe.Runtime.ChainSync.Api (ScriptHash, TxError, TxId, TxOutRef(..), UTxOError)
 import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
 import Language.Marlowe.Runtime.Core.Api
+import Language.Marlowe.Runtime.Core.ScriptRegistry (MarloweScripts(..), getMarloweVersion)
 import Network.Protocol.ChainSeek.Codec (DeserializeError)
 import Network.Protocol.Job.Client
 import Network.Protocol.Job.Codec
@@ -28,6 +37,9 @@ import Network.Protocol.Query.Codec (codecQuery)
 import Network.Protocol.Query.Server (QueryServer)
 import qualified Network.Protocol.Query.Types as Query
 import Network.TypedProtocol.Codec
+import Ouroboros.Consensus.BlockchainTime (SystemStart, fromRelativeTime)
+import Ouroboros.Consensus.HardFork.History (interpretQuery, slotToWallclock)
+import qualified Ouroboros.Network.Block as O
 
 data ContractHistoryError
   = HansdshakeFailed
@@ -123,6 +135,37 @@ deriving instance Show (ContractStep 'V1)
 deriving instance Eq (ContractStep 'V1)
 instance Binary (ContractStep 'V1)
 instance ToJSON (ContractStep 'V1)
+
+extractCreation :: ContractId -> Chain.Transaction -> Either ExtractCreationError SomeCreateStep
+extractCreation contractId tx@Chain.Transaction{inputs} = do
+  Chain.TransactionOutput{ assets, address = scriptAddress, datum = mdatum } <-
+    getOutput (txIx $ unContractId contractId) tx
+  marloweScriptHash <- getScriptHash scriptAddress
+  (SomeMarloweVersion version, MarloweScripts{..}) <- note InvalidScriptHash $ getMarloweVersion marloweScriptHash
+  let payoutValidatorHash = payoutScript
+  for_ inputs \Chain.TransactionInput{..} ->
+    when (isScriptAddress marloweScriptHash address) $ Left NotCreationTransaction
+  txDatum <- note NoCreateDatum mdatum
+  datum <- note InvalidCreateDatum $ fromChainDatum version txDatum
+  let createOutput = TransactionScriptOutput scriptAddress assets (unContractId contractId) datum
+  pure $ SomeCreateStep version CreateStep{..}
+
+getScriptHash :: Chain.Address -> Either ExtractCreationError ScriptHash
+getScriptHash address = do
+  credential <- note ByronAddress $ Chain.paymentCredential address
+  case credential of
+    Chain.ScriptCredential scriptHash -> pure scriptHash
+    _                                 -> Left NonScriptAddress
+
+isScriptAddress :: ScriptHash -> Chain.Address -> Bool
+isScriptAddress scriptHash address = getScriptHash address == Right scriptHash
+
+getOutput :: Chain.TxIx -> Chain.Transaction -> Either ExtractCreationError Chain.TransactionOutput
+getOutput (Chain.TxIx i) Chain.Transaction{..} = go i outputs
+  where
+    go _ []        = Left TxIxNotFound
+    go 0 (x : _)   = Right x
+    go i' (_ : xs) = go (i' - 1) xs
 
 data HistoryCommand status err result where
   FollowContract :: ContractId -> HistoryCommand Void ContractHistoryError Bool
@@ -228,6 +271,69 @@ data History v = History
 deriving instance Show (History 'V1)
 deriving instance Eq (History 'V1)
 instance Binary (History 'V1)
+
+extractMarloweTransaction
+  :: MarloweVersion v
+  -> SystemStart
+  -> EraHistory CardanoMode
+  -> ContractId
+  -> Chain.Address
+  -> Chain.ScriptHash
+  -> TxOutRef
+  -> Chain.BlockHeader
+  -> Chain.Transaction
+  -> Either ExtractMarloweTransactionError (Transaction v)
+extractMarloweTransaction version systemStart eraHistory contractId scriptAddress payoutValidatorHash consumedUTxO blockHeader Chain.Transaction{..} = do
+  let transactionId = txId
+  Chain.TransactionInput { redeemer = mRedeemer } <-
+    note TxInNotFound $ find (consumesUTxO consumedUTxO) inputs
+  rawRedeemer <- note NoRedeemer mRedeemer
+  redeemer <- note InvalidRedeemer $ fromChainRedeemer version rawRedeemer
+  (minSlot, maxSlot) <- case validityRange of
+    Chain.MinMaxBound minSlot maxSlot -> pure (minSlot, maxSlot)
+    _                                 -> Left InvalidValidityRange
+  validityLowerBound <- slotStartTime minSlot
+  validityUpperBound <- slotStartTime maxSlot
+  scriptOutput <- runMaybeT do
+    (ix, Chain.TransactionOutput{ assets, datum = mDatum }) <-
+      hoistMaybe $ find (isToAddress scriptAddress . snd) $ zip [0..] outputs
+    lift do
+      rawDatum <- note NoTransactionDatum mDatum
+      datum <- note InvalidTransactionDatum $ fromChainDatum version rawDatum
+      let txIx = Chain.TxIx ix
+      let utxo = Chain.TxOutRef{..}
+      let address = scriptAddress
+      pure TransactionScriptOutput{..}
+  let
+    payoutOutputs = Map.filter (isToScriptHash payoutValidatorHash)
+      $ Map.fromList
+      $ (\(txIx, output) -> (Chain.TxOutRef{..}, output)) <$> zip [0..] outputs
+  payouts <- flip Map.traverseWithKey payoutOutputs \txOut Chain.TransactionOutput{address, datum=mPayoutDatum, assets} -> do
+    rawPayoutDatum <- note (NoPayoutDatum txOut) mPayoutDatum
+    payoutDatum <- note (InvalidPayoutDatum txOut) $ fromChainPayoutDatum version rawPayoutDatum
+    pure $ Payout address assets payoutDatum
+  let output = TransactionOutput{..}
+  pure Transaction{..}
+  where
+    EraHistory _ interpreter = eraHistory
+    slotStartTime (Chain.SlotNo slotNo) = do
+      (relativeTime, _) <- first (const SlotConversionFailed)
+        $ interpretQuery interpreter
+        $ slotToWallclock
+        $ O.SlotNo slotNo
+      pure $ fromRelativeTime systemStart relativeTime
+
+isToScriptHash :: Chain.ScriptHash -> Chain.TransactionOutput -> Bool
+isToScriptHash toScriptHash Chain.TransactionOutput{..} = case Chain.paymentCredential address of
+  Just (Chain.ScriptCredential hash) -> hash == toScriptHash
+  _                                  -> False
+
+isToAddress :: Chain.Address -> Chain.TransactionOutput -> Bool
+isToAddress toAddress Chain.TransactionOutput{..} = address == toAddress
+
+consumesUTxO :: TxOutRef -> Chain.TransactionInput -> Bool
+consumesUTxO TxOutRef{..} Chain.TransactionInput { txId = txInId, txIx = txInIx } =
+  txId == txInId && txIx == txInIx
 
 data SomeHistory = forall v. SomeHistory (MarloweVersion v) (History v)
 

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -96,10 +96,15 @@ library history-api
     , aeson
     , binary
     , bytestring
+    , cardano-api
     , containers
+    , errors
     , marlowe-chain-sync
     , marlowe-protocols
     , marlowe-runtime
+    , ouroboros-consensus
+    , ouroboros-network
+    , transformers
     , typed-protocols
   visibility: public
 
@@ -126,8 +131,6 @@ library history
     , marlowe-protocols
     , marlowe-runtime
     , marlowe-runtime:history-api
-    , ouroboros-consensus
-    , ouroboros-network
     , semialign
     , stm
     , these
@@ -193,6 +196,7 @@ library tx-api
     , marlowe-chain-sync
     , marlowe-protocols
     , marlowe-runtime
+    , marlowe-runtime:history-api
     , time
   visibility: public
 

--- a/marlowe-runtime/marlowe-tx/Logging.hs
+++ b/marlowe-runtime/marlowe-tx/Logging.hs
@@ -86,6 +86,8 @@ getAppSelectorConfig = \case
 
 getLoadMarloweContextSelectorConfig :: GetSelectorConfig Q.LoadMarloweContextSelector
 getLoadMarloweContextSelectorConfig = \case
+  Q.ExtractCreationFailed -> SelectorConfig "extract-creation-failed" True $ singletonFieldConfig "error" True
+  Q.ExtractMarloweTransactionFailed -> SelectorConfig "extract-transaction-failed" True $ singletonFieldConfig "error" True
   Q.ContractNotFound -> SelectorConfig "contract-not-found" True absurdFieldConfig
   Q.ContractFound -> SelectorConfig "contract-found" True FieldConfig
     { fieldKey = \case

--- a/marlowe-runtime/tx-api/Language/Marlowe/Runtime/Transaction/Api.hs
+++ b/marlowe-runtime/tx-api/Language/Marlowe/Runtime/Transaction/Api.hs
@@ -65,6 +65,7 @@ import Language.Marlowe.Runtime.ChainSync.Api
   , Metadata
   , PlutusScript
   , PolicyId
+  , SchemaVersion
   , ScriptHash
   , SlotNo
   , StakeCredential
@@ -76,6 +77,7 @@ import Language.Marlowe.Runtime.ChainSync.Api
   , putUTCTime
   )
 import Language.Marlowe.Runtime.Core.Api
+import Language.Marlowe.Runtime.History.Api (ExtractCreationError, ExtractMarloweTransactionError)
 import Network.Protocol.Job.Types
 
 -- CIP-25 metadata
@@ -568,8 +570,9 @@ data LoadMarloweContextError
   | LoadMarloweContextToCardanoError
   | MarloweScriptNotPublished ScriptHash
   | PayoutScriptNotPublished ScriptHash
-  | InvalidScriptAddress Address
-  | UnknownMarloweScript ScriptHash
+  | ExtractCreationError ExtractCreationError
+  | ExtractMarloweTransactionError ExtractMarloweTransactionError
+  | HandshakeFailed [SchemaVersion]
   deriving (Eq, Show, Ord, Generic)
   deriving anyclass (Binary, ToJSON)
 

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/REST/Contracts.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/REST/Contracts.hs
@@ -112,11 +112,12 @@ post eb req@PostContractsRequest{..} changeAddressDTO mAddresses mCollateralUtxo
         CreateConstraintError (BalancingError _) -> throwError err500
         CreateLoadMarloweContextFailed LoadMarloweContextErrorNotFound -> throwError err404
         CreateLoadMarloweContextFailed (LoadMarloweContextErrorVersionMismatch _) -> throwError err400
+        CreateLoadMarloweContextFailed (HandshakeFailed _) -> throwError err500
         CreateLoadMarloweContextFailed LoadMarloweContextToCardanoError -> throwError err500
         CreateLoadMarloweContextFailed (MarloweScriptNotPublished _) -> throwError err500
         CreateLoadMarloweContextFailed (PayoutScriptNotPublished _) -> throwError err500
-        CreateLoadMarloweContextFailed (InvalidScriptAddress _) -> throwError err500
-        CreateLoadMarloweContextFailed (UnknownMarloweScript _) -> throwError err500
+        CreateLoadMarloweContextFailed (ExtractCreationError _) -> throwError err500
+        CreateLoadMarloweContextFailed (ExtractMarloweTransactionError _) -> throwError err500
         CreateBuildupFailed MintingUtxoSelectionFailed -> throwError err400
         CreateBuildupFailed (AddressDecodingFailed _) -> throwError err500
         CreateBuildupFailed (MintingScriptDecodingFailed _) -> throwError err500

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
@@ -149,11 +149,12 @@ post eb contractId req@PostTransactionsRequest{..} changeAddressDTO mAddresses m
         ScriptOutputNotFound -> throwError err400
         ApplyInputsLoadMarloweContextFailed LoadMarloweContextErrorNotFound -> throwError err404
         ApplyInputsLoadMarloweContextFailed (LoadMarloweContextErrorVersionMismatch _) -> throwError err400
+        ApplyInputsLoadMarloweContextFailed (HandshakeFailed _) -> throwError err500
         ApplyInputsLoadMarloweContextFailed LoadMarloweContextToCardanoError -> throwError err500
         ApplyInputsLoadMarloweContextFailed (MarloweScriptNotPublished _) -> throwError err500
         ApplyInputsLoadMarloweContextFailed (PayoutScriptNotPublished _) -> throwError err500
-        ApplyInputsLoadMarloweContextFailed (InvalidScriptAddress _) -> throwError err500
-        ApplyInputsLoadMarloweContextFailed (UnknownMarloweScript _) -> throwError err500
+        ApplyInputsLoadMarloweContextFailed (ExtractCreationError _) -> throwError err500
+        ApplyInputsLoadMarloweContextFailed (ExtractMarloweTransactionError _) -> throwError err500
         ApplyInputsConstraintsBuildupFailed (MarloweComputeTransactionFailed _) -> throwError err400
         ApplyInputsConstraintsBuildupFailed UnableToDetermineTransactionTimeout -> throwError err400
         SlotConversionFailed _ -> throwError err400

--- a/nix/dev/compose.nix
+++ b/nix/dev/compose.nix
@@ -149,13 +149,11 @@ let
 
   tx-service = dev-service {
     ports = [ 3723 ];
-    depends_on = [ "chainseekd" "marlowe-history" ];
+    depends_on = [ "chainseekd" ];
     command = [
       "/exec/run-marlowe-tx"
       "--chain-seek-host"
       "chainseekd"
-      "--history-host"
-      "marlowe-history"
       "--host"
       "0.0.0.0"
       "--log-config-file"

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -62,10 +62,15 @@
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
+            (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             ];
           buildable = true;
@@ -89,8 +94,6 @@
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
-            (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
-            (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
             (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
@@ -169,6 +172,7 @@
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             ];
           buildable = true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -62,10 +62,15 @@
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
+            (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             ];
           buildable = true;
@@ -89,8 +94,6 @@
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
-            (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
-            (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
             (hsPkgs."semialign" or (errorHandler.buildDepError "semialign"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
             (hsPkgs."these" or (errorHandler.buildDepError "these"))
@@ -169,6 +172,7 @@
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             ];
           buildable = true;


### PR DESCRIPTION
- [x] rewrites `loadMarloweContext` to use `ChainSeek` directly instead of `MarloweSync`
- [x] removes `marlowe-tx`'s dependency on `marlowe-history`

Explanation of cause: because the `MarloweContext` was being loaded from `marlowe-history`, there was a slight chance that it would still have stale information in it (i.e. the datum from before the previous transaction was confirmed), so it would try to match the inputs against the old datum and fail.

The fix was to load the MarloweContext directly from `chainseekd` instead. this guarantees that the data in the `MarloweContext` is at least as fresh as the data seen when the previous tx was confirmed. Note that this does _not_ guarantee it will work - if a rollback occurs between confirming the previous tx and building the next one, the same problem could happen. However, that isn't a bug - it's a legitimate case that might happen.