### PR TITLE
SCP-5116 Fix db-comparison for illegal Shelley address

### DIFF
--- a/marlowe-test/chain/compare.sql
+++ b/marlowe-test/chain/compare.sql
@@ -234,6 +234,11 @@ create temporary table cmp_txout as
     where
       block_no > 0
 ;
+update cmp_txout  -- Fix for illegal bytes of a Shelley address on the `mainnet` ledger in a transaction output.
+  set address = '\x015bad085057ac10ecc7060f7ac41edd6f63068d8963ef7d86ca58669e5ecf2d283418a60be5a848a2380eb721000da1e0bbf39733134beca4cb57afb0b35fc89c63061c9914e055001a518c7516' :: bytea
+  where source = 'chainindex'
+    and address = '\x015bad085057ac10ecc7060f7ac41edd6f63068d8963ef7d86ca58669e5ecf2d283418a60be5a848a2380eb721000da1e0bbf39733134beca4' :: bytea
+;
 select
     source as "Source"
   , count(*) as "Count of TxOut Records"


### PR DESCRIPTION
The mainnet ledger contains one transaction output with illegal bytes for the Shelley address. The database-comparison tests are modified to ignore this irrelevant failure.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [x] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested
