### PR TITLE
SCP-4855 Fix Misleading Redeemer Type in Runtime API

### DIFF
--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Build.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Build.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -67,7 +68,7 @@ buildApplication
   :: Show (ApplyInputsError v)
   => MarloweVersion v
   -> ContractId
-  -> Redeemer v
+  -> Inputs v
   -> Maybe POSIXTime
   -> Maybe POSIXTime
   -> TransactionMetadata
@@ -75,9 +76,9 @@ buildApplication
   -> Address
   -> [TxOutRef]
   -> Client (Either String (ContractId, C.TxBody C.BabbageEra))
-buildApplication version' contractId' redeemer lower upper metadata' =
-  build show (\InputsApplied{..} -> (contractId, txBody))
-    $ \w -> ApplyInputs version' w contractId' metadata' (utcTime <$> lower) (utcTime <$> upper) redeemer
+buildApplication version' contractId' inputs lower upper metadata' =
+  build show (\InputsApplied{contractId, txBody} -> (contractId, txBody))
+    $ \w -> ApplyInputs version' w contractId' metadata' (utcTime <$> lower) (utcTime <$> upper) inputs
 
 
 buildWithdrawal

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
@@ -1,5 +1,3 @@
-
-
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -54,10 +52,10 @@ import Language.Marlowe.Runtime.ChainSync.Api
   )
 import Language.Marlowe.Runtime.Core.Api
   ( ContractId
-  , IsMarloweVersion(Contract, Redeemer)
+  , IsMarloweVersion(Contract, Inputs)
   , MarloweVersionTag(V1)
   , Payout(..)
-  , Transaction(Transaction, blockHeader, contractId, output, redeemer, transactionId, validityLowerBound, validityUpperBound)
+  , Transaction(Transaction, blockHeader, contractId, inputs, output, transactionId, validityLowerBound, validityUpperBound)
   , TransactionOutput(payouts, scriptOutput)
   , TransactionScriptOutput(..)
   , renderContractId
@@ -180,7 +178,7 @@ data MarloweRequest v =
     }
   | Apply
     { reqContractId :: ContractId
-    , reqInputs :: Redeemer v
+    , reqInputs :: Inputs v
     , reqValidityLowerBound :: Maybe POSIXTime
     , reqValidityUpperBound :: Maybe POSIXTime
     , reqMetadata :: TransactionMetadata
@@ -419,7 +417,7 @@ contractStepToJSON (ApplyTransaction Transaction{..}) =
     [ "step" A..= ("apply" :: String)
     , "txId" A..= transactionId
     , "contractId" A..= renderContractId contractId
-    , "redeemer" A..= redeemer
+    , "redeemer" A..= inputs
     , "scriptOutput" A..= fmap transactionScriptOutputToJSON (scriptOutput output)
     , "payouts" A..= M.map payoutToJSON (payouts output)
     ]

--- a/marlowe-runtime/cli/Language/Marlowe/Runtime/CLI/Command/Apply.hs
+++ b/marlowe-runtime/cli/Language/Marlowe/Runtime/CLI/Command/Apply.hs
@@ -51,8 +51,8 @@ deriving instance Show (ApplyCommandError 'V1)
 
 data ContractInputs v
   = ContractInputsByFile FilePath
-  | ContractInputsByValue (Redeemer v)
-  | ContractInputsByValueWithContinuations (Redeemer v) [FilePath]
+  | ContractInputsByValue (Inputs v)
+  | ContractInputsByValueWithContinuations (Inputs v) [FilePath]
 
 deriving instance Show (ContractInputs 'V1)
 
@@ -215,7 +215,7 @@ readRole = V1.Role . P.TokenName <$> str
 runApplyCommand :: TxCommand ApplyCommand -> CLI ()
 runApplyCommand TxCommand { walletAddresses, signingMethod, metadataFile, subCommand=V1ApplyCommand{..}} = runCLIExceptT do
   inputs' <- case inputs of
-    ContractInputsByValue redeemer -> pure redeemer
+    ContractInputsByValue inputs' -> pure inputs'
     _ -> throwE (PlainInputsSupportedOnly inputs)
   metadata <- readMetadata
   let

--- a/marlowe-runtime/cli/Language/Marlowe/Runtime/CLI/Command/Log.hs
+++ b/marlowe-runtime/cli/Language/Marlowe/Runtime/CLI/Command/Log.hs
@@ -134,10 +134,10 @@ showStep showContract contractId BlockHeader{..} version step= do
   putStr "BlockId:    "
   putStrLn $ T.unpack $ encodeBase16 $ unBlockHeaderHash headerHash
   case step of
-    ApplyTransaction Transaction{redeemer, output} -> do
+    ApplyTransaction Transaction{inputs, output} -> do
       putStr "Inputs:     "
       putStrLn case version of
-        MarloweV1 -> show redeemer
+        MarloweV1 -> show inputs
       putStrLn ""
       when showContract do
         let TransactionOutput{..} = output

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -100,11 +100,13 @@ library history-api
     , cardano-api
     , containers
     , errors
+    , marlowe
     , marlowe-chain-sync
     , marlowe-protocols
     , marlowe-runtime
     , ouroboros-consensus
     , ouroboros-network
+    , plutus-ledger-api
     , transformers
     , typed-protocols
 

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/FollowerSpec.hs
@@ -179,12 +179,12 @@ creationOutput =
 closeTxIn :: Chain.TransactionInput
 closeTxIn =
   let
-    redeemer = Just $ Chain.Redeemer $ toDatum closeRedeemer
+    redeemer = Just $ Chain.Redeemer $ toDatum closeInputs
   in
     Chain.TransactionInput createTxId 0 testScriptAddress (Just $ toDatum createDatum) redeemer
 
-closeRedeemer :: [V1.Input]
-closeRedeemer = [ V1.NormalInput V1.INotify ]
+closeInputs :: [V1.Input]
+closeInputs = [ V1.NormalInput V1.INotify ]
 
 closeTxId :: TxId
 closeTxId = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -680,7 +680,7 @@ checkRollbackToCreationWithInputs = do
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = applyInputsRedeemer
+                    , inputs = applyInputsRedeemer
                     , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
@@ -722,7 +722,7 @@ checkRollbackToCreationClosed = do
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = closeRedeemer
+                    , inputs = closeInputs
                     , output = TransactionOutput mempty Nothing
                     }
                 ]
@@ -753,7 +753,7 @@ checkRollbackToTransaction = do
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = applyInputsRedeemer
+                    , inputs = applyInputsRedeemer
                     , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
@@ -777,7 +777,7 @@ checkRollbackToTransaction = do
                     , blockHeader = block3
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = closeRedeemer
+                    , inputs = closeInputs
                     , output = TransactionOutput mempty Nothing
                     }
                 ]
@@ -804,7 +804,7 @@ checkCloseTransaction = do
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = closeRedeemer
+                    , inputs = closeInputs
                     , output = TransactionOutput mempty Nothing
                     }
                 ]
@@ -831,7 +831,7 @@ checkNonCloseTransaction = do
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = applyInputsRedeemer
+                    , inputs = applyInputsRedeemer
                     , output = TransactionOutput mempty $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
@@ -862,7 +862,7 @@ checkPayoutOpenRedeemedBefore = do
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = applyInputsRedeemer
+                    , inputs = applyInputsRedeemer
                     , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
@@ -901,7 +901,7 @@ checkPayoutOpenRedeemedBefore = do
                     , blockHeader = block4
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = closeRedeemer
+                    , inputs = closeInputs
                     , output = TransactionOutput mempty Nothing
                     }
                 ]
@@ -945,7 +945,7 @@ checkPayoutOpenRedeemedAfter = do
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = applyInputsRedeemer
+                    , inputs = applyInputsRedeemer
                     , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
@@ -969,7 +969,7 @@ checkPayoutOpenRedeemedAfter = do
                     , blockHeader = block3
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = closeRedeemer
+                    , inputs = closeInputs
                     , output = TransactionOutput mempty Nothing
                     }
                 ]
@@ -1011,7 +1011,7 @@ checkPayoutOpenRedeemedTogether = do
                     , blockHeader = block2
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = applyInputsRedeemer
+                    , inputs = applyInputsRedeemer
                     , output = TransactionOutput (Map.singleton payoutUTxO payout) $ Just $ TransactionScriptOutput
                         testScriptAddress
                         mempty
@@ -1040,7 +1040,7 @@ checkPayoutOpenRedeemedTogether = do
                     , blockHeader = block3
                     , validityLowerBound = posixSecondsToUTCTime 0
                     , validityUpperBound = posixSecondsToUTCTime 100
-                    , redeemer = closeRedeemer
+                    , inputs = closeInputs
                     , output = TransactionOutput mempty Nothing
                     }
                 ]

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/History/Script.hs
@@ -349,7 +349,7 @@ genApplyInputsV1 payoutAddress blockHeader contractId TransactionScriptOutput{..
       , blockHeader
       , validityLowerBound = posixSecondsToUTCTime $ secondsToNominalDiffTime $ fromIntegral vLow / 1000
       , validityUpperBound = posixSecondsToUTCTime $ secondsToNominalDiffTime $ fromIntegral vLow / 1000
-      , redeemer = inputs
+      , inputs
       , output
       }
 

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/Transaction/BuildConstraintsSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/Transaction/BuildConstraintsSpec.hs
@@ -110,11 +110,6 @@ createSpec = Hspec.describe "buildCreateConstraints" do
     in case version args of
       MarloweV1 -> result === Right MarloweInputConstraintsNone
       :: Property
-  Hspec.QuickCheck.prop "Doesn't send merkleized continuations" \(SomeCreateArgs args) ->
-    let result = merkleizedContinuationsConstraints <$> runBuildCreateConstraints args
-    in case version args of
-      MarloweV1 -> result === Right mempty
-      :: Property
   Hspec.QuickCheck.prop "Doesn't require extra signatures" \(SomeCreateArgs args) ->
     let result = signatureConstraints <$> runBuildCreateConstraints args
     in case version args of
@@ -249,7 +244,6 @@ withdrawSpec = Hspec.describe "buildWithdrawConstraints" do
           , payToAddresses = Map.empty
           , payToRoles = Map.empty
           , marloweOutputConstraints = TxConstraints.MarloweOutputConstraintsNone
-          , merkleizedContinuationsConstraints = mempty
           , signatureConstraints = Set.empty
           , metadataConstraints = Map.empty
           }

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -21,7 +21,6 @@ module Language.Marlowe.Runtime.Transaction.Constraints
   , mustPayToAddress
   , mustPayToRole
   , mustSendMarloweOutput
-  , mustSendMerkleizedContinuationOutput
   , mustSpendRoleToken
   , requiresMetadata
   , requiresSignature
@@ -49,6 +48,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set (fromAscList, null, singleton, toAscList, toList, union)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
 import Language.Marlowe.Runtime.Cardano.Api
   ( fromCardanoAddressInEra
   , toCardanoAddressInEra
@@ -68,6 +68,7 @@ import Language.Marlowe.Runtime.Core.Api (MarloweVersionTag(..), TransactionScri
 import qualified Language.Marlowe.Runtime.Core.Api as Core
 import Language.Marlowe.Runtime.Core.ScriptRegistry (ReferenceScriptUtxo(..))
 import Language.Marlowe.Runtime.Transaction.Api (ConstraintError(..))
+import qualified Language.Marlowe.Scripts as V1
 import Ouroboros.Consensus.BlockchainTime (SystemStart)
 import qualified Plutus.V2.Ledger.Api as P
 import Witherable (wither)
@@ -92,7 +93,6 @@ data TxConstraints v = TxConstraints
   , payToAddresses :: Map Chain.Address Chain.Assets
   , payToRoles :: Map (Core.PayoutDatum v) Chain.Assets
   , marloweOutputConstraints :: MarloweOutputConstraints v
-  , merkleizedContinuationsConstraints :: Set (Core.Contract v)
   , signatureConstraints :: Set Chain.PaymentKeyHash
   , metadataConstraints :: Map Word64 Chain.Metadata
   }
@@ -192,18 +192,6 @@ mustSendMarloweOutput :: Core.IsMarloweVersion v => Chain.Assets -> Core.Datum v
 mustSendMarloweOutput assets datum =
   mempty { marloweOutputConstraints = MarloweOutput assets datum }
 
--- | Require the transaction to send an output which contains datum with
--- the merkleized continuation. `MarloweTxInput` redeemer only references the continuation
--- through hash but the actual continuation is embedded in the datum of other dedicated for that
--- purpose output.
---
--- Requires that:
---  1. Transaction sends an output to a given address containing the continuation contract in the datum.
---  2. The contract in the rule 1 contains a contract for an appropriate Marlowe version.
-mustSendMerkleizedContinuationOutput :: Core.IsMarloweVersion v => Core.Contract v -> TxConstraints v
-mustSendMerkleizedContinuationOutput contract =
-  mempty { merkleizedContinuationsConstraints = Set.singleton contract }
-
 -- | Require the transaction to send an output to the payout script address
 -- with the given assets and the given datum.
 --
@@ -228,7 +216,7 @@ mustPayToRole assets datum =
 
 data MarloweInputConstraints v
   = MarloweInputConstraintsNone
-  | MarloweInput C.SlotNo C.SlotNo (Core.Redeemer v)
+  | MarloweInput C.SlotNo C.SlotNo (Core.Inputs v)
 
 deriving instance Show (MarloweInputConstraints 'V1)
 deriving instance Eq (MarloweInputConstraints 'V1)
@@ -250,7 +238,7 @@ instance Monoid (MarloweInputConstraints v) where
 --   3. The validity range of the transaction matches the given min and max
 --      validity bounds.
 --   4. All other inputs do not come from a script address.
-mustConsumeMarloweOutput :: Core.IsMarloweVersion v => C.SlotNo -> C.SlotNo -> Core.Redeemer v -> TxConstraints v
+mustConsumeMarloweOutput :: Core.IsMarloweVersion v => C.SlotNo -> C.SlotNo -> Core.Inputs v -> TxConstraints v
 mustConsumeMarloweOutput invalidBefore invalidHereafter inputs =
   mempty { marloweInputConstraints = MarloweInput invalidBefore invalidHereafter inputs }
 
@@ -292,7 +280,6 @@ instance Core.IsMarloweVersion v => Semigroup (TxConstraints v) where
       , payToAddresses = on (Map.unionWith (<>)) payToAddresses a b
       , payToRoles = on (Map.unionWith (<>)) payToRoles a b
       , marloweOutputConstraints = on (<>) marloweOutputConstraints a b
-      , merkleizedContinuationsConstraints = on (<>) merkleizedContinuationsConstraints a b
       , signatureConstraints = on (<>) signatureConstraints a b
       , metadataConstraints = on (<>) metadataConstraints a b
       }
@@ -306,7 +293,6 @@ instance Core.IsMarloweVersion v => Monoid (TxConstraints v) where
       , payToAddresses = mempty
       , payToRoles = mempty
       , marloweOutputConstraints = mempty
-      , merkleizedContinuationsConstraints = mempty
       , signatureConstraints = mempty
       , metadataConstraints = mempty
       }
@@ -885,7 +871,7 @@ solveInitialTxBodyContent protocol marloweVersion MarloweContext{..} WalletConte
     getMarloweInput :: Either (ConstraintError v) (Maybe (C.TxIn, C.BuildTxWith C.BuildTx (C.Witness C.WitCtxTxIn C.BabbageEra)))
     getMarloweInput = case marloweInputConstraints of
       MarloweInputConstraintsNone -> pure Nothing
-      MarloweInput _ _ redeemer -> fmap Just $ do
+      MarloweInput _ _ inputs -> fmap Just $ do
         Core.TransactionScriptOutput{..} <- note MissingMarloweInput scriptOutput
         txIn <- note ToCardanoError $ toCardanoTxIn utxo
         plutusScriptOrRefInput <- note ToCardanoError $ C.PReferenceScript
@@ -897,7 +883,11 @@ solveInitialTxBodyContent protocol marloweVersion MarloweContext{..} WalletConte
             C.PlutusScriptV2
             plutusScriptOrRefInput
             (C.ScriptDatumForTxIn $ toCardanoScriptData $ Core.toChainDatum marloweVersion datum)
-            (toCardanoScriptData $ Chain.unRedeemer $ Core.toChainRedeemer marloweVersion redeemer)
+            ( toCardanoScriptData case marloweVersion of
+                Core.MarloweV1 -> Chain.toDatum $ inputs <&> \case
+                  V1.NormalInput content -> V1.Input content
+                  V1.MerkleizedInput content hash _ -> V1.MerkleizedTxInput content hash
+            )
             (C.ExecutionUnits 0 0)
         pure (txIn, C.BuildTxWith $ C.ScriptWitness C.ScriptWitnessForSpending scriptWitness)
 
@@ -981,12 +971,15 @@ solveInitialTxBodyContent protocol marloweVersion MarloweContext{..} WalletConte
         $ Core.toChainDatum marloweVersion datum
 
     getMerkleizedContinuationOutputs :: [Chain.TransactionOutput]
-    getMerkleizedContinuationOutputs = Set.toList merkleizedContinuationsConstraints <&> \contract ->
-      Chain.TransactionOutput
-        changeAddress
-        mempty
-        Nothing
-        $ Just (Core.toChainMerkleizedContinuationDatum marloweVersion contract)
+    getMerkleizedContinuationOutputs = case marloweInputConstraints of
+      MarloweInput _ _ inputs -> case marloweVersion of
+        Core.MarloweV1 -> flip mapMaybe inputs \case
+          V1.MerkleizedInput _ _ continuation -> Just
+            $ Chain.TransactionOutput changeAddress mempty Nothing
+            $ Just
+            $ Chain.toDatum continuation
+          _ -> Nothing
+      _ -> []
 
     getRoleTokenOutputs :: Either (ConstraintError v) [Chain.TransactionOutput]
     getRoleTokenOutputs = case roleTokenConstraints of

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Server.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Server.hs
@@ -58,9 +58,9 @@ import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
 import Language.Marlowe.Runtime.Core.Api
   ( Contract
   , ContractId(..)
+  , Inputs
   , MarloweVersion(MarloweV1)
   , Payout(Payout, datum)
-  , Redeemer
   , TransactionScriptOutput(..)
   , withMarloweVersion
   )
@@ -195,7 +195,7 @@ worker = component_ \WorkerDependencies{..} -> do
                 metadata
                 minAda
                 contract
-            ApplyInputs version addresses contractId metadata invalidBefore invalidHereafter redeemer ->
+            ApplyInputs version addresses contractId metadata invalidBefore invalidHereafter inputs ->
               withSubEvent ev ExecApplyInputs \ev' -> withMarloweVersion version $ execApplyInputs
                 ev'
                 getTip
@@ -210,7 +210,7 @@ worker = component_ \WorkerDependencies{..} -> do
                 metadata
                 invalidBefore
                 invalidHereafter
-                redeemer
+                inputs
             Withdraw version addresses contractId roleToken ->
               withSubEvent ev ExecWithdraw \ev' -> execWithdraw
                 ev'
@@ -323,7 +323,7 @@ execApplyInputs
   -> TransactionMetadata
   -> Maybe UTCTime
   -> Maybe UTCTime
-  -> Redeemer v
+  -> Inputs v
   -> IO (ServerStCmd MarloweTxCommand Void (ApplyInputsError v) (InputsApplied BabbageEra v) IO ())
 execApplyInputs
   ev

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/DTO.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/DTO.hs
@@ -302,7 +302,7 @@ instance ToDTO TxRecord where
       , inputState = case version of
           MarloweV1 -> Sem.marloweState $ datum input
       , inputs = case version of
-          MarloweV1 -> redeemer
+          MarloweV1 -> inputs
       , outputUtxo = toDTO $ utxo <$> scriptOutput
       , outputContract = case version of
           MarloweV1 -> Sem.marloweContract . datum <$> scriptOutput

--- a/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
+++ b/marlowe-runtime/web-server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
@@ -34,7 +34,7 @@ import Data.Time (UTCTime)
 import Data.Void (Void)
 import Language.Marlowe.Runtime.Cardano.Api (fromCardanoTxId)
 import Language.Marlowe.Runtime.ChainSync.Api (Lovelace, StakeCredential, TransactionMetadata, TxId)
-import Language.Marlowe.Runtime.Core.Api (Contract, ContractId, MarloweVersion, MarloweVersionTag, Redeemer)
+import Language.Marlowe.Runtime.Core.Api (Contract, ContractId, Inputs, MarloweVersion, MarloweVersionTag)
 import Language.Marlowe.Runtime.Transaction.Api
   ( ApplyInputsError
   , ContractCreated(..)
@@ -85,7 +85,7 @@ type ApplyInputs m
   -> TransactionMetadata
   -> Maybe UTCTime
   -> Maybe UTCTime
-  -> Redeemer v
+  -> Inputs v
   -> m (Either (ApplyInputsError v) (InputsApplied BabbageEra v))
 
 data TempTxStatus = Unsigned | Submitted

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -65,11 +65,13 @@
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
             (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             ];

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -65,11 +65,13 @@
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."errors" or (errorHandler.buildDepError "errors"))
+            (hsPkgs."marlowe" or (errorHandler.buildDepError "marlowe"))
             (hsPkgs."marlowe-chain-sync" or (errorHandler.buildDepError "marlowe-chain-sync"))
             (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
             (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
+            (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
             ];


### PR DESCRIPTION
- [x] Rename `Core.Api.Redeemer` to `Core.Api.Inputs`
- [x] Update field names and variable names
- [x] Remove `mustSendMerkleizedContinuationOutput` and just read them from the inputs already in the constraints
- [x] Update `solveConstraints` to store the correct redeemer datum
- [x] Update `extractMarloweTransaction` to lookup the continuation in the script data instead of the redeemer. 