### PR TITLE
MarloweQuery protocol improvements

### DIFF
--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -199,6 +199,8 @@ library sync-api
     , marlowe-runtime
     , marlowe-runtime:discovery-api
     , monad-control
+    , transformers
+    , transformers-base
     , typed-protocols
   visibility: public
 

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Codec.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Codec.hs
@@ -13,12 +13,14 @@ codecMarloweQuery = binaryCodec putMessage getMessage
   where
   putMessage :: PutMessage MarloweQuery
   putMessage = \case
-    ClientAgency TokInit -> \case
+    ClientAgency TokReq -> \case
       MsgRequest req -> do
         putWord8 0x01
         put $ SomeRequest req
 
-    ServerAgency (TokRequest req) -> \case
+      MsgDone -> putWord8 0x03
+
+    ServerAgency (TokRes req) -> \case
       MsgRespond a -> do
         putWord8 0x02
         putResult req a
@@ -28,23 +30,27 @@ codecMarloweQuery = binaryCodec putMessage getMessage
     tag <- getWord8
     case tag of
       0x01 -> case tok of
-        ClientAgency TokInit -> do
+        ClientAgency TokReq -> do
           SomeRequest req <- get
           pure $ SomeMessage $ MsgRequest req
         _ -> fail "Invalid protocol state for MsgRequest"
 
       0x02 -> case tok of
-        ServerAgency (TokRequest req) -> SomeMessage . MsgRespond <$> getResult req
+        ServerAgency (TokRes req) -> SomeMessage . MsgRespond <$> getResult req
         ClientAgency _  -> fail "Invalid protocol state for MsgRespond"
+
+      0x03 -> case tok of
+        ClientAgency TokReq -> pure $ SomeMessage MsgDone
+        _ -> fail "Invalid protocol state for MsgDone"
 
       _ -> fail $ "Invalid message tag " <> show tag
 
-  getResult :: StRequest a -> Get a
+  getResult :: StRes a -> Get a
   getResult = \case
     TokBoth a b -> (,) <$> getResult a <*> getResult b
     TokContractHeaders -> get
 
-  putResult :: StRequest a -> a -> Put
+  putResult :: StRes a -> a -> Put
   putResult = \case
     TokBoth ta tb -> \(a, b) -> putResult ta a *> putResult tb b
     TokContractHeaders -> put

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Server.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Server.hs
@@ -12,25 +12,20 @@ import Language.Marlowe.Runtime.Core.Api (ContractId)
 import Language.Marlowe.Runtime.Discovery.Api (ContractHeader)
 import Network.TypedProtocol
 
-type MarloweQueryServer = Peer MarloweQuery 'AsServer 'StInit
+type MarloweQueryServer = Peer MarloweQuery 'AsServer 'StReq
 
 marloweQueryServer
   :: forall m
    . MonadBaseControl IO m
   => (Range ContractId -> m (Page ContractId ContractHeader))
   -> MarloweQueryServer m ()
-marloweQueryServer getContractHeaders = Await (ClientAgency TokInit) \case
-  MsgRequest req -> Effect do
-    result <- serviceRequest req
-    pure $
-      Yield (ServerAgency $ TokRequest $ reqToSt req) (MsgRespond result) $
-      Done TokDone ()
+marloweQueryServer getContractHeaders = go
   where
-    reqToSt :: Request a -> StRequest a
-    reqToSt = \case
-      ReqContractHeaders _ -> TokContractHeaders
-      ReqBoth a b -> TokBoth (reqToSt a) (reqToSt b)
-
+    go = Await (ClientAgency TokReq) \case
+      MsgRequest req -> Effect do
+        result <- serviceRequest req
+        pure $ Yield (ServerAgency $ TokRes $ requestToSt req) (MsgRespond result) go
+      MsgDone -> Done TokDone ()
     serviceRequest :: Request a -> m a
     serviceRequest = \case
       ReqContractHeaders range -> getContractHeaders range


### PR DESCRIPTION
- [x] Allow multiple queries per session (MsgRespond sends protocol back to initial state instead of done)
- [x] Abstract `MarloweQueryClient` to GADT for cleaner and more restrictive definitions
- [x] Add `Monad`, `MonadTrans`, `MonadIO`, and `MonadBase` instances for `MarloweQueryClient`
- [x] Allow `MarloweQueryClient m a -> Peer MarloweQuery 'AsClient 'StReq m a` to be a total function

Thanks for the feedback @bwbush  