### PR TITLE
SCP-4863 Corrected datum and its hash in chain index

### DIFF
--- a/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/NodeClient.hs
+++ b/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/NodeClient.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE TupleSections #-}
 
 module Language.Marlowe.Runtime.ChainIndexer.NodeClient
   ( Changes(..)

--- a/marlowe-chain-sync/chainseekd/Logging.hs
+++ b/marlowe-chain-sync/chainseekd/Logging.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE Arrows #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}

--- a/marlowe-chain-sync/libchainseek/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
+++ b/marlowe-chain-sync/libchainseek/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StrictData #-}

--- a/marlowe-chain-sync/libchainseek/Language/Marlowe/Runtime/ChainSync/Server.hs
+++ b/marlowe-chain-sync/libchainseek/Language/Marlowe/Runtime/ChainSync/Server.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StrictData #-}
 

--- a/marlowe-chain-sync/marlowe-chain-indexer/Logging.hs
+++ b/marlowe-chain-sync/marlowe-chain-indexer/Logging.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE Arrows #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}

--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -131,6 +131,7 @@ library chain-indexer
     , base16
     , bytestring
     , cardano-api
+    , cardano-binary
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo
     , cardano-ledger-babbage

--- a/marlowe-test/chain/compare.sh
+++ b/marlowe-test/chain/compare.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TIMESTAMP="$(date -u +%Y%m%d)a"
+TIMESTAMP="$(date -u +%Y%m%d%H)"
 COMMIT=$(git rev-parse HEAD)
 
 echo "PGHOST=$PGHOST"

--- a/marlowe-test/chain/compare.sql
+++ b/marlowe-test/chain/compare.sql
@@ -216,7 +216,7 @@ create temporary table cmp_txout as
     , tx_out.address_raw
     , tx_out.value
     , tx_out.data_hash
-    , datum.bytes
+    , case when tx_out.inline_datum_id is not null then datum.bytes else null end
     , not tx.valid_contract
     from max_slotno
     inner join public.block
@@ -289,9 +289,8 @@ create temporary table x_datum as
 	  using (txid, txix)
 	where a.source = 'dbsync'
 	  and b.source = 'chainindex'
-	  and a.datumbytes <> b.datumbytes
 	  and a.datumbytes is not null
-	  and b.datumbytes is not null
+	  and coalesce(a.datumbytes <> b.datumbytes, true)
     ) as cm_datum
 ;
 select

--- a/marlowe-test/chain/compare.sql
+++ b/marlowe-test/chain/compare.sql
@@ -241,16 +241,16 @@ drop table if exists x_txout;
 create temporary table x_txout as
   select 'chainindex-dbsync' :: varchar as "comparison", *
     from (
-      select txid, txix, slotno, address, lovelace, datumhash, datumbytes, iscollateral from cmp_txout where source = 'chainindex'
+      select txid, txix, slotno, address, lovelace, datumhash, iscollateral from cmp_txout where source = 'chainindex'
       except
-      select txid, txix, slotno, address, lovelace, datumhash, datumbytes, iscollateral from cmp_txout where source = 'dbsync'
+      select txid, txix, slotno, address, lovelace, datumhash, iscollateral from cmp_txout where source = 'dbsync'
     ) as mc_txout
   union all
   select 'dbsync-chainindex', *
     from (
-      select txid, txix, slotno, address, lovelace, datumhash, datumbytes, iscollateral from cmp_txout where source = 'dbsync'
+      select txid, txix, slotno, address, lovelace, datumhash, iscollateral from cmp_txout where source = 'dbsync'
       except
-      select txid, txix, slotno, address, lovelace, datumhash, datumbytes, iscollateral from cmp_txout where source = 'chainindex'
+      select txid, txix, slotno, address, lovelace, datumhash, iscollateral from cmp_txout where source = 'chainindex'
     ) as cm_txout
 ;
 select
@@ -259,8 +259,49 @@ select
   from x_txout
   group by comparison
 ;
-\copy (select * from x_txout order by 2, 3, 4, 5, 6, 7, 8, 9, 1) to 'out/txout-discrepancies.csv' CSV HEADER
+\copy (select * from x_txout order by 2, 3, 4, 5, 6, 7, 8, 1) to 'out/txout-discrepancies.csv' CSV HEADER
 
+
+\qecho
+\qecho Datum comparison.
+\qecho
+
+drop table if exists x_datum;
+create temporary table x_datum as
+  select 'chainindex-dbsync' :: varchar as "comparison", *
+    from (
+      select txid, txix, a.datumbytes
+        from cmp_txout as a
+	inner join cmp_txout as b
+	  using (txid, txix)
+	where a.source = 'chainindex'
+	  and b.source = 'dbsync'
+	  and a.datumbytes <> b.datumbytes
+	  and a.datumbytes is not null
+	  and b.datumbytes is not null
+    ) as mc_datum
+  union all
+  select 'dbsync-chainindex', *
+    from (
+      select txid, txix, a.datumbytes
+        from cmp_txout a
+	inner join cmp_txout b
+	  using (txid, txix)
+	where a.source = 'dbsync'
+	  and b.source = 'chainindex'
+	  and a.datumbytes <> b.datumbytes
+	  and a.datumbytes is not null
+	  and b.datumbytes is not null
+    ) as cm_datum
+;
+select
+    comparison as "Discrepancy"
+  , count(*) as "Count of Datum Records"
+  from x_datum
+  group by comparison
+;
+\copy (select * from x_datum order by 2, 3, 4, 1) to 'out/datum-discrepancies.csv' CSV HEADER
+  
 
 \qecho
 \qecho TxIn comparison.
@@ -576,6 +617,12 @@ create table x_summary as
     , (select count(*) from x_txout where comparison = 'chainindex-dbsync')
     , (select count(*) from x_txout where comparison = 'dbsync-chainindex')
     , (select count(*) from x_txout) > 0
+  union all
+  select
+      'datum'
+    , (select count(*) from x_datum where comparison = 'chainindex-dbsync')
+    , (select count(*) from x_datum where comparison = 'dbsync-chainindex')
+    , (select count(*) from x_datum) > 0
   union all
   select
       'txin'

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-chain-sync.nix
@@ -102,6 +102,7 @@
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
             (hsPkgs."cardano-crypto-wrapper" or (errorHandler.buildDepError "cardano-crypto-wrapper"))
             (hsPkgs."cardano-ledger-alonzo" or (errorHandler.buildDepError "cardano-ledger-alonzo"))
             (hsPkgs."cardano-ledger-babbage" or (errorHandler.buildDepError "cardano-ledger-babbage"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-chain-sync.nix
@@ -102,6 +102,7 @@
             (hsPkgs."base16" or (errorHandler.buildDepError "base16"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
+            (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
             (hsPkgs."cardano-crypto-wrapper" or (errorHandler.buildDepError "cardano-crypto-wrapper"))
             (hsPkgs."cardano-ledger-alonzo" or (errorHandler.buildDepError "cardano-ledger-alonzo"))
             (hsPkgs."cardano-ledger-babbage" or (errorHandler.buildDepError "cardano-ledger-babbage"))


### PR DESCRIPTION
Round-trip serialization of CBOR was corrupting some datums and their hashes. This fix retries the bytes directly from the ledger, instead of via `Cardano.Api`.

Tested by `marlowe-test/chain/comparison.sh` to compare `marlowe-chain-indexer` vs `cardano-db-sync` on both the `preview` and `preprod` networks. There was a 100% match.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
