### PR TITLE
SCP-4749 Added metadata support to scaling client

### DIFF
--- a/marlowe-scaling/app/Main.hs
+++ b/marlowe-scaling/app/Main.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -122,17 +121,17 @@ runScenario event config address key contract inputs =
               (contractId, body) <-
                 handleWithEvents subEvent "Build" config request
                   $ \case
-                    Body{..} -> pure (resContractId, resTransactionBody)
+                    Body{..} -> pure (resContractId, resTxBody)
                     response -> unexpected response
               tx <-
                 handleWithEvents subEvent "Sign" config (Sign body [] [key])
                   $ \case
-                    Tx{..}   -> pure resTransaction
+                    Tx{..}   -> pure resTx
                     response -> unexpected response
               txId' <-
                 handleWithEvents subEvent "Submit" config (Submit tx)
                   $ \case
-                    TxId{..} -> pure resTransactionId
+                    TxId{..} -> pure resTxId
                     response -> unexpected response
               handleWithEvents subEvent "Confirm" config (Wait txId' 1)
                 $ \case

--- a/marlowe-scaling/app/Main.hs
+++ b/marlowe-scaling/app/Main.hs
@@ -135,8 +135,8 @@ runScenario event config address key contract inputs =
                     response -> unexpected response
               waitForConfirmation subEvent config txId'
               pure contractId
-    contractId <- transact $ Create contract mempty 1_500_000 mempty address mempty
-    mapM_ (\input -> transact $ Apply contractId [NormalInput input] Nothing Nothing mempty address mempty) inputs
+    contractId <- transact $ Create contract mempty 1_500_000 mempty mempty address mempty
+    mapM_ (\input -> transact $ Apply contractId [NormalInput input] Nothing Nothing mempty mempty address mempty) inputs
     pure contractId
 
 

--- a/marlowe-scaling/app/Main.hs
+++ b/marlowe-scaling/app/Main.hs
@@ -34,7 +34,7 @@ import Language.Marlowe.Core.V1.Semantics.Types
   , Value(ChoiceValue)
   )
 import Language.Marlowe.Core.V1.Semantics.Types.Address (deserialiseAddress)
-import Language.Marlowe.Runtime.ChainSync.Api (Address(unAddress), TxId, fromBech32)
+import Language.Marlowe.Runtime.ChainSync.Api (Address(unAddress), fromBech32)
 import Language.Marlowe.Runtime.Client (handle)
 import Language.Marlowe.Runtime.Client.Types (Config, MarloweRequest(..), MarloweResponse(..))
 import Language.Marlowe.Runtime.Core.Api (ContractId, MarloweVersionTag(V1))
@@ -48,7 +48,7 @@ import System.Environment (getArgs)
 import System.Random (randomRIO)
 
 import qualified Cardano.Api as C
-import qualified Data.Aeson as A (ToJSON, encode)
+import qualified Data.Aeson as A (encode)
 import qualified Data.ByteString.Lazy.Char8 as LBS8 (unpack)
 import qualified Data.Text as T (Text, pack)
 import qualified Data.Time.Clock.POSIX as P (getPOSIXTime)
@@ -113,6 +113,7 @@ runScenario
 runScenario event config address key contract inputs =
   do
     let
+      show' = LBS8.unpack . A.encode
       unexpected response = throwError $ "Unexpected response: " <> show' response
       transact request =
         withSubEvent event (DynamicEventSelector "Transact")
@@ -133,15 +134,14 @@ runScenario event config address key contract inputs =
                   $ \case
                     TxId{..} -> pure resTransactionId
                     response -> unexpected response
-              waitForConfirmation subEvent config txId'
+              handleWithEvents subEvent "Confirm" config (Wait txId' 1)
+                $ \case
+                  TxId{}   -> pure ()
+                  response -> unexpected response
               pure contractId
     contractId <- transact $ Create contract mempty 1_500_000 mempty mempty address mempty
     mapM_ (\input -> transact $ Apply contractId [NormalInput input] Nothing Nothing mempty mempty address mempty) inputs
     pure contractId
-
-
-show' :: A.ToJSON a => a -> String
-show' = LBS8.unpack . A.encode
 
 
 handleWithEvents
@@ -159,18 +159,6 @@ handleWithEvents event name config request extract =
         response <- ExceptT $ handle config request
         addField subEvent $ ("response" :: T.Text) ≔ response
         extract response
-
-
-waitForConfirmation
-  :: DynamicEvent App JSONRef
-  -> Config
-  -> TxId
-  -> App ()
-waitForConfirmation event config txId =
-  handleWithEvents event "Confirm" config (Wait txId 1)
-    $ \case
-      TxId{} -> pure ()
-      response -> throwError $ "Unexpected response: " <> show' response
 
 
 currentTime :: MonadIO m => m POSIXTime

--- a/marlowe-scaling/src/Language/Marlowe/Runtime/Client.hs
+++ b/marlowe-scaling/src/Language/Marlowe/Runtime/Client.hs
@@ -41,8 +41,8 @@ handle config request =
           Follow{..} -> fmap FollowResult <$> followContract reqContractId
           Unfollow{..} -> fmap FollowResult <$> unfollowContract reqContractId
           Get{..} -> fmap (uncurry Info) <$> getContract reqContractId
-          Create{..} -> second (uncurry mkBody) <$> buildCreation MarloweV1 reqContract reqRoles reqMinUtxo reqAddresses reqChange reqCollateral
-          Apply{..} -> second (uncurry mkBody) <$> buildApplication MarloweV1 reqContractId reqInputs reqValidityLowerBound reqValidityUpperBound reqAddresses reqChange reqCollateral
+          Create{..} -> second (uncurry mkBody) <$> buildCreation MarloweV1 reqContract reqRoles reqMinUtxo reqMetadata reqAddresses reqChange reqCollateral
+          Apply{..} -> second (uncurry mkBody) <$> buildApplication MarloweV1 reqContractId reqInputs reqValidityLowerBound reqValidityUpperBound reqMetadata reqAddresses reqChange reqCollateral
           Withdraw{..} -> second (uncurry mkBody) <$> buildWithdrawal MarloweV1 reqContractId reqRole reqAddresses reqChange reqCollateral
           Sign{..} -> pure . Right . uncurry Tx $ sign reqTransactionBody reqPaymentKeys reqPaymentExtendedKeys
           Submit{..} -> second TxId <$> submit reqTransaction

--- a/marlowe-scaling/src/Language/Marlowe/Runtime/Client/Run.hs
+++ b/marlowe-scaling/src/Language/Marlowe/Runtime/Client/Run.hs
@@ -83,7 +83,7 @@ runClientWithConfig
   :: Config
   -> Client a
   -> IO a
-runClientWithConfig Config{..} lambda = do
+runClientWithConfig Config{..} client = do
   chainSeekAddr <- resolve chainSeekHost chainSeekPort
   syncCommandAddr <- resolve chainSeekHost chainSeekCommandPort
   historyJobAddr <- resolve historyHost historyCommandPort
@@ -91,7 +91,7 @@ runClientWithConfig Config{..} lambda = do
   historySyncAddr <- resolve historyHost historySyncPort
   discoveryQueryAddr <- resolve discoveryHost discoveryQueryPort
   txJobAddr <- resolve txHost txCommandPort
-  runReaderT (runClient lambda) Services
+  runReaderT (runClient client) Services
     { runSyncClient = runClientPeerOverSocket chainSeekAddr codecChainSeek (chainSeekClientPeer Genesis)
     , runSyncCommandClient = runClientPeerOverSocket syncCommandAddr codecJob jobClientPeer
     , runHistoryJobClient = runClientPeerOverSocket historyJobAddr codecJob jobClientPeer


### PR DESCRIPTION
Metadata support is added to the Marlowe Runtime client here, so that it can be used by [Marlowe Lambda](https://github.com/input-output-hk/marlowe-lambda).

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
