### PR TITLE
SCP-5031 Fixed collateral indexing for invalid scripts.

### DIFF
--- a/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/Database/PostgreSQL.hs
+++ b/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/Database/PostgreSQL.hs
@@ -567,7 +567,13 @@ commitBlocks = CommitBlocks \blocks ->
       body@(TxBody TxBodyContent{..}) -> case txScriptValidity of
         TxScriptValidity _ ScriptInvalid -> case txReturnCollateral of
           TxReturnCollateralNone     -> []
-          TxReturnCollateral _ txOut -> [SomeTxOut (getTxId body) (TxIx 1) slotNo txOut (Nothing, Nothing) True era]
+          TxReturnCollateral _ txOut -> let
+                                          -- The index of the `TxOut` for collateral change on a transaction that
+                                          -- fails due to an invalid script is one more than the number of `TxOut`s
+                                          -- that there would have been had the transaction succeeded.
+                                          index =  toEnum $ length txOuts
+                                        in
+                                          [SomeTxOut (getTxId body) (TxIx index) slotNo txOut (Nothing, Nothing) True era]
         _ -> do
           (ix, txOut, datumInfo) <- zip3 [0..] txOuts datums
           pure $ SomeTxOut (getTxId body) (TxIx ix) slotNo txOut datumInfo False era

--- a/marlowe-chain-sync/deploy/fix-collateral-index.sql
+++ b/marlowe-chain-sync/deploy/fix-collateral-index.sql
@@ -1,0 +1,16 @@
+-- Deploy chain:fix-collateral-index to pg
+-- requires: split-address
+
+BEGIN;
+
+-- Fix for `preview` testnet.
+UPDATE chain.txOut
+  SET txIx = 3
+  WHERE (encode(txId, 'hex'), txIx) = ('5c4d3e1ad9921afb100040ed0fd275dcf7c2091d54b249a95ec00aa98bce9eff', 1);
+
+-- Fix for `preview` testnet.
+UPDATE chain.txOut
+  SET txIx = 2
+  WHERE (encode(txId, 'hex'), txIx) = ('a705221111f65ec604279e8c0d3b4b6d574139fae7db263f5a2afaac06d7d19c', 1);
+
+COMMIT;

--- a/marlowe-chain-sync/revert/fix-collateral-index.sql
+++ b/marlowe-chain-sync/revert/fix-collateral-index.sql
@@ -1,0 +1,16 @@
+-- Revert chain:fix-collateral-index from pg
+
+BEGIN;
+
+-- Undo fix for `preview` testnet.
+UPDATE chain.txOut
+  SET txIx = 1
+  WHERE (encode(txId, 'hex'), txIx) = ('5c4d3e1ad9921afb100040ed0fd275dcf7c2091d54b249a95ec00aa98bce9eff', 3);
+
+-- Undo fix for `preview` testnet.
+UPDATE chain.txOut
+  SET txIx = 1
+  WHERE (encode(txId, 'hex'), txIx) = ('a705221111f65ec604279e8c0d3b4b6d574139fae7db263f5a2afaac06d7d19c', 2);
+
+
+COMMIT;

--- a/marlowe-chain-sync/sqitch.plan
+++ b/marlowe-chain-sync/sqitch.plan
@@ -11,3 +11,4 @@ initial_partition [partition block tx] 2022-07-25T20:49:31Z Jamie Bertram <jamie
 md5address [tx] 2022-08-26T15:54:39Z Jamie Bertram <jamie.bertram@iohk.io> # Change address index to MD5 hash
 split-address [md5address] 2022-09-30T18:50:49Z Jamie Bertram <jamie.bertram@iohk.io> # Split addresses into their constituent parts
 rename-metadata [tx] 2022-12-14T13:38:23Z Jamie Bertram <jamie.bertram@iohk.io> # Rename metadataKey1564 column
+fix-collateral-index [split-address] 2023-02-07T19:41:05Z Brian W Bush <brian.bush@iohk.io> # Fix two incorrect output indices in `preview`.

--- a/marlowe-chain-sync/verify/fix-collateral-index.sql
+++ b/marlowe-chain-sync/verify/fix-collateral-index.sql
@@ -1,0 +1,7 @@
+-- Verify chain:fix-collateral-index on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;

--- a/marlowe-test/chain/compare.sql
+++ b/marlowe-test/chain/compare.sql
@@ -551,7 +551,7 @@ create temporary table cmp_asset_out as
     inner join public.ma_tx_out
       on ma_tx_out.tx_out_id = tx_out.id
     inner join public.multi_asset
-      on multi_asset.id = ident
+      on multi_asset.id = ma_tx_out.ident
     where
       block_no > 0
 ;
@@ -592,7 +592,7 @@ select
 \qecho
 
 drop table if exists x_summary;
-create table x_summary as
+create temporary table x_summary as
   select
       'block' :: varchar as "Table"
     , (select count(*) from x_block where comparison = 'chainindex-dbsync') as "Count of ChainIndex Minus DbSync"


### PR DESCRIPTION
The output index of collateral change is now correctly computed according to the ledger rules. The `marlowe-chain-indexer` vs `cardano-db-sync` comparison test passes on both `preprod` and `preview`:

```console

   Table   | Count of ChainIndex Minus DbSync | Count of DbSync Minus ChainIndex | Discrepancies? 
-----------+----------------------------------+----------------------------------+----------------
 block     |                                0 |                                0 | f
 tx        |                                0 |                                0 | f
 metadata  |                                0 |                                0 | f
 txout     |                                0 |                                0 | f
 datum     |                                0 |                                0 | f
 txin      |                                0 |                                0 | f
 asset     |                                0 |                                0 | f
 assetmint |                                0 |                                0 | f
 assetout  |                                0 |                                0 | f
(9 rows)

 Any Failures? 
---------------
 f
(1 row)
```

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
