### PR TITLE
SCP-4864 Fixed collateral change output index, per Babbage spec.

### DIFF
--- a/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/Database/PostgreSQL.hs
+++ b/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/Database/PostgreSQL.hs
@@ -569,7 +569,7 @@ commitBlocks = CommitBlocks \blocks ->
       body@(TxBody TxBodyContent{..}) -> case txScriptValidity of
         TxScriptValidity _ ScriptInvalid -> case txReturnCollateral of
           TxReturnCollateralNone     -> []
-          TxReturnCollateral _ txOut -> [SomeTxOut (getTxId body) (TxIx 0) slotNo txOut True era]
+          TxReturnCollateral _ txOut -> [SomeTxOut (getTxId body) (TxIx 1) slotNo txOut True era]
         _ -> do
           (ix, txOut) <- [0..] `zip` txOuts
           pure $ SomeTxOut (getTxId body) (TxIx ix) slotNo txOut False era


### PR DESCRIPTION
We verified with Jared the interpretation of the Babbage spec that collateral change outputs have index 1.

Tested via comparing that the comparison of `marlowe-chain-indexer` vs `cardano-db-sync` no longer has discrepancies and collateral change output on `preview` and and `preprod`.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
