### PR TITLE
Fixed bug where WalletContext was missing assets

### DIFF
--- a/marlowe-runtime/test/Language/Marlowe/Runtime/Transaction/ConstraintsSpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/Transaction/ConstraintsSpec.hs
@@ -491,8 +491,7 @@ spec = do
 genWalletWithNuisance :: MarloweVersion v -> TxConstraints v -> Word64 -> Gen WalletContext
 genWalletWithNuisance marloweVersion' constraints' minLovelace = do
   wc <- genWalletContext marloweVersion' constraints'
-  adaTxOutRef <- arbitrary
-  nuisTxOutRef <- arbitrary
+  (adaTxOutRef, nuisTxOutRef) <- suchThat ((,) <$> arbitrary <*> arbitrary) (uncurry (/=))
   someAddress <- arbitrary
   let lovelaceToAdd = Chain.Assets (Chain.Lovelace minLovelace) (Chain.Tokens Map.empty)
   nuisAssets <- (lovelaceToAdd <>) <$> arbitrary


### PR DESCRIPTION
Found a bug where invalid wallets were being created for some tests intermittantly because of a collision in generating TxOutRef values. Fixed.
