### PR TITLE
SCP-5057 Fixed CIP-19 network tag for `FindTxsTo` and `FindTxsFor`.

### DIFF
--- a/marlowe-chain-sync/chainseekd/Main.hs
+++ b/marlowe-chain-sync/chainseekd/Main.hs
@@ -76,7 +76,7 @@ run Options{..} = withSocketsDo do
           chainSyncDependencies eventBackend = ChainSyncDependencies
             { databaseQueries = hoistDatabaseQueries
                 (either throwUsageError pure <=< Pool.use pool)
-                PostgreSQL.databaseQueries
+                $ PostgreSQL.databaseQueries networkId
             , acceptRunChainSeekServer = acceptRunServerPeerOverSocketWithLoggingWithHandshake
                 (narrowEventBackend ChainSeekServer eventBackend)
                 throwIO

--- a/marlowe-chain-sync/libchainseek/Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL.hs
+++ b/marlowe-chain-sync/libchainseek/Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL.hs
@@ -354,9 +354,9 @@ performFindTxsTo credentials point = do
       )
     addressParts = Set.toList credentials >>= \case
       PaymentKeyCredential pkh ->
-        (,unPaymentKeyHash pkh) . BS.pack . pure <$> [0x00, 0x20, 0x40, 0x60]
+        (,unPaymentKeyHash pkh) . BS.pack . pure <$> [0x00, 0x20, 0x40, 0x60] <> [0x01, 0x21, 0x41, 0x61]
       ScriptCredential sh ->
-        (,unScriptHash sh) . BS.pack . pure <$> [0x10, 0x30, 0x50, 0x70]
+        (,unScriptHash sh) . BS.pack . pure <$> [0x10, 0x30, 0x50, 0x70] <> [0x11, 0x31, 0x51, 0x71]
     foldTxs :: Fold ReadTxRow (Maybe BlockHeader, Map TxId Transaction)
     foldTxs = Fold foldTxs' (Nothing, mempty) id
 
@@ -527,9 +527,9 @@ performFindTxsFor credentials point = do
       )
     addressParts = Set.toList (NESet.toSet credentials) >>= \case
       PaymentKeyCredential pkh ->
-        (,unPaymentKeyHash pkh) . BS.pack . pure <$> [0x00, 0x20, 0x40, 0x60]
+        (,unPaymentKeyHash pkh) . BS.pack . pure <$> [0x00, 0x20, 0x40, 0x60] <> [0x01, 0x21, 0x41, 0x61]
       ScriptCredential sh ->
-        (,unScriptHash sh) . BS.pack . pure <$> [0x10, 0x30, 0x50, 0x70]
+        (,unScriptHash sh) . BS.pack . pure <$> [0x10, 0x30, 0x50, 0x70] <> [0x11, 0x31, 0x51, 0x71]
     foldTxs :: Fold ReadTxRow (Maybe BlockHeader, Map TxId Transaction)
     foldTxs = Fold foldTxs' (Nothing, mempty) id
 

--- a/marlowe-integration/src/Test/Integration/Marlowe/Local.hs
+++ b/marlowe-integration/src/Test/Integration/Marlowe/Local.hs
@@ -262,7 +262,7 @@ withLocalMarloweRuntime' MarloweRuntimeOptions{..} test = withRunInIO \runInIO -
 
       chainSeekDatabaseQueries = ChainSync.hoistDatabaseQueries
         (either (fail . show) pure <=< Pool.use pool)
-        ChainSync.databaseQueries
+        (ChainSync.databaseQueries localNodeNetworkId)
 
       marloweIndexerDatabaseQueries = Indexer.hoistDatabaseQueries
         (either (fail . show) pure <=< Pool.use pool)


### PR DESCRIPTION
The query functions `performFindTxsFor` and `performFindTxsAt` in `Language.Marlowe.Runtime.ChainSync.Database.PostgreSQL` were hardwired for testnets only: they ignored the [CIP-19 network binary tag](https://cips.cardano.org/cips/cip19/#binaryformat) for `mainnet`. This commit fixes the network tag for these two functions.

Tested manually on `mainnet` by comparing the output of `marlowe-pipe` to public explorers.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [ ] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested
