### PR TITLE
fix typo in drop constraint command

### DIFF
--- a/marlowe-runtime/marlowe-indexer/deploy/rollback.sql
+++ b/marlowe-runtime/marlowe-indexer/deploy/rollback.sql
@@ -49,7 +49,7 @@ ALTER TABLE marlowe.withdrawalTxIn
   ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
 
 ALTER TABLE marlowe.invalidApplyTx
-  DROP CONSTRAINT invalidApplyIn_blockId_fkey,
+  DROP CONSTRAINT invalidApplyTx_blockId_fkey,
   ADD FOREIGN KEY (blockId) REFERENCES marlowe.block (id) ON DELETE CASCADE;
 
 COMMIT;


### PR DESCRIPTION

Fixing typo in constraint name in rollback migration.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description
    - [x] Reviewer requested
