### PR TITLE
SCP-4932 Fixed erroneous `findMinUtxo` computation.

### DIFF
--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -441,11 +441,12 @@ findMinUtxo protocol (chAddress, mbDatum, origValue) =
       -- FIXME Found what looks like the same value being added and then subtracted from this computation
       -- atLeastHalfAnAda = origValue <> C.lovelaceToValue (maximum [500_000, C.selectLovelace origValue] - C.selectLovelace origValue)
       atLeastHalfAnAda = C.lovelaceToValue (maximum [500_000, C.selectLovelace origValue])
+      revisedValue = origValue <> C.negateValue (C.lovelaceToValue $ C.selectLovelace origValue) <> atLeastHalfAnAda
       datum = maybe C.TxOutDatumNone
         (C.TxOutDatumInTx C.ScriptDataInBabbageEra . C.fromPlutusData . P.toData)
         $ Core.fromChainDatum Core.MarloweV1 =<< mbDatum
 
-    dummyTxOut <- makeTxOut chAddress datum atLeastHalfAnAda C.ReferenceScriptNone
+    dummyTxOut <- makeTxOut chAddress datum revisedValue C.ReferenceScriptNone
     case C.calculateMinimumUTxO C.ShelleyBasedEraBabbage dummyTxOut protocol of
        Right minValue -> pure minValue
        Left e -> Left . CoinSelectionFailed $ show e

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -15,6 +15,8 @@ module Language.Marlowe.Runtime.Transaction.Constraints
   , WalletContext(..)
   , adjustTxForMinUtxo
   , balanceTx
+  , ensureMinUtxo
+  , findMinUtxo
   , mustConsumeMarloweOutput
   , mustConsumePayouts
   , mustMintRoleToken

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -64,7 +64,7 @@ import Language.Marlowe.Runtime.Cardano.Api
   , toCardanoTxOutValue
   , tokensToCardanoValue
   )
-import Language.Marlowe.Runtime.ChainSync.Api (lookupUTxO, toCardanoMetadata, toUTxOTuple, toUTxOsList)
+import Language.Marlowe.Runtime.ChainSync.Api (lookupUTxO, toCardanoMetadata, toPlutusData, toUTxOTuple, toUTxOsList)
 import qualified Language.Marlowe.Runtime.ChainSync.Api as Chain
 import Language.Marlowe.Runtime.Core.Api (MarloweVersionTag(..), TransactionScriptOutput(utxo))
 import qualified Language.Marlowe.Runtime.Core.Api as Core
@@ -72,7 +72,6 @@ import Language.Marlowe.Runtime.Core.ScriptRegistry (ReferenceScriptUtxo(..))
 import Language.Marlowe.Runtime.Transaction.Api (ConstraintError(..))
 import qualified Language.Marlowe.Scripts as V1
 import Ouroboros.Consensus.BlockchainTime (SystemStart)
-import qualified Plutus.V2.Ledger.Api as P
 import Witherable (wither)
 
 -- For debug logging
@@ -445,8 +444,8 @@ findMinUtxo protocol (chAddress, mbDatum, origValue) =
       atLeastHalfAnAda = C.lovelaceToValue (maximum [500_000, C.selectLovelace origValue])
       revisedValue = origValue <> C.negateValue (C.lovelaceToValue $ C.selectLovelace origValue) <> atLeastHalfAnAda
       datum = maybe C.TxOutDatumNone
-        (C.TxOutDatumInTx C.ScriptDataInBabbageEra . C.fromPlutusData . P.toData)
-        $ Core.fromChainDatum Core.MarloweV1 =<< mbDatum
+        (C.TxOutDatumInTx C.ScriptDataInBabbageEra . C.fromPlutusData . toPlutusData)
+        $ mbDatum
 
     dummyTxOut <- makeTxOut chAddress datum revisedValue C.ReferenceScriptNone
     case C.calculateMinimumUTxO C.ShelleyBasedEraBabbage dummyTxOut protocol of


### PR DESCRIPTION
Test case:
```bash
$MARLOWE_BIN/marlowe deposit \
  --contract 2f8fba6ee73ae86b7d06813f2265ef2c8777b6737f0ef037db08e0c517569b63#1 \
  --from-party addr_test1qp4zezsn0234wrdlkuxchus5fgtj3nprf25amdnedtad7t37akzcvrry0tv73kney9dkafq072p0dn8lmyvkwdth2res3205wz \
  --to-party addr_test1qp4zezsn0234wrdlkuxchus5fgtj3nprf25amdnedtad7t37akzcvrry0tv73kney9dkafq072p0dn8lmyvkwdth2res3205wz --currency 4c666f86a731f72fa97c43fb00a52dd4d00519f4cad0d1389ad6f6d7 \
  --token-name DollarThree \
  --quantity 200 \
  --validity-lower-bound 1673943329094 \
  --validity-upper-bound 1673943569094 \
  --change-address addr_test1qp4zezsn0234wrdlkuxchus5fgtj3nprf25amdnedtad7t37akzcvrry0tv73kney9dkafq072p0dn8lmyvkwdth2res3205wz \
  --manual-sign tx.unsigned
```
Result before this commit:
```console
ApplyFailed (ApplyInputsConstraintError (BalancingError "TxBodyErrorMinUTxONotMet (TxOutInAnyEra BabbageEra (TxOut (AddressInEra (ShelleyAddressInEra ShelleyBasedEraBabbage) (ShelleyAddress Testnet (KeyHashObj (KeyHash \"6a2c8a137aa3570dbfb70d8bf2144a1728cc234aa9ddb6
796afadf2e\")) (StakeRefBase (KeyHashObj (KeyHash \"3eed85860c647ad9e8da79215b6ea40ff282f6ccffd91967357750f3\"))))) (TxOutValue MultiAssetInBabbageEra (valueFromList [(AdaAssetId,978370),(AssetId \"4c666f86a731f72fa97c43fb00a52dd4d00519f4cad0d1389ad6f6d7\" \"DollarTh
ree\",499800)])) TxOutDatumNone ReferenceScriptNone)) (Lovelace 1193870)"))
```
Result after this commit:
```console
"{\"txId\":\"136a8caa3a315360c207b7d4ef9232ea7b120462208b750a3d1d66531ab5a82f\"}"
```

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
