### PR TITLE
SCP-4883 ΔQ enhancements for `marlowe-scaling` client

### DIFF
--- a/marlowe-apps/Finder.md
+++ b/marlowe-apps/Finder.md
@@ -40,7 +40,9 @@ Usage: marlowe-finder [--chain-seek-host HOST_NAME]
                       [--discovery-query-port PORT_NUMBER]
                       [--discovery-sync-port PORT_NUMBER] [--tx-host HOST_NAME]
                       [--tx-command-port PORT_NUMBER]
-                      [--timeout-seconds INTEGER] [--polling SECONDS]
+                      [--timeout-seconds INTEGER] [--build-seconds INTEGER]
+                      [--confirm-seconds INTEGER] [--retry-seconds INTEGER]
+                      [--retry-limit INTEGER] [--polling SECONDS]
                       [--requeue SECONDS]
 
   This command-line tool watches the blockchain for Marlowe contracts for active
@@ -55,32 +57,31 @@ Available options:
   --chain-seek-command-port PORT_NUMBER
                            The port number of the chain-seek server's job API.
                            Can be set as the environment variable
-                           MARLOWE_RT_CHAINSEEK_COMMAND_PORT (default: 13720)
+                           MARLOWE_RT_CHAINSEEK_COMMAND_PORT (default: 3720)
   --chain-seek-query-port PORT_NUMBER
                            The port number of the chain-seek server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_CHAINSEEK_QUERY_PORT (default: 13716)
+                           MARLOWE_RT_CHAINSEEK_QUERY_PORT (default: 3716)
   --chain-seek-sync-port PORT_NUMBER
                            The port number of the chain-seek server's
                            synchronization API. Can be set as the environment
                            variable MARLOWE_RT_CHAINSEEK_SYNC_PORT
-                           (default: 13715)
+                           (default: 3715)
   --history-host HOST_NAME The hostname of the Marlowe Runtime history server.
                            Can be set as the environment variable
                            MARLOWE_RT_HISTORY_HOST (default: "127.0.0.1")
   --history-command-port PORT_NUMBER
                            The port number of the history server's job API. Can
                            be set as the environment variable
-                           MARLOWE_RT_HISTORY_COMMAND_PORT (default: 13717)
+                           MARLOWE_RT_HISTORY_COMMAND_PORT (default: 3717)
   --history-query-port PORT_NUMBER
                            The port number of the history server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_HISTORY_QUERY_PORT (default: 13718)
+                           MARLOWE_RT_HISTORY_QUERY_PORT (default: 3718)
   --history-sync-port PORT_NUMBER
                            The port number of the history server's
                            synchronization API. Can be set as the environment
-                           variable MARLOWE_RT_HISTORY_SYNC_PORT
-                           (default: 13719)
+                           variable MARLOWE_RT_HISTORY_SYNC_PORT (default: 3719)
   --discovery-host HOST_NAME
                            The hostname of the Marlowe Runtime discovery server.
                            Can be set as the environment variable
@@ -88,21 +89,46 @@ Available options:
   --discovery-query-port PORT_NUMBER
                            The port number of the discovery server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_DISCOVERY_QUERY_PORT (default: 13721)
+                           MARLOWE_RT_DISCOVERY_QUERY_PORT (default: 3721)
   --discovery-sync-port PORT_NUMBER
                            The port number of the discovery server's
                            synchronization API. Can be set as the environment
                            variable MARLOWE_RT_DISCOVERY_SYNC_PORT
-                           (default: 13722)
+                           (default: 3722)
   --tx-host HOST_NAME      The hostname of the Marlowe Runtime transaction
                            server. Can be set as the environment variable
                            MARLOWE_RT_TX_HOST (default: "127.0.0.1")
   --tx-command-port PORT_NUMBER
                            The port number of the transaction server's job API.
                            Can be set as the environment variable
-                           MARLOWE_RT_TX_COMMAND_PORT (default: 13723)
+                           MARLOWE_RT_TX_COMMAND_PORT (default: 3723)
   --timeout-seconds INTEGER
-                           Time timeout in seconds for transaction confirmation.
+                           Timeout in seconds for transaction confirmation.
+                           (default: 600)
+  --build-seconds INTEGER  Wait specified seconds before transaction
+                           construction. No waiting occurs if a non-positive
+                           number of seconds is specified. The specified wait
+                           period is randomly increased up to a factor of two.
+                           Increasing this value will increase the probability
+                           that Marlowe Runtime's node has seen the transactions
+                           that the submitting node has seen. (default: 3)
+  --confirm-seconds INTEGER
+                           Wait specified seconds after transaction
+                           confirmation. No waiting occurs if a non-positive
+                           number of seconds is specified. The specified wait
+                           period is randomly increased up to a factor of two.
+                           Increasing this value will increase the probability
+                           that the submitting node has seen the transactions
+                           that Marlowe Runtime has seen. (default: 3)
+  --retry-seconds INTEGER  Wait specified seconds after after a failed
+                           transaction before trying again. No retries occur if
+                           a non-positive number of seconds is specified.
+                           (default: 10)
+  --retry-limit INTEGER    Maximum number of attempts for trying a failed
+                           transaction again. Each subsequent retry waits twice
+                           as long as the previous retry. No retries occur if a
+                           non-positive number of retries is specified.
+                           (default: 5)
   --polling SECONDS        The polling frequency for waiting on Marlowe Runtime.
   --requeue SECONDS        The requeuing frequency for reviewing the progress of
                            contracts on Marlowe Runtime.

--- a/marlowe-apps/Oracle.md
+++ b/marlowe-apps/Oracle.md
@@ -196,7 +196,9 @@ Usage: marlowe-oracle [--chain-seek-host HOST_NAME]
                       [--discovery-query-port PORT_NUMBER]
                       [--discovery-sync-port PORT_NUMBER] [--tx-host HOST_NAME]
                       [--tx-command-port PORT_NUMBER]
-                      [--timeout-seconds INTEGER] [--polling SECONDS]
+                      [--timeout-seconds INTEGER] [--build-seconds INTEGER]
+                      [--confirm-seconds INTEGER] [--retry-seconds INTEGER]
+                      [--retry-limit INTEGER] [--polling SECONDS]
                       [--requeue SECONDS] ADDRESS KEYFILE
 
   This command-line tool watches the blockchain for Marlowe contracts to which
@@ -212,32 +214,31 @@ Available options:
   --chain-seek-command-port PORT_NUMBER
                            The port number of the chain-seek server's job API.
                            Can be set as the environment variable
-                           MARLOWE_RT_CHAINSEEK_COMMAND_PORT (default: 23720)
+                           MARLOWE_RT_CHAINSEEK_COMMAND_PORT (default: 3720)
   --chain-seek-query-port PORT_NUMBER
                            The port number of the chain-seek server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_CHAINSEEK_QUERY_PORT (default: 23716)
+                           MARLOWE_RT_CHAINSEEK_QUERY_PORT (default: 3716)
   --chain-seek-sync-port PORT_NUMBER
                            The port number of the chain-seek server's
                            synchronization API. Can be set as the environment
                            variable MARLOWE_RT_CHAINSEEK_SYNC_PORT
-                           (default: 23715)
+                           (default: 3715)
   --history-host HOST_NAME The hostname of the Marlowe Runtime history server.
                            Can be set as the environment variable
                            MARLOWE_RT_HISTORY_HOST (default: "127.0.0.1")
   --history-command-port PORT_NUMBER
                            The port number of the history server's job API. Can
                            be set as the environment variable
-                           MARLOWE_RT_HISTORY_COMMAND_PORT (default: 23717)
+                           MARLOWE_RT_HISTORY_COMMAND_PORT (default: 3717)
   --history-query-port PORT_NUMBER
                            The port number of the history server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_HISTORY_QUERY_PORT (default: 23718)
+                           MARLOWE_RT_HISTORY_QUERY_PORT (default: 3718)
   --history-sync-port PORT_NUMBER
                            The port number of the history server's
                            synchronization API. Can be set as the environment
-                           variable MARLOWE_RT_HISTORY_SYNC_PORT
-                           (default: 23719)
+                           variable MARLOWE_RT_HISTORY_SYNC_PORT (default: 3719)
   --discovery-host HOST_NAME
                            The hostname of the Marlowe Runtime discovery server.
                            Can be set as the environment variable
@@ -245,21 +246,46 @@ Available options:
   --discovery-query-port PORT_NUMBER
                            The port number of the discovery server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_DISCOVERY_QUERY_PORT (default: 23721)
+                           MARLOWE_RT_DISCOVERY_QUERY_PORT (default: 3721)
   --discovery-sync-port PORT_NUMBER
                            The port number of the discovery server's
                            synchronization API. Can be set as the environment
                            variable MARLOWE_RT_DISCOVERY_SYNC_PORT
-                           (default: 23722)
+                           (default: 3722)
   --tx-host HOST_NAME      The hostname of the Marlowe Runtime transaction
                            server. Can be set as the environment variable
                            MARLOWE_RT_TX_HOST (default: "127.0.0.1")
   --tx-command-port PORT_NUMBER
                            The port number of the transaction server's job API.
                            Can be set as the environment variable
-                           MARLOWE_RT_TX_COMMAND_PORT (default: 23723)
+                           MARLOWE_RT_TX_COMMAND_PORT (default: 3723)
   --timeout-seconds INTEGER
-                           Time timeout in seconds for transaction confirmation.
+                           Timeout in seconds for transaction confirmation.
+                           (default: 600)
+  --build-seconds INTEGER  Wait specified seconds before transaction
+                           construction. No waiting occurs if a non-positive
+                           number of seconds is specified. The specified wait
+                           period is randomly increased up to a factor of two.
+                           Increasing this value will increase the probability
+                           that Marlowe Runtime's node has seen the transactions
+                           that the submitting node has seen. (default: 3)
+  --confirm-seconds INTEGER
+                           Wait specified seconds after transaction
+                           confirmation. No waiting occurs if a non-positive
+                           number of seconds is specified. The specified wait
+                           period is randomly increased up to a factor of two.
+                           Increasing this value will increase the probability
+                           that the submitting node has seen the transactions
+                           that Marlowe Runtime has seen. (default: 3)
+  --retry-seconds INTEGER  Wait specified seconds after after a failed
+                           transaction before trying again. No retries occur if
+                           a non-positive number of seconds is specified.
+                           (default: 10)
+  --retry-limit INTEGER    Maximum number of attempts for trying a failed
+                           transaction again. Each subsequent retry waits twice
+                           as long as the previous retry. No retries occur if a
+                           non-positive number of retries is specified.
+                           (default: 5)
   --polling SECONDS        The polling frequency for waiting on Marlowe Runtime.
   --requeue SECONDS        The requeuing frequency for reviewing the progress of
                            contracts on Marlowe Runtime.

--- a/marlowe-apps/Scaling.md
+++ b/marlowe-apps/Scaling.md
@@ -84,7 +84,9 @@ Usage: marlowe-scaling [--chain-seek-host HOST_NAME]
                        [--discovery-query-port PORT_NUMBER]
                        [--discovery-sync-port PORT_NUMBER] [--tx-host HOST_NAME]
                        [--tx-command-port PORT_NUMBER]
-                       [--timeout-seconds INTEGER] NATURAL [ADDRESS=KEYFILE]
+                       [--timeout-seconds INTEGER] [--build-seconds INTEGER]
+                       [--confirm-seconds INTEGER] [--retry-seconds INTEGER]
+                       [--retry-limit INTEGER] NATURAL [ADDRESS=KEYFILE]
 
   This command-line tool is a scaling test client for Marlowe Runtime: it runs
   multiple contracts in parallel against a Marlowe Runtime backend, with a
@@ -100,32 +102,31 @@ Available options:
   --chain-seek-command-port PORT_NUMBER
                            The port number of the chain-seek server's job API.
                            Can be set as the environment variable
-                           MARLOWE_RT_CHAINSEEK_COMMAND_PORT (default: 23720)
+                           MARLOWE_RT_CHAINSEEK_COMMAND_PORT (default: 3720)
   --chain-seek-query-port PORT_NUMBER
                            The port number of the chain-seek server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_CHAINSEEK_QUERY_PORT (default: 23716)
+                           MARLOWE_RT_CHAINSEEK_QUERY_PORT (default: 3716)
   --chain-seek-sync-port PORT_NUMBER
                            The port number of the chain-seek server's
                            synchronization API. Can be set as the environment
                            variable MARLOWE_RT_CHAINSEEK_SYNC_PORT
-                           (default: 23715)
+                           (default: 3715)
   --history-host HOST_NAME The hostname of the Marlowe Runtime history server.
                            Can be set as the environment variable
                            MARLOWE_RT_HISTORY_HOST (default: "127.0.0.1")
   --history-command-port PORT_NUMBER
                            The port number of the history server's job API. Can
                            be set as the environment variable
-                           MARLOWE_RT_HISTORY_COMMAND_PORT (default: 23717)
+                           MARLOWE_RT_HISTORY_COMMAND_PORT (default: 3717)
   --history-query-port PORT_NUMBER
                            The port number of the history server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_HISTORY_QUERY_PORT (default: 23718)
+                           MARLOWE_RT_HISTORY_QUERY_PORT (default: 3718)
   --history-sync-port PORT_NUMBER
                            The port number of the history server's
                            synchronization API. Can be set as the environment
-                           variable MARLOWE_RT_HISTORY_SYNC_PORT
-                           (default: 23719)
+                           variable MARLOWE_RT_HISTORY_SYNC_PORT (default: 3719)
   --discovery-host HOST_NAME
                            The hostname of the Marlowe Runtime discovery server.
                            Can be set as the environment variable
@@ -133,21 +134,31 @@ Available options:
   --discovery-query-port PORT_NUMBER
                            The port number of the discovery server's query API.
                            Can be set as the environment variable
-                           MARLOWE_RT_DISCOVERY_QUERY_PORT (default: 23721)
+                           MARLOWE_RT_DISCOVERY_QUERY_PORT (default: 3721)
   --discovery-sync-port PORT_NUMBER
                            The port number of the discovery server's
                            synchronization API. Can be set as the environment
                            variable MARLOWE_RT_DISCOVERY_SYNC_PORT
-                           (default: 23722)
+                           (default: 3722)
   --tx-host HOST_NAME      The hostname of the Marlowe Runtime transaction
                            server. Can be set as the environment variable
                            MARLOWE_RT_TX_HOST (default: "127.0.0.1")
   --tx-command-port PORT_NUMBER
                            The port number of the transaction server's job API.
                            Can be set as the environment variable
-                           MARLOWE_RT_TX_COMMAND_PORT (default: 23723)
+                           MARLOWE_RT_TX_COMMAND_PORT (default: 3723)
   --timeout-seconds INTEGER
-                           Time timeout in seconds for transaction confirmation.
+                           Timeout in seconds for transaction confirmation.
+                           (default: 600)
+  --build-seconds INTEGER  Wait specified seconds before transaction
+                           construction. (default: 3)
+  --confirm-seconds INTEGER
+                           Wait specified seconds after transaction
+                           confirmation. (default: 3)
+  --retry-seconds INTEGER  Wait specified seconds after after a failed
+                           transaction before trying again. (default: 10)
+  --retry-limit INTEGER    Maximum number of attempts for trying a failed
+                           transaction again. (default: 4)
   NATURAL                  The number of contracts to run sequentially for each
                            party.
   ADDRESS=KEYFILE          The addresses of the parties and the files with their

--- a/marlowe-apps/Scaling.md
+++ b/marlowe-apps/Scaling.md
@@ -151,14 +151,29 @@ Available options:
                            Timeout in seconds for transaction confirmation.
                            (default: 600)
   --build-seconds INTEGER  Wait specified seconds before transaction
-                           construction. (default: 3)
+                           construction. No waiting occurs if a non-positive
+                           number of seconds is specified. The specified wait
+                           period is randomly increased up to a factor of two.
+                           Increasing this value will increase the probability
+                           that Marlowe Runtime's node has seen the transactions
+                           that the submitting node has seen. (default: 3)
   --confirm-seconds INTEGER
                            Wait specified seconds after transaction
-                           confirmation. (default: 3)
+                           confirmation. No waiting occurs if a non-positive
+                           number of seconds is specified. The specified wait
+                           period is randomly increased up to a factor of two.
+                           Increasing this value will increase the probability
+                           that the submitting node has seen the transactions
+                           that Marlowe Runtime has seen. (default: 3)
   --retry-seconds INTEGER  Wait specified seconds after after a failed
-                           transaction before trying again. (default: 10)
+                           transaction before trying again. No retries occur if
+                           a non-positive number of seconds is specified.
+                           (default: 10)
   --retry-limit INTEGER    Maximum number of attempts for trying a failed
-                           transaction again. (default: 4)
+                           transaction again. Each subsequent retry waits twice
+                           as long as the previous retry. No retries occur if a
+                           non-positive number of retries is specified.
+                           (default: 5)
   NATURAL                  The number of contracts to run sequentially for each
                            party.
   ADDRESS=KEYFILE          The addresses of the parties and the files with their

--- a/marlowe-apps/marlowe-apps.cabal
+++ b/marlowe-apps/marlowe-apps.cabal
@@ -45,6 +45,7 @@ library
                     , mtl
                     , network
                     , optparse-applicative
+                    , random
                     , stm
                     , text
                     , time

--- a/marlowe-apps/marlowe-apps.cabal
+++ b/marlowe-apps/marlowe-apps.cabal
@@ -1,6 +1,6 @@
 cabal-version      : 3.0
 name               : marlowe-apps
-version            : 0.2.0.1
+version            : 0.2.1.0
 synopsis           : Marlowe Runtimee applications
 license            : Apache-2.0
 license-file       : LICENSE

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Parser.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Parser.hs
@@ -8,7 +8,7 @@ module Language.Marlowe.Runtime.App.Parser
 
 
 import Data.Default (def)
-import Language.Marlowe.Runtime.App.Types (Config(Config, confirmSeconds, timeoutSeconds))
+import Language.Marlowe.Runtime.App.Types (Config(Config, buildSeconds, confirmSeconds, timeoutSeconds))
 import Language.Marlowe.Runtime.CLI.Option (CliOption, host, optParserWithEnvDefault, port)
 import Language.Marlowe.Runtime.ChainSync.Api (Address, fromBech32)
 import Network.Socket (HostName, PortNumber)
@@ -42,6 +42,13 @@ getConfigParser =
           <> O.value (timeoutSeconds def)
           <> O.showDefault
           <> O.help "Timeout in seconds for transaction confirmation."
+      buildSecondsParser =
+        O.option O.auto
+          $  O.long "build-seconds"
+          <> O.metavar "INTEGER"
+          <> O.value (buildSeconds def)
+          <> O.showDefault
+          <> O.help "Wait specified seconds before transaction construction."
       confirmSecondsParser =
         O.option O.auto
           $  O.long "confirm-seconds"
@@ -65,6 +72,7 @@ getConfigParser =
       <*> txHostParser
       <*> txCommandPortParser
       <*> timeoutSecondsParser
+      <*> buildSecondsParser
       <*> confirmSecondsParser
 
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Parser.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Parser.hs
@@ -8,7 +8,8 @@ module Language.Marlowe.Runtime.App.Parser
 
 
 import Data.Default (def)
-import Language.Marlowe.Runtime.App.Types (Config(Config, buildSeconds, confirmSeconds, timeoutSeconds))
+import Language.Marlowe.Runtime.App.Types
+  (Config(Config, buildSeconds, confirmSeconds, retryLimit, retrySeconds, timeoutSeconds))
 import Language.Marlowe.Runtime.CLI.Option (CliOption, host, optParserWithEnvDefault, port)
 import Language.Marlowe.Runtime.ChainSync.Api (Address, fromBech32)
 import Network.Socket (HostName, PortNumber)
@@ -56,6 +57,20 @@ getConfigParser =
           <> O.value (confirmSeconds def)
           <> O.showDefault
           <> O.help "Wait specified seconds after transaction confirmation."
+      retrySecondsParser =
+        O.option O.auto
+          $  O.long "retry-seconds"
+          <> O.metavar "INTEGER"
+          <> O.value (retrySeconds def)
+          <> O.showDefault
+          <> O.help "Wait specified seconds after after a failed transaction before trying again."
+      retryLimitParser =
+        O.option O.auto
+          $  O.long "retry-limit"
+          <> O.metavar "INTEGER"
+          <> O.value (retryLimit def)
+          <> O.showDefault
+          <> O.help "Maximum number of attempts for trying a failed transaction again."
     pure
       $ Config
       <$> chainSeekHostParser
@@ -74,6 +89,8 @@ getConfigParser =
       <*> timeoutSecondsParser
       <*> buildSecondsParser
       <*> confirmSecondsParser
+      <*> retrySecondsParser
+      <*> retryLimitParser
 
 
 chainSeekHost :: CliOption O.OptionFields HostName

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Parser.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Parser.hs
@@ -7,7 +7,8 @@ module Language.Marlowe.Runtime.App.Parser
   ) where
 
 
-import Language.Marlowe.Runtime.App.Types (Config(Config))
+import Data.Default (def)
+import Language.Marlowe.Runtime.App.Types (Config(Config, confirmSeconds, timeoutSeconds))
 import Language.Marlowe.Runtime.CLI.Option (CliOption, host, optParserWithEnvDefault, port)
 import Language.Marlowe.Runtime.ChainSync.Api (Address, fromBech32)
 import Network.Socket (HostName, PortNumber)
@@ -38,8 +39,16 @@ getConfigParser =
         O.option O.auto
           $  O.long "timeout-seconds"
           <> O.metavar "INTEGER"
-          <> O.value 600
-          <> O.help "Time timeout in seconds for transaction confirmation."
+          <> O.value (timeoutSeconds def)
+          <> O.showDefault
+          <> O.help "Timeout in seconds for transaction confirmation."
+      confirmSecondsParser =
+        O.option O.auto
+          $  O.long "confirm-seconds"
+          <> O.metavar "INTEGER"
+          <> O.value (confirmSeconds def)
+          <> O.showDefault
+          <> O.help "Wait specified seconds after transaction confirmation."
     pure
       $ Config
       <$> chainSeekHostParser
@@ -56,6 +65,7 @@ getConfigParser =
       <*> txHostParser
       <*> txCommandPortParser
       <*> timeoutSecondsParser
+      <*> confirmSecondsParser
 
 
 chainSeekHost :: CliOption O.OptionFields HostName

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Parser.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Parser.hs
@@ -49,28 +49,28 @@ getConfigParser =
           <> O.metavar "INTEGER"
           <> O.value (buildSeconds def)
           <> O.showDefault
-          <> O.help "Wait specified seconds before transaction construction."
+          <> O.help "Wait specified seconds before transaction construction. No waiting occurs if a non-positive number of seconds is specified. The specified wait period is randomly increased up to a factor of two. Increasing this value will increase the probability that Marlowe Runtime's node has seen the transactions that the submitting node has seen."
       confirmSecondsParser =
         O.option O.auto
           $  O.long "confirm-seconds"
           <> O.metavar "INTEGER"
           <> O.value (confirmSeconds def)
           <> O.showDefault
-          <> O.help "Wait specified seconds after transaction confirmation."
+          <> O.help "Wait specified seconds after transaction confirmation. No waiting occurs if a non-positive number of seconds is specified. The specified wait period is randomly increased up to a factor of two. Increasing this value will increase the probability that the submitting node has seen the transactions that Marlowe Runtime has seen."
       retrySecondsParser =
         O.option O.auto
           $  O.long "retry-seconds"
           <> O.metavar "INTEGER"
           <> O.value (retrySeconds def)
           <> O.showDefault
-          <> O.help "Wait specified seconds after after a failed transaction before trying again."
+          <> O.help "Wait specified seconds after after a failed transaction before trying again. No retries occur if a non-positive number of seconds is specified."
       retryLimitParser =
         O.option O.auto
           $  O.long "retry-limit"
           <> O.metavar "INTEGER"
           <> O.value (retryLimit def)
           <> O.showDefault
-          <> O.help "Maximum number of attempts for trying a failed transaction again."
+          <> O.help "Maximum number of attempts for trying a failed transaction again. Each subsequent retry waits twice as long as the previous retry. No retries occur if a non-positive number of retries is specified."
     pure
       $ Config
       <$> chainSeekHostParser

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -160,8 +160,8 @@ transactWithEvents event config@Config{buildSeconds, confirmSeconds, retryLimit,
           when (buildSeconds > 0)
             . withSubEvent subEvent (DynamicEventSelector "WaitBeforeBuild")
             . const
-            $ liftIO . threadDelay . ((buildSeconds * 1_000_000) +)
-            =<< randomRIO (-500_000, 500_000)
+            $ liftIO . threadDelay . (buildSeconds *)
+            =<< randomRIO (1_000_000, 2_000_000)
           (contractId, body) <-
             handleWithEvents subEvent "Build" config request
               $ \case
@@ -184,8 +184,8 @@ transactWithEvents event config@Config{buildSeconds, confirmSeconds, retryLimit,
           when (confirmSeconds > 0)
             . withSubEvent subEvent (DynamicEventSelector "WaitAfterConfirm")
             . const
-            $ liftIO . threadDelay . ((confirmSeconds * 1_000_000) +)
-            =<< randomRIO (-500_000, 500_000)
+            $ liftIO . threadDelay . (confirmSeconds +)
+            =<< randomRIO (1_000_000, 2_000_000)
           pure contractId
 
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -184,7 +184,7 @@ transactWithEvents event config@Config{buildSeconds, confirmSeconds, retryLimit,
           when (confirmSeconds > 0)
             . withSubEvent subEvent (DynamicEventSelector "WaitAfterConfirm")
             . const
-            $ liftIO . threadDelay . (confirmSeconds +)
+            $ liftIO . threadDelay . (confirmSeconds *)
             =<< randomRIO (1_000_000, 2_000_000)
           pure contractId
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -154,7 +154,7 @@ transactWithEvents event config@Config{buildSeconds, confirmSeconds, retryLimit,
     show' = LBS8.unpack . A.encode
     unexpected response = throwError $ "Unexpected response: " <> show' response
   in
-    retry "Transact" event [retrySeconds * 2^(i-1) | i <- [1..retryLimit]]
+    retry "Transact" event [retrySeconds * 2^(i-1) | retrySeconds > 0, retryLimit > 0, i <- [1..retryLimit]]
       $ \subEvent ->
         do
           when (buildSeconds > 0)

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -175,8 +175,9 @@ transactWithEvents event config@Config{confirmSeconds} key request =
               TxInfo{} -> pure ()
               response -> unexpected response
           when (confirmSeconds > 0)
-            . liftIO . threadDelay
-            $ 1_000_000 * confirmSeconds
+            . withSubEvent subEvent (DynamicEventSelector "Wait")
+            . const
+            $ liftIO . threadDelay $ confirmSeconds * 1_000_000
           pure contractId
 
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -35,6 +35,7 @@ import Observe.Event (Event, addField, newEvent, withSubEvent)
 import Observe.Event.Backend (unitEventBackend)
 import Observe.Event.Dynamic (DynamicEvent, DynamicEventSelector(..))
 import Observe.Event.Syntax ((≔))
+import System.Random (randomRIO)
 
 import qualified Cardano.Api as C (PaymentExtendedKey, SigningKey)
 import qualified Data.Aeson as A (encode)
@@ -159,7 +160,8 @@ transactWithEvents event config@Config{buildSeconds, confirmSeconds} key request
           when (buildSeconds > 0)
             . withSubEvent subEvent (DynamicEventSelector "WaitBeforeBuild")
             . const
-            $ liftIO . threadDelay $ buildSeconds * 1_000_000
+            $ liftIO . threadDelay . (buildSeconds *)
+            =<< randomRIO (500_000, 1_500_000)
           (contractId, body) <-
             handleWithEvents subEvent "Build" config request
               $ \case
@@ -182,7 +184,8 @@ transactWithEvents event config@Config{buildSeconds, confirmSeconds} key request
           when (confirmSeconds > 0)
             . withSubEvent subEvent (DynamicEventSelector "WaitAfterConfirm")
             . const
-            $ liftIO . threadDelay $ confirmSeconds * 1_000_000
+            $ liftIO . threadDelay . (confirmSeconds *)
+            =<< randomRIO (500_000, 1_500_000)
           pure contractId
 
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -205,7 +205,7 @@ retry name event (delay : delays) action =
           Right result -> pure $ Right result
           Left message -> runExceptT
                             $ do
-                              addField subEvent $ ("failure" :: T.Text) ≔ message
+                              addField subEvent $ ("failedAttempt" :: T.Text) ≔ message
                               addField subEvent $ ("waitForRetry" :: T.Text) ≔ delay
                               liftIO . threadDelay $ delay * 1_000_000
                               retry name event delays action

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -160,8 +160,8 @@ transactWithEvents event config@Config{buildSeconds, confirmSeconds, retryLimit,
           when (buildSeconds > 0)
             . withSubEvent subEvent (DynamicEventSelector "WaitBeforeBuild")
             . const
-            $ liftIO . threadDelay . (buildSeconds *)
-            =<< randomRIO (500_000, 1_500_000)
+            $ liftIO . threadDelay . ((buildSeconds * 1_000_000) +)
+            =<< randomRIO (-500_000, 500_000)
           (contractId, body) <-
             handleWithEvents subEvent "Build" config request
               $ \case
@@ -184,8 +184,8 @@ transactWithEvents event config@Config{buildSeconds, confirmSeconds, retryLimit,
           when (confirmSeconds > 0)
             . withSubEvent subEvent (DynamicEventSelector "WaitAfterConfirm")
             . const
-            $ liftIO . threadDelay . (confirmSeconds *)
-            =<< randomRIO (500_000, 1_500_000)
+            $ liftIO . threadDelay . ((confirmSeconds * 1_000_000) +)
+            =<< randomRIO (-500_000, 500_000)
           pure contractId
 
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
@@ -108,6 +108,7 @@ data Config =
   , txHost :: HostName
   , txCommandPort :: PortNumber
   , timeoutSeconds :: Int
+  , buildSeconds :: Int
   , confirmSeconds :: Int
   }
     deriving (Read, Show)
@@ -129,7 +130,8 @@ instance Default Config where
     , txHost = "127.0.0.1"
     , txCommandPort = 3723
     , timeoutSeconds = 600
-    , confirmSeconds = 5
+    , buildSeconds = 3
+    , confirmSeconds = 3
     }
 
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
@@ -108,6 +108,7 @@ data Config =
   , txHost :: HostName
   , txCommandPort :: PortNumber
   , timeoutSeconds :: Int
+  , confirmSeconds :: Int
   }
     deriving (Read, Show)
 
@@ -128,6 +129,7 @@ instance Default Config where
     , txHost = "127.0.0.1"
     , txCommandPort = 3723
     , timeoutSeconds = 600
+    , confirmSeconds = 5
     }
 
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
@@ -135,7 +135,7 @@ instance Default Config where
     , buildSeconds = 3
     , confirmSeconds = 3
     , retrySeconds = 10
-    , retryLimit = 4
+    , retryLimit = 5
     }
 
 

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
@@ -110,6 +110,8 @@ data Config =
   , timeoutSeconds :: Int
   , buildSeconds :: Int
   , confirmSeconds :: Int
+  , retrySeconds :: Int
+  , retryLimit :: Int
   }
     deriving (Read, Show)
 
@@ -132,6 +134,8 @@ instance Default Config where
     , timeoutSeconds = 600
     , buildSeconds = 3
     , confirmSeconds = 3
+    , retrySeconds = 10
+    , retryLimit = 4
     }
 
 

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-apps.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-apps.nix
@@ -11,7 +11,7 @@
     flags = {};
     package = {
       specVersion = "3.0";
-      identifier = { name = "marlowe-apps"; version = "0.2.0.1"; };
+      identifier = { name = "marlowe-apps"; version = "0.2.1.0"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "Brian W Bush <brian.bush@iohk.io>";

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-apps.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-apps.nix
@@ -55,6 +55,7 @@
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."network" or (errorHandler.buildDepError "network"))
           (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."random" or (errorHandler.buildDepError "random"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-apps.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-apps.nix
@@ -11,7 +11,7 @@
     flags = {};
     package = {
       specVersion = "3.0";
-      identifier = { name = "marlowe-apps"; version = "0.2.0.1"; };
+      identifier = { name = "marlowe-apps"; version = "0.2.1.0"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "Brian W Bush <brian.bush@iohk.io>";

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-apps.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-apps.nix
@@ -55,6 +55,7 @@
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
           (hsPkgs."network" or (errorHandler.buildDepError "network"))
           (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."random" or (errorHandler.buildDepError "random"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))


### PR DESCRIPTION
The following parameters were added to `marlowe-scaling`:
- delay before building transaction
- delay after transaction is confirmed
- jittering of delays
- retry with backoff

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
