### PR TITLE
SCP-4410 Removed triple repetition of help text from marlowe-cli.

### DIFF
--- a/marlowe-cli/marlowe-cli.cabal
+++ b/marlowe-cli/marlowe-cli.cabal
@@ -1,13 +1,13 @@
 cabal-version: 2.2
 name: marlowe-cli
-version: 0.0.10.1
+version: 0.0.10.2
 license: Apache-2.0
 license-files:
   LICENSE
   NOTICE
 build-type: Simple
 maintainer: brian.bush@iohk.io
-stability: experimental
+stability: stable
 author: Brian W Bush
 synopsis:
   Command-line tool for running Marlowe financial contracts on Cardano Computation Layer

--- a/marlowe-cli/src/Language/Marlowe/CLI/Command/Util.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Command/Util.hs
@@ -16,7 +16,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
 
 
 module Language.Marlowe.CLI.Command.Util

--- a/marlowe-cli/src/Language/Marlowe/CLI/Orphans.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Orphans.hs
@@ -13,7 +13,6 @@
 
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 

--- a/marlowe-cli/src/Language/Marlowe/CLI/Plutus/Script/Utils.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Plutus/Script/Utils.hs
@@ -11,7 +11,7 @@ import Prettyprinter (pretty)
 
 import qualified Plutus.Script.Utils.V1.Typed.Scripts as V1
 import qualified Plutus.Script.Utils.V2.Typed.Scripts as V2
-import qualified PlutusTx as PlutusTx
+import qualified PlutusTx
 -- These types are common to Plutus V1 and V2
 import Cardano.Api (PlutusScriptV1)
 import Cardano.Api.Byron (PlutusScriptV2)

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cli.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cli.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe-cli"; version = "0.0.10.1"; };
+      identifier = { name = "marlowe-cli"; version = "0.0.10.2"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "brian.bush@iohk.io";

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cli.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cli.nix
@@ -11,7 +11,7 @@
     flags = { defer-plugin-errors = false; };
     package = {
       specVersion = "2.2";
-      identifier = { name = "marlowe-cli"; version = "0.0.10.1"; };
+      identifier = { name = "marlowe-cli"; version = "0.0.10.2"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "brian.bush@iohk.io";


### PR DESCRIPTION
Before:
```console
marlowe-cli : a command-line tool for Marlowe contracts

Usage: marlowe-cli [--version] 
                   (COMMAND | COMMAND | [--alonzo-era] (COMMAND | COMMAND) | 
                     --babbage-era (COMMAND | COMMAND))

  Utilities for Marlowe.

Available options:
  -h,--help                Show this help text
  --version                Show version.
  --alonzo-era             Read and write Alonzo transactions
  --babbage-era            Read and write Babbage transactions

High-level commands:
  run                      Run a contract.
  template                 Create a contract from a template.
  test                     Test contracts.

Low-level commands:
  contract                 Export contract address, validator, datum, or
                           redeemer.
  input                    Create inputs to a contract.
  role                     Export role address, validator, datum, or redeemer.
  transaction              Create and submit transactions.
  util                     Miscellaneous utilities.

High-level commands:
  run                      Run a contract.
  template                 Create a contract from a template.
  test                     Test contracts.

Low-level commands:
  contract                 Export contract address, validator, datum, or
                           redeemer.
  input                    Create inputs to a contract.
  role                     Export role address, validator, datum, or redeemer.
  transaction              Create and submit transactions.
  util                     Miscellaneous utilities.

High-level commands:
  run                      Run a contract.
  template                 Create a contract from a template.
  test                     Test contracts.

Low-level commands:
  contract                 Export contract address, validator, datum, or
                           redeemer.
  input                    Create inputs to a contract.
  role                     Export role address, validator, datum, or redeemer.
  transaction              Create and submit transactions.
  util                     Miscellaneous utilities.
```

After:
```console
marlowe-cli : a command-line tool for Marlowe contracts

Usage: marlowe-cli [--version] ([--alonzo-era | --babbage-era] 
                   (COMMAND | COMMAND))

  Utilities for Marlowe.

Available options:
  -h,--help                Show this help text
  --version                Show version.
  --alonzo-era             Specify the Alonzo era
  --babbage-era            Specify the Babbage era (default)

High-level commands:
  run                      Run a contract.
  template                 Create a contract from a template.
  test                     Test contracts.

Low-level commands:
  contract                 Export contract address, validator, datum, or
                           redeemer.
  input                    Create inputs to a contract.
  role                     Export role address, validator, datum, or redeemer.
  transaction              Create and submit transactions.
  util                     Miscellaneous utilities.
```

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
