### PR TITLE
Scp 4992 get contract headers

### DIFF
--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
@@ -96,7 +96,7 @@ commitBlocks blocks = H.statement (prepareParams blocks)
       ( SELECT * FROM UNNEST ($46 :: bytea[], $47 :: bigint[], $48 :: bytea[], $49 :: bigint[], $50 :: bytea[], $51 :: smallint[])
       )
     , insertWithdrawalTxIns AS
-      ( INSERT INTO marlowe.withdrawalTxIn (txId, blockId, payoutTxId, payoutTxIx)
+      ( INSERT INTO marlowe.withdrawalTxIn (txId, slotNo, blockId, blockNo, payoutTxId, payoutTxIx)
         SELECT * FROM withdrawalTxInInputs
       )
     , invalidApplyTxInputs (txId, inputTxId, inputTxIx, blockId, error) AS

--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
@@ -38,10 +38,6 @@ commitBlocks blocks = H.statement (prepareParams blocks)
     , insertBlocks AS
       ( INSERT INTO marlowe.block (id, slotNo, blockNo)
         SELECT * FROM blockInputs
-        ON CONFLICT (id) DO UPDATE
-        SET
-          rollbackToSlot = NULL,
-          rollbackToBlock = NULL
       )
 
     , txOutInputs (txId, txIx, blockId, address, lovelace) AS

--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
@@ -68,39 +68,39 @@ commitBlocks blocks = H.statement (prepareParams blocks)
         SELECT * FROM contractTxOutInputs
       )
 
-    , createTxOutInputs (txId, txIx, blockId, metadata) AS
-      ( SELECT * FROM UNNEST ($22 :: bytea[], $23 :: smallint[], $24 :: bytea[], $25 :: bytea?[])
+    , createTxOutInputs (txId, txIx, slotNo, blockId, blockNo, metadata) AS
+      ( SELECT * FROM UNNEST ($22 :: bytea[], $23 :: smallint[], $24 :: bigint[], $25 :: bytea[], $26 :: bigint[], $27 :: bytea?[])
       )
     , insertCreateTxOuts AS
-      ( INSERT INTO marlowe.createTxOut (txId, txIx, blockId, metadata)
+      ( INSERT INTO marlowe.createTxOut (txId, txIx, slotNo, blockId, blockNo, metadata)
         SELECT * FROM createTxOutInputs
       )
 
-    , applyTxInputs (txId, createTxId, createTxIx, blockId, invalidBefore, invalidHereafter, metadata, inputTxId, inputTxIx, inputs, outputTxIx) AS
-      ( SELECT * FROM UNNEST ($26 :: bytea[], $27 :: bytea[], $28 :: smallint[], $29 :: bytea[], $30 :: timestamp[], $31 :: timestamp[], $32 :: bytea?[], $33 :: bytea[], $34 :: smallint[], $35 :: bytea[], $36 :: smallint?[])
+    , applyTxInputs (txId, createTxId, createTxIx, slotNo, blockId, blockNo, invalidBefore, invalidHereafter, metadata, inputTxId, inputTxIx, inputs, outputTxIx) AS
+      ( SELECT * FROM UNNEST ($28 :: bytea[], $29 :: bytea[], $30 :: smallint[], $31 :: bigint[], $32 :: bytea[], $33 :: bigint[], $34 :: timestamp[], $35 :: timestamp[], $36 :: bytea?[], $37 :: bytea[], $38 :: smallint[], $39 :: bytea[], $40 :: smallint?[])
       )
     , insertApplyTxs AS
-      ( INSERT INTO marlowe.applyTx (txId, createTxId, createTxIx, blockId, invalidBefore, invalidHereafter, metadata, inputTxId, inputTxIx, inputs, outputTxIx)
+      ( INSERT INTO marlowe.applyTx (txId, createTxId, createTxIx, slotNo, blockId, blockNo, invalidBefore, invalidHereafter, metadata, inputTxId, inputTxIx, inputs, outputTxIx)
         SELECT * FROM applyTxInputs
       )
 
     , payoutTxOutInputs (txId, txIx, blockId, rolesCurrency, role) AS
-      ( SELECT * FROM UNNEST ($37 :: bytea[], $38 :: smallint[], $39 :: bytea[], $40 :: bytea[], $41 :: bytea[])
+      ( SELECT * FROM UNNEST ($41 :: bytea[], $42 :: smallint[], $43 :: bytea[], $44 :: bytea[], $45 :: bytea[])
       )
     , insertPayoutTxOuts AS
       ( INSERT INTO marlowe.payoutTxOut (txId, txIx, blockId, rolesCurrency, role)
         SELECT * FROM payoutTxOutInputs
       )
 
-    , withdrawalTxInInputs (txId, blockId, payoutTxId, payoutTxIx) AS
-      ( SELECT * FROM UNNEST ($42 :: bytea[], $43 :: bytea[], $44 :: bytea[], $45 :: smallint[])
+    , withdrawalTxInInputs (txId, slotNo, blockId, blockNo, payoutTxId, payoutTxIx) AS
+      ( SELECT * FROM UNNEST ($46 :: bytea[], $47 :: bigint[], $48 :: bytea[], $49 :: bigint[], $50 :: bytea[], $51 :: smallint[])
       )
     , insertWithdrawalTxIns AS
       ( INSERT INTO marlowe.withdrawalTxIn (txId, blockId, payoutTxId, payoutTxIx)
         SELECT * FROM withdrawalTxInInputs
       )
     , invalidApplyTxInputs (txId, inputTxId, inputTxIx, blockId, error) AS
-      ( SELECT * FROM UNNEST ($46 :: bytea[], $47 :: bytea[], $48 :: smallint[], $49 :: bytea[], $50 :: text[])
+      ( SELECT * FROM UNNEST ($52 :: bytea[], $53 :: bytea[], $54 :: smallint[], $55 :: bytea[], $56 :: text[])
       )
     INSERT INTO marlowe.invalidApplyTx (txId, inputTxId, inputTxIx, blockId, error)
     SELECT * FROM invalidApplyTxInputs
@@ -134,13 +134,17 @@ type QueryParams =
 
   , Vector ByteString -- createTxOut txId rows
   , Vector Int16 -- createTxOut txIx rows
+  , Vector Int64 -- createTxOut slotNo rows
   , Vector ByteString -- createTxOut blockId rows
+  , Vector Int64 -- createTxOut blockNo rows
   , Vector (Maybe ByteString) -- createTxOut metadata rows
 
   , Vector ByteString -- applyTx txId rows
   , Vector ByteString -- applyTx createTxId rows
   , Vector Int16 -- applyTx createTxIx rows
+  , Vector Int64 -- applyTx slotNo rows
   , Vector ByteString -- applyTx blockId rows
+  , Vector Int64 -- applyTx blockNo rows
   , Vector LocalTime -- applyTx invalidBefore rows
   , Vector LocalTime -- applyTx invalidHereafter rows
   , Vector (Maybe ByteString) -- applyTx metadata rows
@@ -156,7 +160,9 @@ type QueryParams =
   , Vector ByteString -- payoutTxOut role rows
 
   , Vector ByteString -- withdrawalTxIn txId rows
+  , Vector Int64 -- withdrawalTxIn slotNo rows
   , Vector ByteString -- withdrawalTxIn blockId rows
+  , Vector Int64 -- withdrawalTxIn blockNo rows
   , Vector ByteString -- withdrawalTxIn payoutTxId rows
   , Vector Int16 -- withdrawalTxIn payoutTxIx rows
 
@@ -257,7 +263,9 @@ transactionScriptOutputToRows blockHeader@BlockHeader{..} payoutValidatorHash Tx
 type CreateTxOutRow =
   ( ByteString -- txId
   , Int16 -- txIx
+  , Int64 -- slotNo
   , ByteString -- blockId
+  , Int64 -- blockNo
   , Maybe ByteString -- metadata
   )
 
@@ -272,7 +280,9 @@ createTxToTxOutRows blockHeader@BlockHeader{..} MarloweCreateTransaction{..} =
       , contractTxOutRow
       , ( txId'
         , txIx'
+        , fromIntegral slotNo
         , unBlockHeaderHash headerHash
+        , fromIntegral blockNo
         , if Map.null (unTransactionMetadata metadata)
             then Nothing
             else Just $ toStrict $ runPut $ put metadata
@@ -284,7 +294,9 @@ type ApplyTxRow =
   ( ByteString -- txId
   , ByteString -- createTxId
   , Int16 -- createTxIx
+  , Int64 -- slotNo
   , ByteString -- blockId
+  , Int64 -- blockNo
   , LocalTime -- invalidBefore
   , LocalTime -- invalidHereafter
   , Maybe ByteString -- metadata
@@ -322,7 +334,9 @@ applyTxToRows (MarloweApplyInputsTransaction MarloweV1 UnspentContractOutput{..}
     ( ( txId'
       , createTxId'
       , createTxIx'
+      , fromIntegral slotNo
       , unBlockHeaderHash headerHash
+      , fromIntegral blockNo
       , utcToLocalTime utc validityLowerBound
       , utcToLocalTime utc validityUpperBound
       , if Map.null (unTransactionMetadata metadata)
@@ -357,7 +371,9 @@ applyTxToRows (MarloweApplyInputsTransaction MarloweV1 UnspentContractOutput{..}
 
 type WithdrawalTxInRow =
   ( ByteString -- txId
+  , Int64 -- slotNo
   , ByteString -- blockId
+  , Int64 -- blockNo
   , ByteString -- payoutTxId
   , Int16 -- payoutTxIx
   )
@@ -377,7 +393,9 @@ withdrawTxToWithdrawalTxInRows
 withdrawTxToWithdrawalTxInRows BlockHeader{..} MarloweWithdrawTransaction{..} =
   (Map.elems consumedPayouts >>= Set.toList) <&> \TxOutRef{..} ->
     ( unTxId consumingTx
+    , fromIntegral slotNo
     , unBlockHeaderHash headerHash
+    , fromIntegral blockNo
     , unTxId txId
     , fromIntegral txIx
     )
@@ -411,13 +429,17 @@ prepareParams blocks =
 
   , V.fromList createTxOutTxIdRows
   , V.fromList createTxOutTxIxRows
+  , V.fromList createTxOutSlotNoRows
   , V.fromList createTxOutBlockIdRows
+  , V.fromList createTxOutBlockNoRows
   , V.fromList createTxOutMetadataRows
 
   , V.fromList applyTxTxIdRows
   , V.fromList applyTxCreateTxIdRows
   , V.fromList applyTxCreateTxIxRows
+  , V.fromList applyTxSlotNoRows
   , V.fromList applyTxBlockIdRows
+  , V.fromList applyTxBlockNoRows
   , V.fromList applyTxInvalidBeforeRows
   , V.fromList applyTxInvalidHereafterRows
   , V.fromList applyTxMetadataRows
@@ -433,7 +455,9 @@ prepareParams blocks =
   , V.fromList payoutTxOutRoleRows
 
   , V.fromList withdrawalTxInTxIdRows
+  , V.fromList withdrawalTxInSlotNoRows
   , V.fromList withdrawalTxInBlockIdRows
+  , V.fromList withdrawalTxInBlockNoRows
   , V.fromList withdrawalTxInPayoutTxIdRows
   , V.fromList withdrawalTxInPayoutTxIxRows
 
@@ -482,14 +506,18 @@ prepareParams blocks =
 
     ( createTxOutTxIdRows
       , createTxOutTxIxRows
+      , createTxOutSlotNoRows
       , createTxOutBlockIdRows
+      , createTxOutBlockNoRows
       , createTxOutMetadataRows
-      ) = unzip4 createTxOutRows
+      ) = unzip6 createTxOutRows
 
     ( applyTxTxIdRows
       , applyTxCreateTxIdRows
       , applyTxCreateTxIxRows
+      , applyTxSlotNoRows
       , applyTxBlockIdRows
+      , applyTxBlockNoRows
       , applyTxInvalidBeforeRows
       , applyTxInvalidHereafterRows
       , applyTxMetadataRows
@@ -497,7 +525,7 @@ prepareParams blocks =
       , applyTxInputTxIxRows
       , applyTxInputsRows
       , applyTxOutputTxIxRows
-      ) = unzip11 applyTxRows
+      ) = unzip13 applyTxRows
 
     ( payoutTxOutTxIdRows
       , payoutTxOutTxIxRows
@@ -507,10 +535,12 @@ prepareParams blocks =
       ) = unzip5 payoutTxOutRows
 
     ( withdrawalTxInTxIdRows
+      , withdrawalTxInSlotNoRows
       , withdrawalTxInBlockIdRows
+      , withdrawalTxInBlockNoRows
       , withdrawalTxInPayoutTxIdRows
       , withdrawalTxInPayoutTxIxRows
-      ) = unzip4 withdrawalTxInRows
+      ) = unzip6 withdrawalTxInRows
 
     ( invalidApplyTxTxIdRows
       , invalidApplyTxInputTxIdRows
@@ -580,9 +610,9 @@ foldMap8 k = foldr
   )
   (mempty, mempty, mempty, mempty, mempty, mempty, mempty, mempty)
 
-unzip11 :: [(a, b, c, d, e, f, g, h, i, j, k)] -> ([a], [b], [c], [d], [e], [f], [g], [h], [i], [j], [k])
-unzip11 = foldr
-  (\(a, b, c, d, e, f, g, h, i, j, k) (as, bs, cs, ds, es, fs, gs, hs, is, js, ks) ->
+unzip13 :: [(a, b, c, d, e, f, g, h, i, j, k, l, m)] -> ([a], [b], [c], [d], [e], [f], [g], [h], [i], [j], [k], [l], [m])
+unzip13 = foldr
+  (\(a, b, c, d, e, f, g, h, i, j, k, l, m) (as, bs, cs, ds, es, fs, gs, hs, is, js, ks, ls, ms) ->
     ( a : as
     , b : bs
     , c : cs
@@ -594,6 +624,8 @@ unzip11 = foldr
     , i : is
     , j : js
     , k : ks
+    , l : ls
+    , m : ms
     )
   )
-  ([], [], [], [], [], [], [], [], [], [], [])
+  ([], [], [], [], [], [], [], [], [], [], [], [], [])

--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/GetIntersectionPoints.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/GetIntersectionPoints.hs
@@ -21,8 +21,6 @@ getIntersectionPoints securityParameter = do
       SELECT id :: bytea, slotNo :: bigint, blockNo :: bigint
         FROM marlowe.block
        WHERE blockNo >= $1 :: bigint
-         AND rollbackToSlot IS NULL
-         AND rollbackToBlock IS NULL
        ORDER BY slotNo DESC
     |]
 

--- a/marlowe-runtime/marlowe-indexer/deploy/block-cols.sql
+++ b/marlowe-runtime/marlowe-indexer/deploy/block-cols.sql
@@ -1,0 +1,73 @@
+-- Deploy marlowe:block-cols to pg
+-- requires: schema
+
+BEGIN;
+
+ALTER TABLE marlowe.createTxOut
+  ADD COLUMN slotNo BIGINT,
+  ADD COLUMN blockNo BIGINT;
+
+ALTER TABLE marlowe.applyTx
+  ADD COLUMN slotNo BIGINT,
+  ADD COLUMN blockNo BIGINT;
+
+ALTER TABLE marlowe.withdrawalTxIn
+  ADD COLUMN createTxId BYTEA,
+  ADD COLUMN createTxIx SMALLINT,
+  ADD COLUMN slotNo BIGINT,
+  ADD COLUMN blockNo BIGINT;
+
+UPDATE marlowe.createTxOut
+  SET
+    slotNo = block.slotNo,
+    blockNo = block.blockNo
+  FROM marlowe.block
+  WHERE block.id = createTxOut.blockId;
+
+UPDATE marlowe.applyTx
+  SET
+    slotNo = block.slotNo,
+    blockNo = block.blockNo
+  FROM marlowe.block
+  WHERE block.id = applyTx.blockId;
+
+UPDATE marlowe.withdrawalTxIn
+  SET
+    slotNo = block.slotNo,
+    blockNo = block.blockNo
+  FROM marlowe.block
+  WHERE block.id = withdrawalTxIn.blockId;
+
+UPDATE marlowe.withdrawalTxIn
+  SET
+    createTxId = applyTx.createTxId,
+    createTxIx = applyTx.createTxIx
+  FROM marlowe.payoutTxOut
+  JOIN marlowe.applyTx ON payoutTxOut.txId = applyTx.txId
+  WHERE payoutTxOut.txId = withdrawalTxIn.payoutTxId
+    AND payoutTxOut.txIx = withdrawalTxIn.payoutTxIx;
+
+ALTER TABLE marlowe.createTxOut
+  ALTER COLUMN slotNo SET NOT NULL,
+  ALTER COLUMN blockNo SET NOT NULL;
+
+ALTER TABLE marlowe.applyTx
+  ALTER COLUMN slotNo SET NOT NULL,
+  ALTER COLUMN blockNo SET NOT NULL;
+
+ALTER TABLE marlowe.withdrawalTxIn
+  ALTER COLUMN slotNo SET NOT NULL,
+  ALTER COLUMN blockNo SET NOT NULL,
+  ADD FOREIGN KEY (createTxId, createTxIx) REFERENCES marlowe.createTxOut (txId, txIx);
+
+CREATE INDEX createTxOut_slotNo ON marlowe.createTxOut (slotNo);
+CREATE INDEX createTxOut_slotNo_txId_txIx ON marlowe.createTxOut (slotNo, txId, txIx);
+
+CREATE INDEX applyTx_slotNo ON marlowe.applyTx (slotNo);
+CREATE INDEX applyTx_slotNo_txId_txIx ON marlowe.applyTx (slotNo, txId);
+
+CREATE INDEX withdrawalTxIn_slotNo ON marlowe.withdrawalTxIn (slotNo);
+CREATE INDEX withdrawalTxIn_slotNo_txId_txIx ON marlowe.withdrawalTxIn (slotNo, txId);
+CREATE INDEX withdrawalTxIn_createTxId_createTxIx ON marlowe.withdrawalTxIn (createTxId, createTxIx);
+
+COMMIT;

--- a/marlowe-runtime/marlowe-indexer/deploy/rollback.sql
+++ b/marlowe-runtime/marlowe-indexer/deploy/rollback.sql
@@ -1,0 +1,55 @@
+-- Deploy marlowe:rollback to pg
+-- requires: schema
+
+BEGIN;
+
+CREATE TABLE marlowe.rollbackBlock
+  ( fromBlock BYTEA PRIMARY KEY
+  , toBlock BYTEA NOT NULL REFERENCES marlowe.block (id)
+  , toSlotNo BIGINT NOT NULL
+  );
+
+CREATE INDEX rollbackBlock_toSlotNo ON marlowe.rollbackBlock USING BTREE (toSlotNo);
+CREATE INDEX rollbackBlock_toBlock ON marlowe.rollbackBlock USING BTREE (toBlock);
+
+DELETE FROM marlowe.block
+WHERE rollbackToBlock IS NOT NULL
+  AND rollbackToSlot IS NOT NULL;
+
+ALTER TABLE marlowe.block
+  DROP COLUMN rollbackToBlock,
+  DROP COLUMN rollbackToSlot;
+
+ALTER TABLE marlowe.txOut
+  DROP CONSTRAINT txOut_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
+
+ALTER TABLE marlowe.txOutAsset
+  DROP CONSTRAINT txOutAsset_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
+
+ALTER TABLE marlowe.contractTxOut
+  DROP CONSTRAINT contractTxOut_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
+
+ALTER TABLE marlowe.createTxOut
+  DROP CONSTRAINT createTxOut_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
+
+ALTER TABLE marlowe.applyTx
+  DROP CONSTRAINT applyTx_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
+
+ALTER TABLE marlowe.payoutTxOut
+  DROP CONSTRAINT payoutTxOut_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
+
+ALTER TABLE marlowe.withdrawalTxIn
+  DROP CONSTRAINT withdrawalTxIn_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
+
+ALTER TABLE marlowe.invalidApplyTx
+  DROP CONSTRAINT invalidApplyIn_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
+
+COMMIT;

--- a/marlowe-runtime/marlowe-indexer/revert/block-cols.sql
+++ b/marlowe-runtime/marlowe-indexer/revert/block-cols.sql
@@ -1,0 +1,29 @@
+-- Revert marlowe:block-cols from pg
+
+BEGIN;
+
+DROP INDEX createTxOut_slotNo;
+DROP INDEX createTxOut_slotNo_txId_txIx;
+
+DROP INDEX applyTx_slotNo ON marlowe.applyTx;
+DROP INDEX applyTx_slotNo_txId_txIx ON marlowe.applyTx;
+
+DROP INDEX withdrawalTxIn_slotNo ON marlowe.withdrawalTxIn;
+DROP INDEX withdrawalTxIn_slotNo_txId_txIx ON marlowe.withdrawalTxIn;
+DROP INDEX withdrawalTxIn_createTxId_createTxIx ON marlowe.withdrawalTxIn;
+
+ALTER TABLE marlowe.createTxOut
+  DROP COLUMN slotNo,
+  DROP COLUMN blockNo;
+
+ALTER TABLE marlowe.applyTx
+  DROP COLUMN slotNo,
+  DROP COLUMN blockNo;
+
+ALTER TABLE marlowe.withdrawalTxIn
+  DROP COLUMN createTxId,
+  DROP COLUMN createTxIx,
+  DROP COLUMN slotNo,
+  DROP COLUMN blockNo;
+
+COMMIT;

--- a/marlowe-runtime/marlowe-indexer/revert/block-cols.sql
+++ b/marlowe-runtime/marlowe-indexer/revert/block-cols.sql
@@ -2,15 +2,15 @@
 
 BEGIN;
 
-DROP INDEX createTxOut_slotNo;
-DROP INDEX createTxOut_slotNo_txId_txIx;
+DROP INDEX marlowe.createTxOut_slotNo;
+DROP INDEX marlowe.createTxOut_slotNo_txId_txIx;
 
-DROP INDEX applyTx_slotNo ON marlowe.applyTx;
-DROP INDEX applyTx_slotNo_txId_txIx ON marlowe.applyTx;
+DROP INDEX marlowe.applyTx_slotNo;
+DROP INDEX marlowe.applyTx_slotNo_txId_txIx;
 
-DROP INDEX withdrawalTxIn_slotNo ON marlowe.withdrawalTxIn;
-DROP INDEX withdrawalTxIn_slotNo_txId_txIx ON marlowe.withdrawalTxIn;
-DROP INDEX withdrawalTxIn_createTxId_createTxIx ON marlowe.withdrawalTxIn;
+DROP INDEX marlowe.withdrawalTxIn_slotNo;
+DROP INDEX marlowe.withdrawalTxIn_slotNo_txId_txIx;
+DROP INDEX marlowe.withdrawalTxIn_createTxId_createTxIx;
 
 ALTER TABLE marlowe.createTxOut
   DROP COLUMN slotNo,

--- a/marlowe-runtime/marlowe-indexer/revert/rollback.sql
+++ b/marlowe-runtime/marlowe-indexer/revert/rollback.sql
@@ -1,0 +1,46 @@
+-- Revert marlowe:rollback from pg
+
+BEGIN;
+
+ALTER TABLE marlowe.txOut
+  DROP CONSTRAINT txOut_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id);
+
+ALTER TABLE marlowe.txOutAsset
+  DROP CONSTRAINT txOutAsset_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id);
+
+ALTER TABLE marlowe.contractTxOut
+  DROP CONSTRAINT contractTxOut_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id);
+
+ALTER TABLE marlowe.createTxOut
+  DROP CONSTRAINT createTxOut_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id);
+
+ALTER TABLE marlowe.applyTx
+  DROP CONSTRAINT applyTx_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id);
+
+ALTER TABLE marlowe.payoutTxOut
+  DROP CONSTRAINT payoutTxOut_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id);
+
+ALTER TABLE marlowe.withdrawalTxIn
+  DROP CONSTRAINT withdrawalTxIn_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id);
+
+ALTER TABLE marlowe.invalidApplyTx
+  DROP CONSTRAINT invalidApplyTx_blockId_fkey,
+  ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id);
+
+ALTER TABLE marlowe.block
+  ADD COLUMN rollbackToBlock BYTEA,
+  ADD COLUMN rollbackToSlot BIGINT;
+
+DROP INDEX marlowe.rollbackBlock_toSlotNo;
+DROP INDEX marlowe.rollbackBlock_toBlock;
+
+DROP TABLE marlowe.rollbackBlock;
+
+COMMIT;

--- a/marlowe-runtime/marlowe-indexer/sqitch.plan
+++ b/marlowe-runtime/marlowe-indexer/sqitch.plan
@@ -3,3 +3,4 @@
 %uri=https://github.com/input-output-hk/marlowe-cardano/tree/main/marlowe-runtime/marlowe-indexer
 
 schema 2023-01-13T17:57:34Z Jamie Bertram <jamie.bertram@iohk.io> # Add schema for Marlowe Indexer
+block-cols [schema] 2023-01-30T21:31:32Z Jamie Bertram <jamie.bertram@iohk.io> # Adds all block columns to main aggregate root tables.

--- a/marlowe-runtime/marlowe-indexer/sqitch.plan
+++ b/marlowe-runtime/marlowe-indexer/sqitch.plan
@@ -4,3 +4,4 @@
 
 schema 2023-01-13T17:57:34Z Jamie Bertram <jamie.bertram@iohk.io> # Add schema for Marlowe Indexer
 block-cols [schema] 2023-01-30T21:31:32Z Jamie Bertram <jamie.bertram@iohk.io> # Adds all block columns to main aggregate root tables.
+rollback [schema] 2023-02-01T13:09:33Z Jamie Bertram <jamie.bertram@iohk.io> # Moves rollback info to a separate table for safety.

--- a/marlowe-runtime/marlowe-indexer/verify/block-cols.sql
+++ b/marlowe-runtime/marlowe-indexer/verify/block-cols.sql
@@ -1,0 +1,9 @@
+-- Verify marlowe:block-cols on pg
+
+BEGIN;
+
+SELECT slotNo, blockNo FROM marlowe.createTxOut;
+SELECT slotNo, blockNo FROM marlowe.applyTx;
+SELECT slotNo, blockNo, createTxId, createTxIx FROM marlowe.withdrawalTxIn;
+
+ROLLBACK;

--- a/marlowe-runtime/marlowe-indexer/verify/rollback.sql
+++ b/marlowe-runtime/marlowe-indexer/verify/rollback.sql
@@ -1,0 +1,7 @@
+-- Verify marlowe:rollback on pg
+
+BEGIN;
+
+SELECT fromBlock, toBlock, toSlotNo FROM marlowe.rollbackBlock;
+
+ROLLBACK;

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -193,6 +193,7 @@ library sync
     Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetTip
     Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetTipForContract
     Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetCreateStep
+    Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetHeaders
     Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetIntersectionForContract
     Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetIntersection
     Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetNextHeaders

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -194,9 +194,11 @@ library sync-api
     , aeson
     , binary
     , bytestring
+    , lifted-async
     , marlowe-protocols
     , marlowe-runtime
     , marlowe-runtime:discovery-api
+    , monad-control
     , typed-protocols
   visibility: public
 
@@ -208,6 +210,7 @@ library sync
     Language.Marlowe.Runtime.Sync
     Language.Marlowe.Runtime.Sync.MarloweHeaderSyncServer
     Language.Marlowe.Runtime.Sync.MarloweSyncServer
+    Language.Marlowe.Runtime.Sync.QueryServer
     Language.Marlowe.Runtime.Sync.Database
     Language.Marlowe.Runtime.Sync.Database.PostgreSQL
     Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetTip
@@ -598,6 +601,7 @@ executable marlowe-sync
     , marlowe-runtime:discovery-api
     , marlowe-runtime:history-api
     , marlowe-runtime:sync
+    , marlowe-runtime:sync-api
     , network
     , optparse-applicative
     , text
@@ -724,6 +728,7 @@ test-suite marlowe-runtime-test
     Language.Marlowe.Runtime.Transaction.CommandSpec
     Language.Marlowe.Protocol.HeaderSyncSpec
     Language.Marlowe.Protocol.SyncSpec
+    Language.Marlowe.Protocol.QuerySpec
     Paths_marlowe_runtime
   build-depends:
       base >= 4.9 && < 5
@@ -748,6 +753,7 @@ test-suite marlowe-runtime-test
     , marlowe-runtime:discovery-api
     , marlowe-runtime:history
     , marlowe-runtime:history-api
+    , marlowe-runtime:sync-api
     , marlowe-runtime:tx
     , marlowe-runtime:tx-api
     , marlowe-test

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -180,6 +180,26 @@ library indexer
     , vector
   visibility: public
 
+library sync-api
+  import: lang
+  hs-source-dirs:   sync-api
+  visibility: public
+  exposed-modules:
+    Language.Marlowe.Protocol.Query.Client
+    Language.Marlowe.Protocol.Query.Codec
+    Language.Marlowe.Protocol.Query.Server
+    Language.Marlowe.Protocol.Query.Types
+  build-depends:
+      base >= 4.9 && < 5
+    , aeson
+    , binary
+    , bytestring
+    , marlowe-protocols
+    , marlowe-runtime
+    , marlowe-runtime:discovery-api
+    , typed-protocols
+  visibility: public
+
 library sync
   import: lang
   hs-source-dirs:   sync
@@ -217,6 +237,7 @@ library sync
     , marlowe-runtime
     , marlowe-runtime:discovery-api
     , marlowe-runtime:history-api
+    , marlowe-runtime:sync-api
     , plutus-ledger-api
     , text
     , time

--- a/marlowe-runtime/marlowe-sync/Logging.hs
+++ b/marlowe-runtime/marlowe-sync/Logging.hs
@@ -6,6 +6,7 @@ module Logging
   ) where
 
 import Language.Marlowe.Protocol.HeaderSync.Types (MarloweHeaderSync)
+import Language.Marlowe.Protocol.Query.Types (MarloweQuery)
 import Language.Marlowe.Protocol.Sync.Types (MarloweSync)
 import Language.Marlowe.Runtime.Sync.Database (DatabaseSelector, getDatabaseSelectorConfig)
 import Network.Protocol.Driver
@@ -16,6 +17,7 @@ import Observe.Event.Component
 data RootSelector f where
   MarloweSyncServer :: AcceptSocketDriverSelector MarloweSync f -> RootSelector f
   MarloweHeaderSyncServer :: AcceptSocketDriverSelector MarloweHeaderSync f -> RootSelector f
+  MarloweQueryServer :: AcceptSocketDriverSelector MarloweQuery f -> RootSelector f
   Database :: DatabaseSelector f -> RootSelector f
   ConfigWatcher :: ConfigWatcherSelector f -> RootSelector f
 
@@ -23,6 +25,7 @@ getRootSelectorConfig :: GetSelectorConfig RootSelector
 getRootSelectorConfig = \case
   MarloweSyncServer sel -> prependKey "marlowe-sync-server" $ getAcceptSocketDriverSelectorConfig marloweSyncServerConfig sel
   MarloweHeaderSyncServer sel -> prependKey "marlowe-header-sync-server" $ getAcceptSocketDriverSelectorConfig marloweHeaderSyncServerConfig sel
+  MarloweQueryServer sel -> prependKey "marlowe-query-server" $ getAcceptSocketDriverSelectorConfig marloweHeaderSyncServerConfig sel
   Database sel -> prependKey "database" $ getDatabaseSelectorConfig sel
   ConfigWatcher ReloadConfig -> SelectorConfig "reload-log-config" True
     $ singletonFieldConfig "config" True

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Client.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Client.hs
@@ -4,17 +4,58 @@
 module Language.Marlowe.Protocol.Query.Client
   where
 
-import Data.Void (absurd)
+import Control.Applicative (liftA2)
 import Language.Marlowe.Protocol.Query.Types
 import Language.Marlowe.Runtime.Core.Api (ContractId)
 import Language.Marlowe.Runtime.Discovery.Api (ContractHeader)
 import Network.TypedProtocol
 
-type MarloweQueryClient = Peer MarloweQuery 'AsClient 'StInit
+data MarloweQueryClient m a
+  = MarloweQueryClientPure a
+  | MarloweQueryClientPeer (Peer MarloweQuery 'AsClient 'StInit m a)
+  deriving (Functor)
+
+instance Applicative m => Applicative (MarloweQueryClient m) where
+  pure = MarloweQueryClientPure
+  MarloweQueryClientPure f <*> a = f <$> a
+  f <*> MarloweQueryClientPure a = ($ a) <$> f
+  MarloweQueryClientPeer peerF <*> MarloweQueryClientPeer peerA = MarloweQueryClientPeer $ apPeerInit peerF peerA
+    where
+    apPeerInit
+      :: Peer MarloweQuery 'AsClient 'StInit m (a -> b)
+      -> Peer MarloweQuery 'AsClient 'StInit m a
+      -> Peer MarloweQuery 'AsClient 'StInit m b
+    apPeerInit pf pa = case (pf, pa) of
+      (Effect m1, Effect m2) -> Effect $ liftA2 apPeerInit m1 m2
+      (Effect m1, _) -> Effect $ flip apPeerInit pa <$> m1
+      (_, Effect m2) -> Effect $ apPeerInit pf <$> m2
+      (Yield (ClientAgency TokInit) (MsgRequest req1) pf', Yield (ClientAgency TokInit) (MsgRequest req2) pa') ->
+        Yield (ClientAgency TokInit) (MsgRequest (ReqBoth req1 req2)) $ apPeerRequest pf' pa'
+
+    apPeerRequest
+      :: Peer MarloweQuery 'AsClient ('StRequest r1) m (a -> b)
+      -> Peer MarloweQuery 'AsClient ('StRequest r2) m a
+      -> Peer MarloweQuery 'AsClient ('StRequest (r1, r2)) m b
+    apPeerRequest pf pa = case (pf, pa) of
+      (Effect m1, Effect m2) -> Effect $ liftA2 apPeerRequest m1 m2
+      (Effect m1, _) -> Effect $ flip apPeerRequest pa <$> m1
+      (_, Effect m2) -> Effect $ apPeerRequest pf <$> m2
+      (Await (ServerAgency (TokRequest req1)) handleF, Await (ServerAgency (TokRequest req2)) handleA) ->
+        Await (ServerAgency $ TokRequest $ TokBoth req1 req2) \case
+          MsgRespond (r1, r2) -> appPeerDone (handleF $ MsgRespond r1) (handleA $ MsgRespond r2)
+
+    appPeerDone
+      :: Peer MarloweQuery 'AsClient 'StDone m (a -> b)
+      -> Peer MarloweQuery 'AsClient 'StDone m a
+      -> Peer MarloweQuery 'AsClient 'StDone m b
+    appPeerDone pf pa = case (pf, pa) of
+      (Effect m1, Effect m2) -> Effect $ liftA2 appPeerDone m1 m2
+      (Effect m1, _) -> Effect $ flip appPeerDone pa <$> m1
+      (_, Effect m2) -> Effect $ appPeerDone pf <$> m2
+      (Done TokDone f, Done TokDone a) -> Done TokDone $ f a
 
 getContractHeaders :: Range ContractId -> MarloweQueryClient m (Page ContractId ContractHeader)
-getContractHeaders range =
-  Yield (ClientAgency TokInit) (MsgGetContractHeaders range) $
-  Await (ServerAgency TokGetContractHeaders) \case
-    MsgResolve page -> Done TokDone page
-    MsgReject err -> absurd err
+getContractHeaders range = MarloweQueryClientPeer $
+  Yield (ClientAgency TokInit) (MsgRequest $ ReqContractHeaders range) $
+  Await (ServerAgency $ TokRequest TokContractHeaders) \(MsgRespond page) ->
+    Done TokDone page

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Client.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Client.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module Language.Marlowe.Protocol.Query.Client
+  where
+
+import Data.Void (absurd)
+import Language.Marlowe.Protocol.Query.Types
+import Language.Marlowe.Runtime.Core.Api (ContractId)
+import Language.Marlowe.Runtime.Discovery.Api (ContractHeader)
+import Network.TypedProtocol
+
+type MarloweQueryClient = Peer MarloweQuery 'AsClient 'StInit
+
+getContractHeaders :: Range ContractId -> MarloweQueryClient m (Page ContractId ContractHeader)
+getContractHeaders range =
+  Yield (ClientAgency TokInit) (MsgGetContractHeaders range) $
+  Await (ServerAgency TokGetContractHeaders) \case
+    MsgResolve page -> Done TokDone page
+    MsgReject err -> absurd err

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Codec.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Codec.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE GADTs #-}
+module Language.Marlowe.Protocol.Query.Codec
+  where
+
+import Data.Binary (get, getWord8, put, putWord8)
+import qualified Data.ByteString.Lazy as LBS
+import Language.Marlowe.Protocol.Query.Types
+import Network.Protocol.Codec (DeserializeError, GetMessage, PutMessage, binaryCodec)
+import Network.TypedProtocol.Codec (Codec, PeerHasAgency(..), SomeMessage(SomeMessage))
+
+codecMarloweHeaderSync :: Applicative m => Codec MarloweQuery DeserializeError m LBS.ByteString
+codecMarloweHeaderSync = binaryCodec putMessage getMessage
+  where
+  putMessage :: PutMessage MarloweQuery
+  putMessage = \case
+    ClientAgency TokInit -> \case
+      MsgGetContractHeaders range -> do
+        putWord8 0x01
+        put range
+
+    ServerAgency TokGetContractHeaders -> \case
+      MsgResolve result -> do
+        putWord8 0x02
+        put result
+
+      MsgReject err -> do
+        putWord8 0x03
+        put err
+
+  getMessage :: GetMessage MarloweQuery
+  getMessage tok = do
+    tag <- getWord8
+    case tag of
+      0x01 -> case tok of
+        ClientAgency TokInit -> SomeMessage . MsgGetContractHeaders <$> get
+        _ -> fail "Invalid protocol state for MsgGetContractHeaders"
+
+      0x02 -> case tok of
+        ServerAgency TokGetContractHeaders -> SomeMessage . MsgResolve <$> get
+        ClientAgency _  -> fail "Invalid protocol state for MsgResolve"
+
+      0x03 -> case tok of
+        ServerAgency TokGetContractHeaders -> SomeMessage . MsgReject <$> get
+        ClientAgency _ -> fail "Invalid protocol state for MsgReject"
+
+      _ -> fail $ "Invalid message tag " <> show tag

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Codec.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Codec.hs
@@ -2,45 +2,49 @@
 module Language.Marlowe.Protocol.Query.Codec
   where
 
-import Data.Binary (get, getWord8, put, putWord8)
+import Data.Binary (Get, Put, get, getWord8, put, putWord8)
 import qualified Data.ByteString.Lazy as LBS
 import Language.Marlowe.Protocol.Query.Types
 import Network.Protocol.Codec (DeserializeError, GetMessage, PutMessage, binaryCodec)
 import Network.TypedProtocol.Codec (Codec, PeerHasAgency(..), SomeMessage(SomeMessage))
 
-codecMarloweHeaderSync :: Applicative m => Codec MarloweQuery DeserializeError m LBS.ByteString
-codecMarloweHeaderSync = binaryCodec putMessage getMessage
+codecMarloweQuery :: Applicative m => Codec MarloweQuery DeserializeError m LBS.ByteString
+codecMarloweQuery = binaryCodec putMessage getMessage
   where
   putMessage :: PutMessage MarloweQuery
   putMessage = \case
     ClientAgency TokInit -> \case
-      MsgGetContractHeaders range -> do
+      MsgRequest req -> do
         putWord8 0x01
-        put range
+        put $ SomeRequest req
 
-    ServerAgency TokGetContractHeaders -> \case
-      MsgResolve result -> do
+    ServerAgency (TokRequest req) -> \case
+      MsgRespond a -> do
         putWord8 0x02
-        put result
-
-      MsgReject err -> do
-        putWord8 0x03
-        put err
+        putResult req a
 
   getMessage :: GetMessage MarloweQuery
   getMessage tok = do
     tag <- getWord8
     case tag of
       0x01 -> case tok of
-        ClientAgency TokInit -> SomeMessage . MsgGetContractHeaders <$> get
-        _ -> fail "Invalid protocol state for MsgGetContractHeaders"
+        ClientAgency TokInit -> do
+          SomeRequest req <- get
+          pure $ SomeMessage $ MsgRequest req
+        _ -> fail "Invalid protocol state for MsgRequest"
 
       0x02 -> case tok of
-        ServerAgency TokGetContractHeaders -> SomeMessage . MsgResolve <$> get
-        ClientAgency _  -> fail "Invalid protocol state for MsgResolve"
-
-      0x03 -> case tok of
-        ServerAgency TokGetContractHeaders -> SomeMessage . MsgReject <$> get
-        ClientAgency _ -> fail "Invalid protocol state for MsgReject"
+        ServerAgency (TokRequest req) -> SomeMessage . MsgRespond <$> getResult req
+        ClientAgency _  -> fail "Invalid protocol state for MsgRespond"
 
       _ -> fail $ "Invalid message tag " <> show tag
+
+  getResult :: StRequest a -> Get a
+  getResult = \case
+    TokBoth a b -> (,) <$> getResult a <*> getResult b
+    TokContractHeaders -> get
+
+  putResult :: StRequest a -> a -> Put
+  putResult = \case
+    TokBoth ta tb -> \(a, b) -> putResult ta a *> putResult tb b
+    TokContractHeaders -> put

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Server.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Server.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 
 module Language.Marlowe.Protocol.Query.Server
   where
 
+import Control.Concurrent.Async.Lifted (concurrently)
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Language.Marlowe.Protocol.Query.Types
 import Language.Marlowe.Runtime.Core.Api (ContractId)
 import Language.Marlowe.Runtime.Discovery.Api (ContractHeader)
@@ -12,12 +15,23 @@ import Network.TypedProtocol
 type MarloweQueryServer = Peer MarloweQuery 'AsServer 'StInit
 
 marloweQueryServer
-  :: Monad m
+  :: forall m
+   . MonadBaseControl IO m
   => (Range ContractId -> m (Page ContractId ContractHeader))
   -> MarloweQueryServer m ()
 marloweQueryServer getContractHeaders = Await (ClientAgency TokInit) \case
-  MsgGetContractHeaders range -> Effect do
-    page <- getContractHeaders range
+  MsgRequest req -> Effect do
+    result <- serviceRequest req
     pure $
-      Yield (ServerAgency TokGetContractHeaders) (MsgResolve page) $
+      Yield (ServerAgency $ TokRequest $ reqToSt req) (MsgRespond result) $
       Done TokDone ()
+  where
+    reqToSt :: Request a -> StRequest a
+    reqToSt = \case
+      ReqContractHeaders _ -> TokContractHeaders
+      ReqBoth a b -> TokBoth (reqToSt a) (reqToSt b)
+
+    serviceRequest :: Request a -> m a
+    serviceRequest = \case
+      ReqContractHeaders range -> getContractHeaders range
+      ReqBoth a b -> concurrently (serviceRequest a) (serviceRequest b)

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Server.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Server.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module Language.Marlowe.Protocol.Query.Server
+  where
+
+import Language.Marlowe.Protocol.Query.Types
+import Language.Marlowe.Runtime.Core.Api (ContractId)
+import Language.Marlowe.Runtime.Discovery.Api (ContractHeader)
+import Network.TypedProtocol
+
+type MarloweQueryServer = Peer MarloweQuery 'AsServer 'StInit
+
+marloweQueryServer
+  :: Monad m
+  => (Range ContractId -> m (Page ContractId ContractHeader))
+  -> MarloweQueryServer m ()
+marloweQueryServer getContractHeaders = Await (ClientAgency TokInit) \case
+  MsgGetContractHeaders range -> Effect do
+    page <- getContractHeaders range
+    pure $
+      Yield (ServerAgency TokGetContractHeaders) (MsgResolve page) $
+      Done TokDone ()

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Types.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Types.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Language.Marlowe.Protocol.Query.Types
+  where
+
+import Data.Aeson (ToJSON)
+import Data.Binary (Binary)
+import Data.Void (Void)
+import GHC.Generics (Generic)
+import Language.Marlowe.Runtime.Core.Api (ContractId)
+import Language.Marlowe.Runtime.Discovery.Api (ContractHeader)
+import Network.TypedProtocol
+
+data MarloweQuery where
+  StInit :: MarloweQuery
+  StRequest :: err -> result -> MarloweQuery
+  StDone :: MarloweQuery
+
+instance Protocol MarloweQuery where
+  data Message MarloweQuery st st' where
+    MsgGetContractHeaders :: Range ContractId -> Message MarloweQuery
+      'StInit
+      ('StRequest Void (Page ContractId ContractHeader))
+
+    MsgResolve :: result -> Message MarloweQuery
+      ('StRequest err result)
+      'StDone
+
+    MsgReject :: err -> Message MarloweQuery
+      ('StRequest err result)
+      'StDone
+
+  data ClientHasAgency ps where
+    TokInit :: ClientHasAgency 'StInit
+
+  data ServerHasAgency ps where
+    TokGetContractHeaders :: ServerHasAgency ('StRequest Void (Page ContractId ContractHeader))
+
+  data NobodyHasAgency ps where
+    TokDone :: NobodyHasAgency 'StDone
+
+  exclusionLemma_ClientAndServerHaveAgency TokInit = \case
+  exclusionLemma_NobodyAndClientHaveAgency TokDone = \case
+  exclusionLemma_NobodyAndServerHaveAgency TokDone = \case
+
+data Range a = Range
+  { rangeStart :: Maybe a
+  , rangeOffset :: Int
+  , rangeLimit :: Int
+  , rangeDirection :: Order
+  }
+  deriving stock (Eq, Show, Read, Ord, Functor, Generic, Foldable, Traversable)
+  deriving anyclass (ToJSON, Binary)
+
+data Page a b = Page
+  { items :: [b]
+  , nextRange :: Maybe (Range a)
+  , totalCount :: Int
+  }
+  deriving stock (Eq, Show, Read, Ord, Functor, Generic, Foldable, Traversable)
+  deriving anyclass (ToJSON, Binary)
+
+data Order = Ascending | Descending
+  deriving stock (Eq, Show, Read, Ord, Enum, Bounded, Generic)
+  deriving anyclass (ToJSON, Binary)

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Types.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Types.hs
@@ -5,38 +5,83 @@
 module Language.Marlowe.Protocol.Query.Types
   where
 
-import Data.Aeson (ToJSON)
-import Data.Binary (Binary)
-import Data.Void (Void)
+import Data.Aeson (ToJSON(..), Value, object, (.=))
+import Data.Bifunctor (bimap)
+import Data.Binary (Binary(..), getWord8, putWord8)
 import GHC.Generics (Generic)
+import GHC.Show (showCommaSpace, showSpace)
 import Language.Marlowe.Runtime.Core.Api (ContractId)
 import Language.Marlowe.Runtime.Discovery.Api (ContractHeader)
+import Network.Protocol.Codec.Spec (MessageEq(..), ShowProtocol(..))
+import Network.Protocol.Driver (MessageToJSON(..))
 import Network.TypedProtocol
+import Network.TypedProtocol.Codec (AnyMessageAndAgency(..))
 
 data MarloweQuery where
   StInit :: MarloweQuery
-  StRequest :: err -> result -> MarloweQuery
+  StRequest :: a -> MarloweQuery
   StDone :: MarloweQuery
+
+data Request a where
+  ReqContractHeaders :: Range ContractId -> Request (Page ContractId ContractHeader)
+  ReqBoth :: Request a -> Request b -> Request (a, b)
+
+data SomeRequest where
+  SomeRequest :: Request a -> SomeRequest
+
+instance Binary SomeRequest where
+  get = do
+    tag <- getWord8
+    case tag of
+      0x00 -> do
+        SomeRequest a <- get
+        SomeRequest b <- get
+        pure $ SomeRequest $ ReqBoth a b
+      0x01 -> SomeRequest . ReqContractHeaders <$> get
+      _ -> fail "Invalid Request tag"
+
+  put (SomeRequest req) = case req of
+    ReqBoth a b -> do
+      putWord8 0x00
+      put $ SomeRequest a
+      put $ SomeRequest b
+    ReqContractHeaders range -> do
+      putWord8 0x01
+      put range
+
+deriving instance Eq (Request a)
+deriving instance Show (Request a)
+instance ToJSON (Request a) where
+  toJSON = \case
+    ReqContractHeaders range -> object
+      [ "get-contract-headers-for-range" .= range
+      ]
+    ReqBoth a b -> object
+      [ "req-both" .= (toJSON a, toJSON b)
+      ]
+
+data StRequest a where
+  TokContractHeaders :: StRequest (Page ContractId ContractHeader)
+  TokBoth :: StRequest a -> StRequest b -> StRequest (a, b)
+
+deriving instance Show (StRequest a)
+deriving instance Eq (StRequest a)
 
 instance Protocol MarloweQuery where
   data Message MarloweQuery st st' where
-    MsgGetContractHeaders :: Range ContractId -> Message MarloweQuery
+    MsgRequest :: Request a -> Message MarloweQuery
       'StInit
-      ('StRequest Void (Page ContractId ContractHeader))
+      ('StRequest a)
 
-    MsgResolve :: result -> Message MarloweQuery
-      ('StRequest err result)
-      'StDone
-
-    MsgReject :: err -> Message MarloweQuery
-      ('StRequest err result)
+    MsgRespond :: a -> Message MarloweQuery
+      ('StRequest a)
       'StDone
 
   data ClientHasAgency ps where
     TokInit :: ClientHasAgency 'StInit
 
   data ServerHasAgency ps where
-    TokGetContractHeaders :: ServerHasAgency ('StRequest Void (Page ContractId ContractHeader))
+    TokRequest :: StRequest a -> ServerHasAgency ('StRequest a)
 
   data NobodyHasAgency ps where
     TokDone :: NobodyHasAgency 'StDone
@@ -65,3 +110,52 @@ data Page a b = Page
 data Order = Ascending | Descending
   deriving stock (Eq, Show, Read, Ord, Enum, Bounded, Generic)
   deriving anyclass (ToJSON, Binary)
+
+instance MessageToJSON MarloweQuery where
+  messageToJSON = \case
+    ClientAgency TokInit -> \case
+      MsgRequest req -> object [ "request" .= req ]
+    ServerAgency (TokRequest req) -> \case
+      MsgRespond a -> object [ "respond" .= responseToJSON req a ]
+
+    where
+      responseToJSON :: StRequest a -> a -> Value
+      responseToJSON = \case
+        TokContractHeaders -> toJSON
+        TokBoth a b -> toJSON . bimap (responseToJSON a) (responseToJSON b)
+
+instance ShowProtocol MarloweQuery where
+  showsPrecMessage p = fmap (showParen (p >= 11)) . \case
+    ClientAgency TokInit -> \case
+      MsgRequest req -> (showString "MsgRequest" . showSpace . showsPrec 11 req)
+    ServerAgency (TokRequest req) -> \case
+      MsgRespond a -> showsPrecResult req 11 a
+    where
+      showsPrecResult :: StRequest a -> Int -> a -> String -> String
+      showsPrecResult = \case
+        TokContractHeaders -> showsPrec
+        TokBoth ta tb -> \_ (a, b) -> showParen True (showsPrecResult ta 0 a . showCommaSpace . showsPrecResult tb 0 b)
+  showsPrecServerHasAgency p (TokRequest req) = showParen (p >= 11) (showString "TokRequest" . showSpace . showsPrec 11 req)
+  showsPrecClientHasAgency _ TokInit = showString "TokInit"
+
+instance MessageEq MarloweQuery where
+  messageEq = \case
+    AnyMessageAndAgency (ClientAgency TokInit) (MsgRequest req) -> \case
+      AnyMessageAndAgency (ClientAgency TokInit) (MsgRequest req') -> reqEq req req'
+      _ -> False
+    AnyMessageAndAgency (ServerAgency (TokRequest req)) (MsgRespond a) -> \case
+      AnyMessageAndAgency (ServerAgency (TokRequest req')) (MsgRespond a') -> resultEq req req' a a'
+      _ -> False
+    where
+      reqEq :: Request a -> Request a1 -> Bool
+      reqEq (ReqContractHeaders range) (ReqContractHeaders range') = range == range'
+      reqEq (ReqContractHeaders _) _ = False
+      reqEq (ReqBoth a b) (ReqBoth a' b') = reqEq a a' && reqEq b b'
+      reqEq (ReqBoth _ _) _ = False
+
+      resultEq :: StRequest a -> StRequest b -> a -> b -> Bool
+      resultEq TokContractHeaders TokContractHeaders = (==)
+      resultEq TokContractHeaders _ = const $ const False
+      resultEq (TokBoth ta tb) (TokBoth ta' tb') = \(a, b) (a', b') ->
+        resultEq ta ta' a a' && resultEq tb tb' b b'
+      resultEq (TokBoth _ _) _ = const $ const False

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync.hs
@@ -5,19 +5,23 @@ module Language.Marlowe.Runtime.Sync
 
 import Control.Concurrent.Component
 import Language.Marlowe.Protocol.HeaderSync.Server (MarloweHeaderSyncServer)
+import Language.Marlowe.Protocol.Query.Server (MarloweQueryServer)
 import Language.Marlowe.Protocol.Sync.Server (MarloweSyncServer)
 import Language.Marlowe.Runtime.Sync.Database (DatabaseQueries)
 import Language.Marlowe.Runtime.Sync.MarloweHeaderSyncServer
-import Language.Marlowe.Runtime.Sync.MarloweSyncServer (MarloweSyncServerDependencies(..), marloweSyncServer)
+import Language.Marlowe.Runtime.Sync.MarloweSyncServer
+import Language.Marlowe.Runtime.Sync.QueryServer
 import Network.Protocol.Driver (RunServer)
 
 data SyncDependencies = SyncDependencies
   { databaseQueries :: DatabaseQueries IO
   , acceptRunMarloweSyncServer :: IO (RunServer IO MarloweSyncServer)
   , acceptRunMarloweHeaderSyncServer :: IO (RunServer IO MarloweHeaderSyncServer)
+  , acceptRunMarloweQueryServer :: IO (RunServer IO MarloweQueryServer)
   }
 
 sync :: Component IO SyncDependencies ()
 sync = proc SyncDependencies{..} -> do
   marloweSyncServer -< MarloweSyncServerDependencies{..}
   marloweHeaderSyncServer -< MarloweHeaderSyncServerDependencies{..}
+  queryServer -< QueryServerDependencies{..}

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database.hs
@@ -13,6 +13,7 @@ import Data.Aeson (ToJSON)
 import Data.Text (Text)
 import Data.Void (Void)
 import GHC.Generics (Generic)
+import Language.Marlowe.Protocol.Query.Types (Page, Range)
 import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, ChainPoint)
 import Language.Marlowe.Runtime.Core.Api (ContractId, MarloweVersion(..), SomeMarloweVersion)
 import Language.Marlowe.Runtime.Discovery.Api (ContractHeader)
@@ -128,27 +129,6 @@ data DatabaseQueries m = DatabaseQueries
   , getNextSteps :: forall v. MarloweVersion v -> ContractId -> ChainPoint -> m (Next (ContractStep v))
   , getHeaders :: Range ContractId -> m (Page ContractId ContractHeader)
   }
-
-data Range a = Range
-  { rangeStart :: Maybe a
-  , rangeOffset :: Int
-  , rangeLimit :: Int
-  , rangeDirection :: Order
-  }
-  deriving stock (Eq, Show, Read, Ord, Functor, Generic, Foldable, Traversable)
-  deriving anyclass (ToJSON)
-
-data Page a b = Page
-  { items :: [b]
-  , nextRange :: Maybe (Range a)
-  , totalCount :: Int
-  }
-  deriving stock (Eq, Show, Read, Ord, Functor, Generic, Foldable, Traversable)
-  deriving anyclass (ToJSON)
-
-data Order = Ascending | Descending
-  deriving stock (Eq, Show, Read, Ord, Enum, Bounded, Generic)
-  deriving anyclass (ToJSON)
 
 data Next a
   = Rollback ChainPoint

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL.hs
@@ -5,6 +5,7 @@ import qualified Hasql.Session as H
 import qualified Hasql.Transaction.Sessions as T
 import Language.Marlowe.Runtime.Sync.Database (DatabaseQueries(DatabaseQueries))
 import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetCreateStep (getCreateStep)
+import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetHeaders (getHeaders)
 import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetIntersection (getIntersection)
 import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetIntersectionForContract (getIntersectionForContract)
 import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetNextHeaders (getNextHeaders)
@@ -21,3 +22,4 @@ databaseQueries = DatabaseQueries
   (\contractId -> T.transaction T.Serializable T.Read . getIntersectionForContract contractId)
   (T.transaction T.Serializable T.Read . getNextHeaders)
   (\version contractId -> T.transaction T.Serializable T.Read . getNextSteps version contractId)
+  (T.transaction T.Serializable T.Read . getHeaders)

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetCreateStep.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetCreateStep.hs
@@ -39,9 +39,9 @@ getCreateStep (ContractId TxOutRef{..}) = T.statement params $
       ( SELECT $1 :: bytea, $2 :: smallint
       )
     SELECT
-      block.slotNo :: bigint,
-      block.id :: bytea,
-      block.blockNo :: bigint,
+      createTxOut.slotNo :: bigint,
+      createTxOut.blockId :: bytea,
+      createTxOut.blockNo :: bigint,
       txOut.address :: bytea,
       txOut.lovelace :: bigint,
       txOutAsset.policyId :: bytea?,
@@ -56,7 +56,6 @@ getCreateStep (ContractId TxOutRef{..}) = T.statement params $
     JOIN marlowe.contractTxOut USING (txId, txIx)
     JOIN marlowe.txOut USING (txId, txIx)
     LEFT JOIN marlowe.txOutAsset USING (txId, txIx)
-    JOIN marlowe.block ON block.id = createTxOut.blockId
     JOIN contractId USING (txId, txIx)
   |] foldResults
   where

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetHeaders.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetHeaders.hs
@@ -1,0 +1,227 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetHeaders
+  where
+
+import Control.Foldl (Fold)
+import qualified Control.Foldl as Fold
+import Data.Binary (get)
+import Data.Binary.Get (runGet)
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy (fromStrict)
+import Data.Int (Int16, Int64)
+import Data.Maybe (fromJust)
+import Hasql.TH (foldStatement, singletonStatement)
+import qualified Hasql.Transaction as T
+import Language.Marlowe.Runtime.ChainSync.Api
+  ( Address(..)
+  , BlockHeader(..)
+  , BlockHeaderHash(..)
+  , Credential(..)
+  , PolicyId(..)
+  , ScriptHash(..)
+  , TxId(..)
+  , TxOutRef(..)
+  , paymentCredential
+  )
+import Language.Marlowe.Runtime.Core.Api
+  (ContractId(..), MarloweVersion(MarloweV1), SomeMarloweVersion(SomeMarloweVersion))
+import Language.Marlowe.Runtime.Discovery.Api (ContractHeader(..))
+import Language.Marlowe.Runtime.Sync.Database (Order(..), Page(..), Range(..))
+import Prelude hiding (init)
+
+getHeaders
+  :: Range ContractId
+  -> T.Transaction (Page ContractId ContractHeader)
+getHeaders range@Range{rangeStart = Just (ContractId TxOutRef{..}), ..} = do
+  totalItems <- fromIntegral <$> T.statement () [singletonStatement| SELECT COUNT(*) :: int FROM marlowe.createTxOut |]
+  T.statement params case rangeDirection of
+    Descending ->
+      [foldStatement|
+        SELECT
+          block.slotNo :: bigint,
+          block.id :: bytea,
+          block.blockNo :: bigint,
+          createTxOut.txId :: bytea,
+          createTxOut.txIx :: smallint,
+          contractTxOut.rolesCurrency :: bytea,
+          createTxOut.metadata :: bytea?,
+          txOut.address :: bytea,
+          contractTxOut.payoutScriptHash :: bytea
+        FROM marlowe.createTxOut
+        JOIN marlowe.contractTxOut USING (txId, txIx)
+        JOIN marlowe.txOut USING (txId, txIx)
+        JOIN marlowe.block
+          ON block.id = createTxOut.blockId
+        JOIN
+          ( SELECT slotNo, txId, txIx
+            FROM marlowe.createTxOut
+            JOIN marlowe.block
+              ON block.id = createTxOut.blockId
+            WHERE txId = $1 :: bytea
+              AND txIx = $2 :: smallint
+          ) AS pivot
+          ON block.slotNo < pivot.slotNo OR
+            ( block.slotNo = pivot.slotNo AND
+              ( createTxOut.txId < pivot.txId OR
+                ( createTxOut.txId = pivot.txId AND
+                    createTxOut.txIx <= pivot.txIx
+                )
+              )
+            )
+        ORDER BY block.slotNo DESC, createTxOut.txId DESC, createTxOut.txIx DESC
+        OFFSET ($3 :: int) ROWS
+        FETCH NEXT ($4 :: int) ROWS ONLY
+      |] (foldPage range totalItems)
+
+    Ascending ->
+      [foldStatement|
+        SELECT
+          block.slotNo :: bigint,
+          block.id :: bytea,
+          block.blockNo :: bigint,
+          createTxOut.txId :: bytea,
+          createTxOut.txIx :: smallint,
+          contractTxOut.rolesCurrency :: bytea,
+          createTxOut.metadata :: bytea?,
+          txOut.address :: bytea,
+          contractTxOut.payoutScriptHash :: bytea
+        FROM marlowe.createTxOut
+        JOIN marlowe.contractTxOut USING (txId, txIx)
+        JOIN marlowe.txOut USING (txId, txIx)
+        JOIN marlowe.block
+          ON block.id = createTxOut.blockId
+        JOIN
+          ( SELECT slotNo, txId, txIx
+            FROM marlowe.createTxOut
+            JOIN marlowe.block
+              ON block.id = createTxOut.blockId
+            WHERE txId = $1 :: bytea
+              AND txIx = $2 :: smallint
+          ) AS pivot
+          ON block.slotNo > pivot.slotNo OR
+            ( block.slotNo = pivot.slotNo AND
+              ( createTxOut.txId > pivot.txId OR
+                ( createTxOut.txId = pivot.txId AND
+                    createTxOut.txIx >= pivot.txIx
+                )
+              )
+            )
+        ORDER BY block.slotNo, createTxOut.txId, createTxOut.txIx
+        OFFSET ($3 :: int) ROWS
+        FETCH NEXT ($4 :: int) ROWS ONLY
+      |] (foldPage range totalItems)
+  where
+    params = (unTxId txId, fromIntegral txIx, fromIntegral rangeOffset, fromIntegral rangeLimit)
+
+getHeaders range@Range{..} = do
+  totalItems <- fromIntegral <$> T.statement () [singletonStatement| SELECT COUNT(*) :: int FROM marlowe.createTxOut |]
+  T.statement params case rangeDirection of
+    Descending ->
+      [foldStatement|
+        SELECT
+          block.slotNo :: bigint,
+          block.id :: bytea,
+          block.blockNo :: bigint,
+          createTxOut.txId :: bytea,
+          createTxOut.txIx :: smallint,
+          contractTxOut.rolesCurrency :: bytea,
+          createTxOut.metadata :: bytea?,
+          txOut.address :: bytea,
+          contractTxOut.payoutScriptHash :: bytea
+        FROM marlowe.createTxOut
+        JOIN marlowe.contractTxOut USING (txId, txIx)
+        JOIN marlowe.txOut USING (txId, txIx)
+        JOIN marlowe.block
+          ON block.id = createTxOut.blockId
+        ORDER BY block.slotNo DESC, createTxOut.txId DESC, createTxOut.txIx DESC
+        OFFSET ($1 :: int) ROWS
+        FETCH NEXT ($2 :: int) ROWS ONLY
+      |] (foldPage range totalItems)
+
+    Ascending ->
+      [foldStatement|
+        SELECT
+          block.slotNo :: bigint,
+          block.id :: bytea,
+          block.blockNo :: bigint,
+          createTxOut.txId :: bytea,
+          createTxOut.txIx :: smallint,
+          contractTxOut.rolesCurrency :: bytea,
+          createTxOut.metadata :: bytea?,
+          txOut.address :: bytea,
+          contractTxOut.payoutScriptHash :: bytea
+        FROM marlowe.createTxOut
+        JOIN marlowe.contractTxOut USING (txId, txIx)
+        JOIN marlowe.txOut USING (txId, txIx)
+        JOIN marlowe.block
+          ON block.id = createTxOut.blockId
+        ORDER BY block.slotNo, createTxOut.txId, createTxOut.txIx
+        OFFSET ($1 :: int) ROWS
+        FETCH NEXT ($2 :: int) ROWS ONLY
+      |] (foldPage range totalItems)
+  where
+    params = (fromIntegral rangeOffset, fromIntegral rangeLimit)
+
+
+type ResultRow =
+  ( Int64
+  , ByteString
+  , Int64
+  , ByteString
+  , Int16
+  , ByteString
+  , Maybe ByteString
+  , ByteString
+  , ByteString
+  )
+
+foldPage :: Range ContractId -> Int -> Fold ResultRow (Page ContractId ContractHeader)
+foldPage range totalItems = Page
+  <$> foldItems
+  <*> foldNextRange range
+  <*> pure totalItems
+
+foldItems :: Fold ResultRow [ContractHeader]
+foldItems = fmap decodeContractHeader <$> Fold.list
+
+decodeContractHeader :: ResultRow -> ContractHeader
+decodeContractHeader
+  ( slotNo
+  , blockHeaderHash
+  , blockNo
+  , txId
+  , txIx
+  , rolesCurrency
+  , metadata
+  , address
+  , payoutScriptHash
+  ) = ContractHeader
+    { contractId = ContractId (TxOutRef (TxId txId) (fromIntegral txIx))
+    , rolesCurrency = PolicyId rolesCurrency
+    , metadata = maybe mempty (runGet get. fromStrict) metadata
+    , marloweScriptHash = fromJust do
+        credential <- paymentCredential $ Address address
+        case credential of
+          ScriptCredential hash -> pure hash
+          _ -> Nothing
+    , marloweScriptAddress = Address address
+    , payoutScriptHash = ScriptHash payoutScriptHash
+    , marloweVersion = SomeMarloweVersion MarloweV1
+    , blockHeader = BlockHeader
+        (fromIntegral slotNo)
+        (BlockHeaderHash blockHeaderHash)
+        (fromIntegral blockNo)
+    }
+
+foldNextRange :: Range ContractId -> Fold ResultRow (Maybe (Range ContractId))
+foldNextRange range = fmap (decodeNextRange range) <$> Fold.last
+
+decodeNextRange :: Range ContractId -> ResultRow -> Range ContractId
+decodeNextRange Range{..} (_, _, _, txId, txIx, _, _, _, _) = Range
+  { rangeStart = Just $ ContractId (TxOutRef (TxId txId) (fromIntegral txIx))
+  , rangeOffset = rangeOffset + 1
+  , ..
+  }

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetHeaders.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetHeaders.hs
@@ -15,6 +15,7 @@ import Data.Int (Int16, Int64)
 import Data.Maybe (fromJust)
 import Hasql.TH (foldStatement, singletonStatement)
 import qualified Hasql.Transaction as T
+import Language.Marlowe.Protocol.Query.Types
 import Language.Marlowe.Runtime.ChainSync.Api
   ( Address(..)
   , BlockHeader(..)
@@ -29,7 +30,6 @@ import Language.Marlowe.Runtime.ChainSync.Api
 import Language.Marlowe.Runtime.Core.Api
   (ContractId(..), MarloweVersion(MarloweV1), SomeMarloweVersion(SomeMarloweVersion))
 import Language.Marlowe.Runtime.Discovery.Api (ContractHeader(..))
-import Language.Marlowe.Runtime.Sync.Database (Order(..), Page(..), Range(..))
 import Prelude hiding (init)
 
 getHeaders

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetHeaders.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetHeaders.hs
@@ -41,9 +41,9 @@ getHeaders range@Range{rangeStart = Just (ContractId TxOutRef{..}), ..} = do
     Descending ->
       [foldStatement|
         SELECT
-          block.slotNo :: bigint,
-          block.id :: bytea,
-          block.blockNo :: bigint,
+          createTxOut.slotNo :: bigint,
+          createTxOut.blockId :: bytea,
+          createTxOut.blockNo :: bigint,
           createTxOut.txId :: bytea,
           createTxOut.txIx :: smallint,
           contractTxOut.rolesCurrency :: bytea,
@@ -53,25 +53,21 @@ getHeaders range@Range{rangeStart = Just (ContractId TxOutRef{..}), ..} = do
         FROM marlowe.createTxOut
         JOIN marlowe.contractTxOut USING (txId, txIx)
         JOIN marlowe.txOut USING (txId, txIx)
-        JOIN marlowe.block
-          ON block.id = createTxOut.blockId
         JOIN
           ( SELECT slotNo, txId, txIx
             FROM marlowe.createTxOut
-            JOIN marlowe.block
-              ON block.id = createTxOut.blockId
             WHERE txId = $1 :: bytea
               AND txIx = $2 :: smallint
           ) AS pivot
-          ON block.slotNo < pivot.slotNo OR
-            ( block.slotNo = pivot.slotNo AND
+          ON createTxOut.slotNo < pivot.slotNo OR
+            ( createTxOut.slotNo = pivot.slotNo AND
               ( createTxOut.txId < pivot.txId OR
                 ( createTxOut.txId = pivot.txId AND
                     createTxOut.txIx <= pivot.txIx
                 )
               )
             )
-        ORDER BY block.slotNo DESC, createTxOut.txId DESC, createTxOut.txIx DESC
+        ORDER BY createTxOut.slotNo DESC, createTxOut.txId DESC, createTxOut.txIx DESC
         OFFSET ($3 :: int) ROWS
         FETCH NEXT ($4 :: int) ROWS ONLY
       |] (foldPage range totalItems)
@@ -79,9 +75,9 @@ getHeaders range@Range{rangeStart = Just (ContractId TxOutRef{..}), ..} = do
     Ascending ->
       [foldStatement|
         SELECT
-          block.slotNo :: bigint,
-          block.id :: bytea,
-          block.blockNo :: bigint,
+          createTxOut.slotNo :: bigint,
+          createTxOut.blockId :: bytea,
+          createTxOut.blockNo :: bigint,
           createTxOut.txId :: bytea,
           createTxOut.txIx :: smallint,
           contractTxOut.rolesCurrency :: bytea,
@@ -91,25 +87,21 @@ getHeaders range@Range{rangeStart = Just (ContractId TxOutRef{..}), ..} = do
         FROM marlowe.createTxOut
         JOIN marlowe.contractTxOut USING (txId, txIx)
         JOIN marlowe.txOut USING (txId, txIx)
-        JOIN marlowe.block
-          ON block.id = createTxOut.blockId
         JOIN
           ( SELECT slotNo, txId, txIx
             FROM marlowe.createTxOut
-            JOIN marlowe.block
-              ON block.id = createTxOut.blockId
             WHERE txId = $1 :: bytea
               AND txIx = $2 :: smallint
           ) AS pivot
-          ON block.slotNo > pivot.slotNo OR
-            ( block.slotNo = pivot.slotNo AND
+          ON createTxOut.slotNo > pivot.slotNo OR
+            ( createTxOut.slotNo = pivot.slotNo AND
               ( createTxOut.txId > pivot.txId OR
                 ( createTxOut.txId = pivot.txId AND
                     createTxOut.txIx >= pivot.txIx
                 )
               )
             )
-        ORDER BY block.slotNo, createTxOut.txId, createTxOut.txIx
+        ORDER BY createTxOut.slotNo, createTxOut.txId, createTxOut.txIx
         OFFSET ($3 :: int) ROWS
         FETCH NEXT ($4 :: int) ROWS ONLY
       |] (foldPage range totalItems)
@@ -122,9 +114,9 @@ getHeaders range@Range{..} = do
     Descending ->
       [foldStatement|
         SELECT
-          block.slotNo :: bigint,
-          block.id :: bytea,
-          block.blockNo :: bigint,
+          createTxOut.slotNo :: bigint,
+          createTxOut.blockId :: bytea,
+          createTxOut.blockNo :: bigint,
           createTxOut.txId :: bytea,
           createTxOut.txIx :: smallint,
           contractTxOut.rolesCurrency :: bytea,
@@ -134,9 +126,7 @@ getHeaders range@Range{..} = do
         FROM marlowe.createTxOut
         JOIN marlowe.contractTxOut USING (txId, txIx)
         JOIN marlowe.txOut USING (txId, txIx)
-        JOIN marlowe.block
-          ON block.id = createTxOut.blockId
-        ORDER BY block.slotNo DESC, createTxOut.txId DESC, createTxOut.txIx DESC
+        ORDER BY createTxOut.slotNo, createTxOut.txId, createTxOut.txIx
         OFFSET ($1 :: int) ROWS
         FETCH NEXT ($2 :: int) ROWS ONLY
       |] (foldPage range totalItems)

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetNextSteps.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetNextSteps.hs
@@ -101,39 +101,28 @@ getNextTxIds (ContractId TxOutRef{..}) point = T.statement params $ fmap (NextTx
       )
     , nextApplyTxIds (slotNo, blockHeaderHash, blockNo, txIds) AS
       ( SELECT
-          block.slotNo,
-          (ARRAY_AGG(block.id))[1],
-          (ARRAY_AGG(block.blockNo))[1],
-          ARRAY_AGG(applyTx.txId)
+          slotNo,
+          (ARRAY_AGG(blockId))[1],
+          (ARRAY_AGG(blockNo))[1],
+          ARRAY_AGG(txId)
         FROM marlowe.applyTx
-        JOIN marlowe.block
-          ON block.id = applyTx.blockId
         JOIN params USING (createTxId, createTxIx)
-        WHERE block.rollbackToBlock IS NULL
-          AND block.slotNo > params.afterSlot
-        GROUP BY block.slotNo
-        ORDER BY block.slotNo
+        WHERE slotNo > params.afterSlot
+        GROUP BY slotNo
+        ORDER BY slotNo
         LIMIT 1
       )
     , nextWithdrawalTxIds (slotNo, blockHeaderHash, blockNo, txIds) AS
       ( SELECT
-          block.slotNo,
-          (ARRAY_AGG(block.id))[1],
-          (ARRAY_AGG(block.blockNo))[1],
-          ARRAY_AGG(withdrawalTxIn.txId)
+          slotNo,
+          (ARRAY_AGG(blockId))[1],
+          (ARRAY_AGG(blockNo))[1],
+          ARRAY_AGG(txId)
         FROM marlowe.withdrawalTxIn
-        JOIN marlowe.block
-          ON block.id = withdrawalTxIn.blockId
-        JOIN marlowe.payoutTxOut
-          ON payoutTxOut.txId = withdrawalTxIn.payoutTxId
-          AND payoutTxOut.txIx = withdrawalTxIn.payoutTxIx
-        JOIN marlowe.applyTx
-          ON applyTx.txId = payoutTxOut.txId
         JOIN params USING (createTxId, createTxIx)
-        WHERE block.rollbackToBlock IS NULL
-          AND block.slotNo > params.afterSlot
-        GROUP BY block.slotNo
-        ORDER BY block.slotNo
+        WHERE slotNo > params.afterSlot
+        GROUP BY slotNo
+        ORDER BY slotNo
         LIMIT 1
       )
     SELECT

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/QueryServer.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/QueryServer.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Language.Marlowe.Runtime.Sync.QueryServer
+  where
+
+import Control.Concurrent.Component
+import Language.Marlowe.Protocol.Query.Server (MarloweQueryServer, marloweQueryServer)
+import Language.Marlowe.Runtime.Sync.Database (DatabaseQueries(..))
+import Network.Protocol.Driver (RunServer(..))
+
+data QueryServerDependencies = QueryServerDependencies
+  { databaseQueries :: DatabaseQueries IO
+  , acceptRunMarloweQueryServer :: IO (RunServer IO MarloweQueryServer)
+  }
+
+queryServer :: Component IO QueryServerDependencies ()
+queryServer = serverComponent (component_ worker) \QueryServerDependencies{..} -> do
+  runMarloweQueryServer <- acceptRunMarloweQueryServer
+  pure WorkerDependencies{..}
+
+data WorkerDependencies = WorkerDependencies
+  { databaseQueries :: DatabaseQueries IO
+  , runMarloweQueryServer :: RunServer IO MarloweQueryServer
+  }
+
+worker :: WorkerDependencies -> IO ()
+worker WorkerDependencies{..} = do
+  let DatabaseQueries{..} = databaseQueries
+  let RunServer runServer = runMarloweQueryServer
+  runServer $ marloweQueryServer getHeaders

--- a/marlowe-runtime/test/Language/Marlowe/Protocol/QuerySpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Protocol/QuerySpec.hs
@@ -1,0 +1,102 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module Language.Marlowe.Protocol.QuerySpec
+  where
+
+import Data.Foldable (fold)
+import Language.Marlowe.Protocol.Query.Codec (codecMarloweQuery)
+import Language.Marlowe.Protocol.Query.Types
+import Language.Marlowe.Runtime.ChainSync.Gen (StructureType(..), oneofStructured, resized)
+import Language.Marlowe.Runtime.Discovery.Gen ()
+import Network.Protocol.Codec.Spec
+import Network.TypedProtocol.Codec
+import Spec.Marlowe.Semantics.Arbitrary ()
+import Test.Hspec (Spec, describe)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck hiding (shrinkMap)
+
+spec :: Spec
+spec = describe "MarloweQuery protocol" do
+  prop "Has a lawful codec" $ checkPropCodec genByteStringSplits codecMarloweQuery
+
+instance ArbitraryMessage MarloweQuery where
+  arbitraryMessage = resized (min 30) $ oneof
+    [ do
+        SomeRequest request <- arbitrary
+        pure $ AnyMessageAndAgency (ClientAgency TokInit) $ MsgRequest request
+    , do
+        SomeStRequest req <- arbitrary
+        a <- arbitraryResult req
+        pure $ AnyMessageAndAgency (ServerAgency (TokRequest req)) $ MsgRespond a
+    ]
+    where
+      arbitraryResult :: StRequest a -> Gen a
+      arbitraryResult = \case
+        TokContractHeaders -> arbitrary
+        TokBoth a b -> resized (`div` 2) $ (,) <$> arbitraryResult a <*> arbitraryResult b
+
+  shrinkMessage = \case
+    ClientAgency TokInit -> \case
+      MsgRequest req -> MsgRequest <$> shrinkRequest req
+    ServerAgency (TokRequest req) -> \case
+      MsgRespond a -> MsgRespond <$> shrinkResponse req a
+
+data SomeStRequest where
+  SomeStRequest :: StRequest a -> SomeStRequest
+
+instance Arbitrary SomeStRequest where
+  arbitrary = oneofStructured
+    [ ( Node
+      , resize 0 do
+          SomeStRequest a <- arbitrary
+          SomeStRequest b <- arbitrary
+          pure $ SomeStRequest $ TokBoth a b
+      )
+    , (Leaf, pure $ SomeStRequest TokContractHeaders)
+    ]
+
+instance Arbitrary SomeRequest where
+  arbitrary = oneofStructured
+    [ ( Node
+      , resize 0 do
+          SomeRequest a <- arbitrary
+          SomeRequest b <- arbitrary
+          pure $ SomeRequest $ ReqBoth a b
+      )
+    , (Leaf, SomeRequest . ReqContractHeaders <$> arbitrary)
+    ]
+  shrink (SomeRequest req) = case req of
+    ReqContractHeaders range -> SomeRequest . ReqContractHeaders <$> shrink range
+    ReqBoth a b -> fold
+      [ [ SomeRequest $ ReqBoth a' b | SomeRequest a' <- shrink (SomeRequest a) ]
+      , [ SomeRequest $ ReqBoth a b' | SomeRequest b' <- shrink (SomeRequest b) ]
+      ]
+
+shrinkRequest :: Request a -> [Request a]
+shrinkRequest = \case
+  ReqContractHeaders range -> ReqContractHeaders <$> shrink range
+  ReqBoth a b -> fold
+    [ [ ReqBoth a' b | a' <- shrinkRequest a ]
+    , [ ReqBoth a b' | b' <- shrinkRequest b ]
+    ]
+
+shrinkResponse :: StRequest a -> a -> [a]
+shrinkResponse = \case
+  TokContractHeaders -> shrink
+  TokBoth ta tb -> \(a, b) -> fold
+    [ [ (a', b) | a' <- shrinkResponse ta a ]
+    , [ (a, b') | b' <- shrinkResponse tb b ]
+    ]
+
+instance (Arbitrary a, Arbitrary b) => Arbitrary (Page a b) where
+  arbitrary = Page <$> arbitrary <*> arbitrary <*> arbitrary
+  shrink = genericShrink
+
+instance Arbitrary a => Arbitrary (Range a) where
+  arbitrary = Range <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  shrink = genericShrink
+
+instance Arbitrary Order where
+  arbitrary = elements [Ascending, Descending]

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-runtime.nix
@@ -156,6 +156,28 @@
             ];
           hsSourceDirs = [ "indexer" ];
           };
+        "sync-api" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."lifted-async" or (errorHandler.buildDepError "lifted-async"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-runtime".components.sublibs.discovery-api or (errorHandler.buildDepError "marlowe-runtime:discovery-api"))
+            (hsPkgs."monad-control" or (errorHandler.buildDepError "monad-control"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            ];
+          buildable = true;
+          modules = [
+            "Language/Marlowe/Protocol/Query/Client"
+            "Language/Marlowe/Protocol/Query/Codec"
+            "Language/Marlowe/Protocol/Query/Server"
+            "Language/Marlowe/Protocol/Query/Types"
+            ];
+          hsSourceDirs = [ "sync-api" ];
+          };
         "sync" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
@@ -176,6 +198,7 @@
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."marlowe-runtime".components.sublibs.discovery-api or (errorHandler.buildDepError "marlowe-runtime:discovery-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
+            (hsPkgs."marlowe-runtime".components.sublibs.sync-api or (errorHandler.buildDepError "marlowe-runtime:sync-api"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
@@ -187,11 +210,13 @@
             "Language/Marlowe/Runtime/Sync"
             "Language/Marlowe/Runtime/Sync/MarloweHeaderSyncServer"
             "Language/Marlowe/Runtime/Sync/MarloweSyncServer"
+            "Language/Marlowe/Runtime/Sync/QueryServer"
             "Language/Marlowe/Runtime/Sync/Database"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetTip"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetTipForContract"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetCreateStep"
+            "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetHeaders"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetIntersectionForContract"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetIntersection"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetNextHeaders"
@@ -541,6 +566,7 @@
             (hsPkgs."marlowe-runtime".components.sublibs.discovery-api or (errorHandler.buildDepError "marlowe-runtime:discovery-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.sync or (errorHandler.buildDepError "marlowe-runtime:sync"))
+            (hsPkgs."marlowe-runtime".components.sublibs.sync-api or (errorHandler.buildDepError "marlowe-runtime:sync-api"))
             (hsPkgs."network" or (errorHandler.buildDepError "network"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
@@ -671,6 +697,7 @@
             (hsPkgs."marlowe-runtime".components.sublibs.discovery-api or (errorHandler.buildDepError "marlowe-runtime:discovery-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.history or (errorHandler.buildDepError "marlowe-runtime:history"))
             (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
+            (hsPkgs."marlowe-runtime".components.sublibs.sync-api or (errorHandler.buildDepError "marlowe-runtime:sync-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.tx or (errorHandler.buildDepError "marlowe-runtime:tx"))
             (hsPkgs."marlowe-runtime".components.sublibs.tx-api or (errorHandler.buildDepError "marlowe-runtime:tx-api"))
             (hsPkgs."marlowe-test" or (errorHandler.buildDepError "marlowe-test"))
@@ -705,6 +732,7 @@
             "Language/Marlowe/Runtime/Transaction/CommandSpec"
             "Language/Marlowe/Protocol/HeaderSyncSpec"
             "Language/Marlowe/Protocol/SyncSpec"
+            "Language/Marlowe/Protocol/QuerySpec"
             "Paths_marlowe_runtime"
             ];
           hsSourceDirs = [ "test" ];

--- a/nix/pkgs/haskell/materialized-darwin/default.nix
+++ b/nix/pkgs/haskell/materialized-darwin/default.nix
@@ -1410,6 +1410,7 @@
           "statistics".components.library.planned = lib.mkOverride 900 true;
           "vault".components.library.planned = lib.mkOverride 900 true;
           "th-abstraction".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.sublibs."sync-api".planned = lib.mkOverride 900 true;
           "plutus-ledger-aeson".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-shelley-test".components.library.planned = lib.mkOverride 900 true;
           "parsers".components.library.planned = lib.mkOverride 900 true;

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-runtime.nix
@@ -156,6 +156,28 @@
             ];
           hsSourceDirs = [ "indexer" ];
           };
+        "sync-api" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."lifted-async" or (errorHandler.buildDepError "lifted-async"))
+            (hsPkgs."marlowe-protocols" or (errorHandler.buildDepError "marlowe-protocols"))
+            (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
+            (hsPkgs."marlowe-runtime".components.sublibs.discovery-api or (errorHandler.buildDepError "marlowe-runtime:discovery-api"))
+            (hsPkgs."monad-control" or (errorHandler.buildDepError "monad-control"))
+            (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
+            ];
+          buildable = true;
+          modules = [
+            "Language/Marlowe/Protocol/Query/Client"
+            "Language/Marlowe/Protocol/Query/Codec"
+            "Language/Marlowe/Protocol/Query/Server"
+            "Language/Marlowe/Protocol/Query/Types"
+            ];
+          hsSourceDirs = [ "sync-api" ];
+          };
         "sync" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
@@ -176,6 +198,7 @@
             (hsPkgs."marlowe-runtime" or (errorHandler.buildDepError "marlowe-runtime"))
             (hsPkgs."marlowe-runtime".components.sublibs.discovery-api or (errorHandler.buildDepError "marlowe-runtime:discovery-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
+            (hsPkgs."marlowe-runtime".components.sublibs.sync-api or (errorHandler.buildDepError "marlowe-runtime:sync-api"))
             (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
@@ -187,11 +210,13 @@
             "Language/Marlowe/Runtime/Sync"
             "Language/Marlowe/Runtime/Sync/MarloweHeaderSyncServer"
             "Language/Marlowe/Runtime/Sync/MarloweSyncServer"
+            "Language/Marlowe/Runtime/Sync/QueryServer"
             "Language/Marlowe/Runtime/Sync/Database"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetTip"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetTipForContract"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetCreateStep"
+            "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetHeaders"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetIntersectionForContract"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetIntersection"
             "Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetNextHeaders"
@@ -541,6 +566,7 @@
             (hsPkgs."marlowe-runtime".components.sublibs.discovery-api or (errorHandler.buildDepError "marlowe-runtime:discovery-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.sync or (errorHandler.buildDepError "marlowe-runtime:sync"))
+            (hsPkgs."marlowe-runtime".components.sublibs.sync-api or (errorHandler.buildDepError "marlowe-runtime:sync-api"))
             (hsPkgs."network" or (errorHandler.buildDepError "network"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
@@ -671,6 +697,7 @@
             (hsPkgs."marlowe-runtime".components.sublibs.discovery-api or (errorHandler.buildDepError "marlowe-runtime:discovery-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.history or (errorHandler.buildDepError "marlowe-runtime:history"))
             (hsPkgs."marlowe-runtime".components.sublibs.history-api or (errorHandler.buildDepError "marlowe-runtime:history-api"))
+            (hsPkgs."marlowe-runtime".components.sublibs.sync-api or (errorHandler.buildDepError "marlowe-runtime:sync-api"))
             (hsPkgs."marlowe-runtime".components.sublibs.tx or (errorHandler.buildDepError "marlowe-runtime:tx"))
             (hsPkgs."marlowe-runtime".components.sublibs.tx-api or (errorHandler.buildDepError "marlowe-runtime:tx-api"))
             (hsPkgs."marlowe-test" or (errorHandler.buildDepError "marlowe-test"))
@@ -705,6 +732,7 @@
             "Language/Marlowe/Runtime/Transaction/CommandSpec"
             "Language/Marlowe/Protocol/HeaderSyncSpec"
             "Language/Marlowe/Protocol/SyncSpec"
+            "Language/Marlowe/Protocol/QuerySpec"
             "Paths_marlowe_runtime"
             ];
           hsSourceDirs = [ "test" ];

--- a/nix/pkgs/haskell/materialized-linux/default.nix
+++ b/nix/pkgs/haskell/materialized-linux/default.nix
@@ -1409,6 +1409,7 @@
           "statistics".components.library.planned = lib.mkOverride 900 true;
           "vault".components.library.planned = lib.mkOverride 900 true;
           "th-abstraction".components.library.planned = lib.mkOverride 900 true;
+          "marlowe-runtime".components.sublibs."sync-api".planned = lib.mkOverride 900 true;
           "plutus-ledger-aeson".components.library.planned = lib.mkOverride 900 true;
           "cardano-ledger-shelley-test".components.library.planned = lib.mkOverride 900 true;
           "parsers".components.library.planned = lib.mkOverride 900 true;


### PR DESCRIPTION
- [x] Adds new table columns and indexes for improved query performance
- [x] Adds new `MarloweQuery` protocol for queries supported by `marlowe-sync`
- [x] Implements `GetContractHeaders` query. 