### PR TITLE
Add Marlowe Runtime Web Server to flake.nix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -207,9 +207,9 @@ Running `nix run .#re-up` will refresh `compose.yaml` if need be and then restar
 
 Services currently included:
 
-* `chainseekd`: `chainseekd` for the `preview` network
-* `marlowe-chain-indexer`: `marlowe-chain-indexer` for the `preview` network
-* `node`: A node for the `preview` network
+* `chainseekd`: `chainseekd` for the `preview` network.
+* `marlowe-chain-indexer`: `marlowe-chain-indexer` for the `preview` network.
+* `node`: A node for the `preview` network.
 * `postgres`: A postgres instance, for chainseekd state.
 * `marlowe-history`: A `marlowe-history` instance.
 * `marlowe-discovery`: A `marlowe-discovery` instance.

--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,11 @@
             program = "${packages.marlowe-tx}/bin/marlowe-tx";
           };
 
+          marlowe-web-server = {
+            type = "app";
+            program = "${packages.marlowe-web-server}/bin/marlowe-web-server";
+          };
+
           marlowe = {
             type = "app";
             program = "${packages.marlowe-rt}/bin/marlowe";

--- a/packages.nix
+++ b/packages.nix
@@ -15,7 +15,7 @@ rec {
 
   inherit (haskell.packages.marlowe-cli.components.exes) marlowe-cli;
   inherit (haskell.packages.marlowe-chain-sync.components.exes) chainseekd marlowe-chain-indexer;
-  inherit (haskell.packages.marlowe-runtime.components.exes) marlowe-history marlowe-discovery marlowe-tx;
+  inherit (haskell.packages.marlowe-runtime.components.exes) marlowe-history marlowe-discovery marlowe-tx marlowe-web-server;
   marlowe-rt = haskell.packages.marlowe-runtime.components.exes.marlowe;
 
   network = pkgs.networks.${networkNixName};


### PR DESCRIPTION
This just adds the`marlowe-web-server` exe to the flake (Marlowe Runtime's REST Web Server)

Pre-submit checklist:
- Branch
    - (N/A) Tests are provided (if possible)
    - (N/A) [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
