### PR TITLE
Delete rollback blocks when saving blocks

### DIFF
--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
@@ -39,6 +39,11 @@ commitBlocks blocks = H.statement (prepareParams blocks)
       ( INSERT INTO marlowe.block (id, slotNo, blockNo)
         SELECT * FROM blockInputs
       )
+    , deleteRollbackBlocks AS
+      ( DELETE FROM marlowe.rollbackBlock
+        USING blockInputs
+        WHERE blockInputs.id = rollbackBlock.fromBlock
+      )
 
     , txOutInputs (txId, txIx, blockId, address, lovelace) AS
       ( SELECT * FROM UNNEST ($4 :: bytea[], $5 :: smallint[], $6 :: bytea[], $7 :: bytea[], $8 :: bigint[])


### PR DESCRIPTION
Here is an issue that impacts `marlowe-indexer` when the node rolls back to genesis. Old blocks get marked as rolled back to Genesis, but these are not removed when adding the blocks back later.

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
    - [x] Reviewer requested
