### PR TITLE
SCP-4588 Added commands for print PIR and UPLC.

### DIFF
--- a/marlowe-cli/marlowe-cli.cabal
+++ b/marlowe-cli/marlowe-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: marlowe-cli
-version: 0.0.10.0
+version: 0.0.10.1
 license: Apache-2.0
 license-files:
   LICENSE

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Contract.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Contract.hs
@@ -31,6 +31,7 @@ import Language.Marlowe.CLI.Command.Parse
   (parseCurrencySymbol, parseNetworkId, parseStakeAddressReference, protocolVersionOpt)
 import Language.Marlowe.CLI.Export
   (exportDatum, exportMarlowe, exportMarloweAddress, exportMarloweValidator, exportRedeemer)
+import Language.Marlowe.CLI.Plutus.Script.Utils (printPir, printUplc)
 import Language.Marlowe.CLI.Types (CliEnv, CliError)
 import Language.Marlowe.Client (defaultMarloweParams, marloweParams)
 import Plutus.V1.Ledger.Api (CurrencySymbol, ProtocolVersion)
@@ -87,6 +88,16 @@ data ContractCommand =
     , outputFile :: Maybe FilePath  -- ^ The output JSON file for the redeemer.
     , printStats :: Bool            -- ^ Whether to print statistics about the redeemer.
     }
+    -- | Print the PIR for the Marlowe validator.
+  | PrintPir
+    {
+      outputFile :: Maybe FilePath  -- ^ The output file for the PIR.
+    }
+    -- | Print the UPLC for the Marlowe validator.
+  | PrintUplc
+    {
+      outputFile :: Maybe FilePath  -- ^ The output file for the UPLC.
+    }
 
 
 -- | Run an export-related command.
@@ -126,6 +137,8 @@ runContractCommand command =
                                inputFiles
                                outputFile
                                printStats
+      PrintPir{..}        -> printPir outputFile
+      PrintUplc{..}       -> printUplc outputFile
 
 
 -- | Parser for export-related commands.
@@ -139,6 +152,8 @@ parseContractCommand network =
     <> exportMarloweCommand network
     <> exportRedeemerCommand
     <> exportValidatorCommand network
+    <> printPirCommand
+    <> printUplcCommand
 
 
 -- | Parser for the "marlowe" command.
@@ -240,3 +255,25 @@ exportRedeemerOptions =
     <$> (O.many . O.strOption)     (O.long "input-file"  <> O.metavar "INPUT_FILE"  <> O.help "JSON input file for redeemer inputs.")
     <*> (O.optional . O.strOption) (O.long "out-file"    <> O.metavar "OUTPUT_FILE" <> O.help "JSON output file for redeemer."      )
     <*> O.switch                   (O.long "print-stats"                            <> O.help "Print statistics."                   )
+
+
+-- | Parser for the "pir" command.
+printPirCommand :: O.Mod O.CommandFields ContractCommand
+printPirCommand =
+  O.command "pir"
+    . O.info (
+      PrintPir
+        <$> (O.optional . O.strOption) (O.long "out-file"    <> O.metavar "OUTPUT_FILE" <> O.help "The output file for the PIR.")
+    )
+    $ O.progDesc "Print the Plutus Intermediate Representation (PIR) for the Marlowe validator."
+
+
+-- | Parser for the "uplc" command.
+printUplcCommand :: O.Mod O.CommandFields ContractCommand
+printUplcCommand =
+  O.command "uplc"
+    . O.info (
+      PrintUplc
+        <$> (O.optional . O.strOption) (O.long "out-file"    <> O.metavar "OUTPUT_FILE" <> O.help "The output file for the UPLC.")
+    )
+    $ O.progDesc "Print the Untyped Plutus Core (UPLC) for the Marlowe validator."

--- a/marlowe-cli/src/Language/Marlowe/CLI/Plutus/Script/Utils.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Plutus/Script/Utils.hs
@@ -1,13 +1,22 @@
 {-# LANGUAGE GADTs #-}
+
+
 module Language.Marlowe.CLI.Plutus.Script.Utils
   where
 
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Language.Marlowe.Scripts (marloweValidatorCompiled)
+import Prettyprinter (pretty)
+
 import qualified Plutus.Script.Utils.V1.Typed.Scripts as V1
 import qualified Plutus.Script.Utils.V2.Typed.Scripts as V2
+import qualified PlutusTx as PlutusTx
 -- These types are common to Plutus V1 and V2
 import Cardano.Api (PlutusScriptV1)
 import Cardano.Api.Byron (PlutusScriptV2)
 import Plutus.V2.Ledger.Api (Validator, ValidatorHash)
+
 
 data TypedValidator' lang t where
   TypedValidatorV1 :: V1.TypedValidator t -> TypedValidator' PlutusScriptV1 t
@@ -22,3 +31,18 @@ validatorScript :: TypedValidator' lang t -> Validator
 validatorScript (TypedValidatorV1 v) = V1.validatorScript v
 validatorScript (TypedValidatorV2 v) = V2.validatorScript v
 
+
+printPir :: MonadIO m => Maybe FilePath -> m ()
+printPir outFile =
+  liftIO
+    . maybe print ((. show) . writeFile) outFile
+    . pretty
+    $ PlutusTx.getPir marloweValidatorCompiled
+
+
+printUplc :: MonadIO m => Maybe FilePath -> m ()
+printUplc outFile =
+  liftIO
+    . maybe print ((. show) . writeFile) outFile
+    . pretty
+    $ PlutusTx.getPlc marloweValidatorCompiled

--- a/marlowe/marlowe-cardano.cabal
+++ b/marlowe/marlowe-cardano.cabal
@@ -63,6 +63,7 @@ library
     plutus-ledger-api,
     plutus-script-utils,
     plutus-tx,
+    prettyprinter,
     sbv >=8.4,
     scientific,
     serialise,

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -47,7 +47,9 @@ module Language.Marlowe.Scripts
   , alternateMarloweValidator
   , alternateMarloweValidatorHash
   , marloweValidator
+  , marloweValidatorCompiled
   , marloweValidatorHash
+  , mkMarloweValidator
     -- * Payout Validator
   , TypedRolePayoutValidator
   , rolePayoutValidator
@@ -413,6 +415,16 @@ marloweValidator =
     typedValidator = Scripts.unsafeMkTypedValidator untypedValidator
   in
     unsafeCoerce typedValidator
+
+
+marloweValidatorCompiled :: PlutusTx.CompiledCode (ValidatorHash -> PlutusTx.BuiltinData -> PlutusTx.BuiltinData -> PlutusTx.BuiltinData -> ())
+marloweValidatorCompiled =
+  let
+    mkUntypedMarloweValidator :: ValidatorHash -> PlutusTx.BuiltinData -> PlutusTx.BuiltinData -> PlutusTx.BuiltinData -> ()
+    mkUntypedMarloweValidator rp = mkUntypedValidator (mkMarloweValidator rp)
+  in
+    $$(PlutusTx.compile [|| mkUntypedMarloweValidator ||])
+
 
 -- | The hash of the Marlowe semantics validator.
 marloweValidatorHash :: ValidatorHash

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cardano.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cardano.nix
@@ -48,6 +48,7 @@
           (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-script-utils" or (errorHandler.buildDepError "plutus-script-utils"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."sbv" or (errorHandler.buildDepError "sbv"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cli.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cli.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe-cli"; version = "0.0.10.0"; };
+      identifier = { name = "marlowe-cli"; version = "0.0.10.1"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "brian.bush@iohk.io";

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cardano.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cardano.nix
@@ -48,6 +48,7 @@
           (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-script-utils" or (errorHandler.buildDepError "plutus-script-utils"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."sbv" or (errorHandler.buildDepError "sbv"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cli.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cli.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe-cli"; version = "0.0.10.0"; };
+      identifier = { name = "marlowe-cli"; version = "0.0.10.1"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "brian.bush@iohk.io";


### PR DESCRIPTION
This adds two commands to `marlowe-cli`:
- `marlowe-cli contract pir` prints the Plutus Intermediate Representation (PIR) of the Marlowe validator.
- `marlowe-cli contract uplc` prints the Untyped Plutus Core (UPLC) of the Marlowe validator.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
