### PR TITLE
SCP-4901 - Add EvalValue command to spec client

### DIFF
--- a/marlowe-test/src/Spec/Marlowe/Service.hs
+++ b/marlowe-test/src/Spec/Marlowe/Service.hs
@@ -28,7 +28,7 @@ import Spec.Marlowe.Service.Serialization (roundtripSerialization)
 import Spec.Marlowe.Service.Types (Request(..), Response(..))
 
 import qualified Data.Aeson as A (Result(..), Value, fromJSON, object, toJSON, (.=))
-import qualified Language.Marlowe.Core.V1.Semantics as Marlowe (computeTransaction, playTrace)
+import qualified Language.Marlowe.Core.V1.Semantics as Marlowe (computeTransaction, evalValue, playTrace)
 
 
 -- | Respond to a request expressed as JSON.
@@ -58,5 +58,10 @@ handle ComputeTransaction{..} =
 handle PlayTrace{..} =
   let
     valueResponse = A.toJSON $ Marlowe.playTrace initialTime contract transactionInputs
+  in
+    pure RequestResponse{..}
+handle EvalValue{..} =
+  let
+    valueResponse = A.toJSON $ Marlowe.evalValue environment state value
   in
     pure RequestResponse{..}

--- a/marlowe-test/src/Spec/Marlowe/Service/Types.hs
+++ b/marlowe-test/src/Spec/Marlowe/Service/Types.hs
@@ -55,6 +55,12 @@ data Request =
     , contract :: Marlowe.Contract
     , initialTime :: POSIXTime
     }
+  | EvalValue
+    {
+      environment :: Marlowe.Environment
+    , state :: Marlowe.State
+    , value :: Marlowe.Value Marlowe.Observation
+    }
     deriving (Eq, Show)
 
 instance FromJSON Request where
@@ -67,6 +73,7 @@ instance FromJSON Request where
             "generate-random-value"        -> GenerateRandomValue <$> o A..: "typeId"
             "compute-transaction"          -> ComputeTransaction <$> o A..: "transactionInput" <*> o A..: "coreContract" <*> o A..: "state"
             "playtrace"                    -> PlayTrace <$> o A..: "transactionInputs" <*> o A..: "coreContract" <*> (POSIXTime <$> o A..: "initialTime")
+            "eval-value"                   -> EvalValue <$> o A..: "environment" <*> o A..: "state" <*> o A..: "value"
             request                        -> fail $ "Request not understood: " <> show request <> "."
 
 instance ToJSON Request where
@@ -99,7 +106,14 @@ instance ToJSON Request where
       , "coreContract" A..= contract
       , "initialTime" A..= getPOSIXTime initialTime
       ]
-
+  toJSON EvalValue{..} =
+    A.object
+      [
+        "request" A..= ("eval-value" :: String)
+      , "environment" A..= environment
+      , "state" A..= state
+      , "value" A..= value
+      ]
 
 data Response =
     InvalidRequest


### PR DESCRIPTION
This PR implements the `EvalValue` command added to the spec test tool in [this PR](https://github.com/input-output-hk/marlowe/pull/160)

Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [X] Relevant tickets are mentioned in commit messages
    - [X] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
    - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [X] Reviewer requested
