### PR TITLE
Create README.md for marlowe-integration-tests and extend it for marlowe-integration

### DIFF
--- a/marlowe-integration-tests/README.md
+++ b/marlowe-integration-tests/README.md
@@ -1,0 +1,30 @@
+# Marlowe integration tests
+
+The Marlowe integration tests are a suite of tests that verify the correct behavior of Marlowe on a local cluster. In order to run the tests, first make sure you check the prerequisites described in [the README.md of the marlowe-integration framework](../marlowe-integration/README.md).
+
+## Running the integration tests
+
+To run the integration tests, you can use the following commands:
+
+```bash
+cd marlowe-cardano
+cabal run marlowe-integration-tests
+```
+
+This command runs all the integration tests. If you want to run only a specific test or set of tests, you can use the `--match` option to filter the tests by name or pattern. For example, to run only the `Basic e2e scenario` test, you can use the following command:
+
+```bash
+cabal run marlowe-integration-tests -- --match "/Language.Marlowe.Runtime.Integration/Marlowe runtime API/Basic e2e scenario/"
+```
+
+This command runs only the test that matches the specified pattern.
+
+## Troubleshooting
+
+If you encounter issues with the PostgreSQL database or the Marlowe integration tests, here are some tips to help you troubleshoot:
+
+- Make sure the PostgreSQL service is running and listening on the correct port (`5432` by default).
+- Check the `pg_hba.conf` file to make sure it allows connections from the local host using the `postgres` user with no password.
+- Make sure the template database exists, by default it is `template1`.
+- Make sure you are running the integration tests from the `marlowe-cardano` directory, not `marlowe-cardano/marlowe-integration-tests`.
+- If you see error messages about the PostgreSQL database rejecting connections, check the PostgreSQL logs for clues.

--- a/marlowe-integration/README.md
+++ b/marlowe-integration/README.md
@@ -36,13 +36,12 @@ This configuration enables the PostgreSQL service, installs the `postgresql` pac
 
 ### Customizing the PostgreSQL configuration
 
-You can configure the connection settings by setting the following
-environment variables:
+You can configure the connection settings by exporting the following environment variables using the `export` command:
 - `MARLOWE_RT_TEST_DB_HOST` sets the host of the postgresql server (by default: `127.0.0.1`).
 - `MARLOWE_RT_TEST_DB_PORT` sets the port of the postgresql server (by default: `5432`).
-- `MARLOWE_RT_TEST_DB_USER` sets the user that will be used to connect to the postgresql server as part of the tests (by default: `postgresql`).
+- `MARLOWE_RT_TEST_DB_USER` sets the user that will be used to connect to the postgresql server as part of the tests (by default: `postgresql`). User must have rights to create databases (`CREATEDB`).
 - `MARLOWE_RT_TEST_DB_PASSWORD` sets the password that will be used to authenticate the connection to postgresql server as part of the tests (by default no password or the empty string).
-- `MARLOWE_RT_TEST_TEMP_DB` sets the template database to be used when creating test databases (by default `template1`).
+- `MARLOWE_RT_TEST_TEMP_DB` sets the template database to be used when creating test databases (by default `template1`), it needs to exist and be accessible by the user specified.
 - `MARLOWE_RT_TEST_CLEANUP_DATABASE` determines whether to delete the test databases after the tests (by default `true`).
 
 


### PR DESCRIPTION
I wrote a `README.md` for `marlowe-integration-tests` and later realised one already existed in `marlowe-integration`, so I used mine to extend the existing one, and also added a small one to `marlowe-integration-tests` that gives minimal instructions and points to the general one.

Also couple of typographical fixes.

Pre-submit checklist:
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
    - [x] Reviewer requested
