### PR TITLE
SCP-5054 Handle epoch-boundary block in chain-indexer tests

### DIFF
--- a/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/Database/PostgreSQL.hs
+++ b/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/Database/PostgreSQL.hs
@@ -339,6 +339,13 @@ data AssetOut = AssetOut TxId TxIx SlotNo PolicyId AssetName Quantity
 -- writes are atomic at the block level (i.e. it should be impossible for a
 -- block to be partially saved). This is because the server may be shut down at
 -- any moment, and the connection to the database will be severed.
+--
+-- NOTE: Mainnet epochs 0 through 175 contain epoch-boundary blocks (EBBs) between
+-- the last block of one epoch and the first block of the new epoch. Such blocks
+-- have a hash, but never any transactions, and are recorded in this index as
+-- belonging to the new epoch. Beware that if a unique key is ever added to the
+-- index for block or slot number, then these blocks will violate that new
+-- constraint.
 commitBlocks :: CommitBlocks Transaction
 commitBlocks = CommitBlocks \blocks ->
   let

--- a/marlowe-test/chain/compare.sh
+++ b/marlowe-test/chain/compare.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TIMESTAMP="$(date -u +%Y%m%d%H)"
+TIMESTAMP="$(date -u +%Y%m%d%H%M)"
 COMMIT=$(git rev-parse HEAD)
 
 echo "PGHOST=$PGHOST"

--- a/marlowe-test/chain/compare.sql
+++ b/marlowe-test/chain/compare.sql
@@ -52,7 +52,7 @@ create temporary table cmp_block as
     inner join public.block
       on slot_no <= max_slotno
     where
-      block_no > 0
+      slot_no > 0
 ;
 select
     source as "Source"

--- a/marlowe-test/chain/compare.sql
+++ b/marlowe-test/chain/compare.sql
@@ -20,7 +20,7 @@ create temporary table max_slotno as
     inner join public.block as dblock
       on cblock.id = dblock.hash
 ;
-select max_slotno as "Latest Block in Common"
+select max_slotno as "Slot for Latest Block in Common"
   from max_slotno
 ;
 \copy max_slotno to 'out/latest-block.csv' CSV HEADER

--- a/marlowe-test/chain/compare.sql
+++ b/marlowe-test/chain/compare.sql
@@ -42,6 +42,10 @@ create temporary table cmp_block as
       on slotno <= max_slotno
     where slotno > 0
       and rollbacktoblock is null
+      -- This eliminates epoch-boundary blocks (EBBs) that
+      -- `marlowe-chain-indexer` and `cardano-db-sync` record
+      -- differently. Those blocks never contain transactions.
+      and id not in (select hash from public.block where slot_no is null)
   union all
   select
       'dbsync'


### PR DESCRIPTION
I upgraded the `marlowe-chain-indexer` vs `cardano-db-sync` comparison test to account for epoch-boundary blocks (EBBs) on `mainnet`. I also added a comment in the PostgreSQL code noting the existence of EBBs.

The comparison tests at aff3683e0ff3281ef76b03177afec66e3665510c passed (for blocks) and are recorded at http://testing.marlowe.run/database/. We still have unrelated comparison failures for `mainnet` only.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested
