### PR TITLE
SCP-5132 Withdrawal query changes

### DIFF
--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/MarloweQuery.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/MarloweQuery.hs
@@ -11,7 +11,9 @@ import Data.Foldable (for_)
 import Data.Functor (void)
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (fromJust)
+import Data.Maybe (fromJust, mapMaybe)
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Language.Marlowe.Protocol.Query.Client
   ( MarloweQueryClient
   , getContractHeaders
@@ -23,7 +25,7 @@ import Language.Marlowe.Protocol.Query.Client
   )
 import Language.Marlowe.Protocol.Query.Types
 import Language.Marlowe.Runtime.Cardano.Api (fromCardanoTxId)
-import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, TransactionMetadata(..), TxId, TxOutRef(..))
+import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, PolicyId, TransactionMetadata(..), TxId, TxOutRef(..))
 import Language.Marlowe.Runtime.Client (runMarloweQueryClient)
 import Language.Marlowe.Runtime.Core.Api
   (ContractId(..), MarloweVersion(..), MarloweVersionTag(..), Payout(..), TransactionScriptOutput(..))
@@ -190,15 +192,104 @@ getTransactionSpec = describe "getTransaction" do
       liftIO $ actual `shouldBe` expected
 
 getWithdrawalsSpec :: SpecWith MarloweQueryTestData
-getWithdrawalsSpec = describe "getWithdrawals" do
-  for_ (Unknown : (Known <$> allContractNos)) \contractNo -> do
-    it (show contractNo) $ runMarloweQueryIntegrationTest \testData -> do
-      let
-        expected = case contractNo of
-          Unknown -> Nothing
-          Known contractNo' -> Just $ contractNoToWithdrawals testData contractNo'
-      actual <- getWithdrawals $ contractNoToContractId testData contractNo
-      liftIO $ actual `shouldBe` expected
+getWithdrawalsSpec = focus $ describe "getWithdrawals" do
+  let
+    withdrawalNoToInt contractNos
+      | Set.null contractNos = \case
+          Withdrawal1 -> Just @Int 0
+          Withdrawal2 -> Just @Int 1
+      | otherwise = \no -> lookup no
+          $ flip zip [0..]
+          $ filter (applyRoleCurrencyFilter contractNos) allWithdrawalNos
+
+    allRanges :: [Range (WithUnknown WithdrawalNo)]
+    allRanges = do
+      rangeStart <- Nothing : Just Unknown : (Just . Known <$> allWithdrawalNos)
+      rangeOffset <- [-1..3]
+      rangeLimit <- [-1..3]
+      rangeDirection <- [Ascending, Descending]
+      pure Range{..}
+
+    withdrawalNoToWithdrawal :: MarloweQueryTestData -> WithdrawalNo -> Withdrawal
+    withdrawalNoToWithdrawal MarloweQueryTestData{..} withdrawalNo = Withdrawal
+      { block
+      , withdrawnPayouts
+      , withdrawalTx = fromCardanoTxId $ getTxId txBody
+      }
+      where
+        ((txBody, block), withdrawnPayouts) = case withdrawalNo of
+          Withdrawal1 ->
+            ( contract1Step5
+            , case inputsAppliedToTransaction (returnDepositBlock contract1Step4) (returnDeposited contract1Step4) of
+                Core.Transaction{output=Core.TransactionOutput{payouts}} -> Map.keysSet payouts
+            )
+          Withdrawal2 ->
+            ( contract2Step5
+            , case inputsAppliedToTransaction (returnDepositBlock contract2Step4) (returnDeposited contract2Step4) of
+                Core.Transaction{output=Core.TransactionOutput{payouts}} -> Map.keysSet payouts
+            )
+
+    getNext :: Set ContractNo -> Order -> WithdrawalNo -> Maybe WithdrawalNo
+    getNext contractNos Ascending = \case
+      Withdrawal1 -> Withdrawal2 <$ withdrawalNoToInt contractNos Withdrawal2
+      Withdrawal2 -> Nothing
+    getNext contractNos Descending = \case
+      Withdrawal1 -> Nothing
+      Withdrawal2 -> Withdrawal1 <$ withdrawalNoToInt contractNos Withdrawal1
+
+    applyRoleCurrencyFilter :: Set ContractNo -> WithdrawalNo -> Bool
+    applyRoleCurrencyFilter contractNos
+      | Set.null contractNos = const True
+      | otherwise = \case
+          Withdrawal1 -> Set.member Contract1 contractNos
+          Withdrawal2 -> Set.member Contract2 contractNos
+
+    expectedPage :: Set ContractNo -> Range (WithUnknown WithdrawalNo) -> Maybe (Page WithdrawalNo WithdrawalNo)
+    expectedPage contractNos Range{..}
+      | rangeLimit <= 0 || rangeOffset < 0 = Nothing
+      | otherwise = case rangeStart of
+        Just Unknown -> Nothing
+        Just (Known withdrawalNo) -> do
+          withdrawalPos <- withdrawalNoToInt contractNos withdrawalNo
+          maxPos <- maximum $ withdrawalNoToInt contractNos <$> allWithdrawalNos
+          expectedPage contractNos Range
+            { rangeStart = Nothing
+            , rangeOffset = rangeOffset + case rangeDirection of
+                Ascending -> withdrawalPos
+                Descending -> maxPos - withdrawalPos
+            , ..
+            }
+        Nothing -> do
+          let
+            items = take rangeLimit $ drop rangeOffset $ filter (applyRoleCurrencyFilter contractNos) case rangeDirection of
+              Ascending -> allWithdrawalNos
+              Descending -> reverse allWithdrawalNos
+            nextRange = case (reverse items, rangeDirection) of
+              ([], _) -> Nothing
+              (lastItem : _, _) -> do
+                nextItem <- getNext contractNos rangeDirection lastItem
+                Just Range
+                  { rangeStart = Just nextItem
+                  , rangeOffset = 0
+                  , ..
+                  }
+            totalCount = length $ mapMaybe (withdrawalNoToInt contractNos) allWithdrawalNos
+          pure Page{..}
+
+  for_ allRanges \range -> do
+    for_ (Set.toList $ Set.powerSet $ Set.fromList allContractNos) \roleCurrencies -> do
+      let expectedSymbolic = expectedPage roleCurrencies range
+      it (show (roleCurrencies, range) <> " => " <> show expectedSymbolic) $ runMarloweQueryIntegrationTest \testData -> do
+        actual <- getWithdrawals (WithdrawalFilter $ Set.map (contractNoToRoleCurrency testData) roleCurrencies) $ withdrawalNoToWithdrawalId testData <$> range
+        let
+          expectedConcrete = fmap
+            (bimap (withdrawalNoToWithdrawalId testData . Known) (withdrawalNoToWithdrawal testData))
+            expectedSymbolic
+        liftIO $ actual `shouldBe` expectedConcrete
+
+contractNoToRoleCurrency :: MarloweQueryTestData -> ContractNo -> PolicyId
+contractNoToRoleCurrency testData contractNo = case contractNoToContractCreated testData contractNo of
+  ContractCreated{..} -> rolesCurrency
 
 getWithdrawalSpec :: SpecWith MarloweQueryTestData
 getWithdrawalSpec = describe "getWithdrawal" do
@@ -233,9 +324,11 @@ setup runSpec = withLocalMarloweRuntime $ runIntegrationTest do
   contract2Step2 <- chooseGimmeTheMoney contract2Step1
   contract2Step3 <- sendNotify contract2Step2
   contract2Step4 <- makeReturnDeposit contract2Step3
+  contract2Step5 <- withdrawPartyAFunds contract2Step4
   contract3Step1 <- makeInitialDeposit contract3
   contract3Step2 <- chooseGimmeTheMoney contract3Step1
   contract3Step3 <- sendNotify contract3Step2
+  contract3Step4 <- makeReturnDeposit contract3Step3
   liftIO $ runSpec MarloweQueryTestData{..}
 
 data MarloweQueryTestData = MarloweQueryTestData
@@ -253,10 +346,12 @@ data MarloweQueryTestData = MarloweQueryTestData
   , contract2Step2 :: StandardContractChoiceMade 'V1
   , contract2Step3 :: StandardContractNotified 'V1
   , contract2Step4 :: StandardContractClosed 'V1
+  , contract2Step5 :: (TxBody BabbageEra, BlockHeader)
   , contract3 :: StandardContractInit 'V1
   , contract3Step1 :: StandardContractFundsDeposited 'V1
   , contract3Step2 :: StandardContractChoiceMade 'V1
   , contract3Step3 :: StandardContractNotified 'V1
+  , contract3Step4 :: StandardContractClosed 'V1
   , contract4 :: StandardContractInit 'V1
   }
 
@@ -268,6 +363,11 @@ data ContractNo
   | Contract2
   | Contract3
   | Contract4
+  deriving (Show, Eq, Ord, Enum, Bounded)
+
+data WithdrawalNo
+  = Withdrawal1
+  | Withdrawal2
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 data TxNo
@@ -282,10 +382,14 @@ data TxNo
   | Contract3Step1
   | Contract3Step2
   | Contract3Step3
+  | Contract3Step4
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 allContractNos :: [ContractNo]
 allContractNos = [minBound..maxBound]
+
+allWithdrawalNos :: [WithdrawalNo]
+allWithdrawalNos = [minBound..maxBound]
 
 allTxNos :: [TxNo]
 allTxNos = [minBound..maxBound]
@@ -297,6 +401,12 @@ contractNoToContractId MarloweQueryTestData{..} = \case
   Known Contract2 -> standardContractId contract2
   Known Contract3 -> standardContractId contract3
   Known Contract4 -> standardContractId contract4
+
+withdrawalNoToWithdrawalId :: MarloweQueryTestData -> WithUnknown WithdrawalNo -> TxId
+withdrawalNoToWithdrawalId MarloweQueryTestData{..} = \case
+  Unknown -> "0000000000000000000000000000000000000000000000000000000000000000"
+  Known Withdrawal1 -> fromCardanoTxId $ getTxId $ fst contract1Step5
+  Known Withdrawal2 -> fromCardanoTxId $ getTxId $ fst contract2Step5
 
 contractOrTxNoToTxId :: MarloweQueryTestData -> WithUnknown (Either ContractNo TxNo) -> TxId
 contractOrTxNoToTxId testData = \case
@@ -318,6 +428,7 @@ txNoToInputsApplied MarloweQueryTestData{..} = \case
   Contract3Step1 -> initialFundsDeposited contract3Step1
   Contract3Step2 -> gimmeTheMoneyChosen contract3Step2
   Contract3Step3 -> notified contract3Step3
+  Contract3Step4 -> returnDeposited contract3Step4
 
 txNoToInput :: MarloweQueryTestData -> TxNo -> TxOutRef
 txNoToInput MarloweQueryTestData{..} = \case
@@ -332,6 +443,7 @@ txNoToInput MarloweQueryTestData{..} = \case
   Contract3Step1 -> unContractId $ standardContractId contract3
   Contract3Step2 -> utxo $ fromJust $ output $ initialFundsDeposited contract3Step1
   Contract3Step3 -> utxo $ fromJust $ output $ gimmeTheMoneyChosen contract3Step2
+  Contract3Step4 -> utxo $ fromJust $ output $ notified contract3Step3
 
 txNoToConsumer :: MarloweQueryTestData -> TxNo -> Maybe TxId
 txNoToConsumer MarloweQueryTestData{..} = fmap inputsAppliedTxId . \case
@@ -345,7 +457,8 @@ txNoToConsumer MarloweQueryTestData{..} = fmap inputsAppliedTxId . \case
   Contract2Step4 -> Nothing
   Contract3Step1 -> Just $ gimmeTheMoneyChosen contract3Step2
   Contract3Step2 -> Just $ notified contract3Step3
-  Contract3Step3 -> Nothing
+  Contract3Step3 -> Just $ returnDeposited contract3Step4
+  Contract3Step4 -> Nothing
 
 txNoToBlockHeader :: MarloweQueryTestData -> TxNo -> BlockHeader
 txNoToBlockHeader MarloweQueryTestData{..} = \case
@@ -360,6 +473,7 @@ txNoToBlockHeader MarloweQueryTestData{..} = \case
   Contract3Step1 -> initialDepositBlock contract3Step1
   Contract3Step2 -> choiceBlock contract3Step2
   Contract3Step3 -> notifiedBlock contract3Step3
+  Contract3Step4 -> returnDepositBlock contract3Step4
 
 txNoToTxId :: MarloweQueryTestData -> TxNo -> TxId
 txNoToTxId testData = inputsAppliedTxId . txNoToInputsApplied testData

--- a/marlowe-runtime/marlowe-indexer/deploy/indexRoleCurrency.sql
+++ b/marlowe-runtime/marlowe-indexer/deploy/indexRoleCurrency.sql
@@ -1,0 +1,10 @@
+-- Deploy marlowe:indexRoleCurrency to pg
+-- requires: schema
+
+BEGIN;
+
+CREATE INDEX contractTxOut_rolesCurrency ON marlowe.contractTxOut USING BTREE (rolesCurrency);
+CREATE INDEX payoutTxOut_rolesCurrency ON marlowe.payoutTxOut USING BTREE (rolesCurrency);
+CREATE INDEX payoutTxOut_rolesCurrency_role ON marlowe.payoutTxOut USING BTREE (rolesCurrency, role);
+
+COMMIT;

--- a/marlowe-runtime/marlowe-indexer/revert/indexRoleCurrency.sql
+++ b/marlowe-runtime/marlowe-indexer/revert/indexRoleCurrency.sql
@@ -1,0 +1,7 @@
+-- Revert marlowe:indexRoleCurrency from pg
+
+BEGIN;
+
+-- XXX Add DDLs here.
+
+COMMIT;

--- a/marlowe-runtime/marlowe-indexer/sqitch.plan
+++ b/marlowe-runtime/marlowe-indexer/sqitch.plan
@@ -7,3 +7,4 @@ block-cols [schema] 2023-01-30T21:31:32Z Jamie Bertram <jamie.bertram@iohk.io> #
 rollback [schema] 2023-02-01T13:09:33Z Jamie Bertram <jamie.bertram@iohk.io> # Moves rollback info to a separate table for safety.
 withdrawalCreateNotNull [block-cols] 2023-02-03T19:58:45Z Jamie Bertram <jamie.bertram@iohk.io> # Adds NOT NULL constraints to withdrawalTxIn createTx columns.
 fixPayouts [schema] 2023-02-03T20:02:36Z Jamie Bertram <jamie.bertram@iohk.io> # Fixes payout columns.
+indexRoleCurrency [schema] 2023-02-28T21:16:41Z Jamie Bertram <jamie.bertram@iohk.io> # Fixes adds index to role currency columns.

--- a/marlowe-runtime/marlowe-indexer/verify/indexRoleCurrency.sql
+++ b/marlowe-runtime/marlowe-indexer/verify/indexRoleCurrency.sql
@@ -1,0 +1,7 @@
+-- Verify marlowe:indexRoleCurrency on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Client.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Client.hs
@@ -54,8 +54,8 @@ request req = ClientRequest req $ pure . pure
 getWithdrawal :: Applicative m => TxId -> MarloweQueryClient m (Maybe Withdrawal)
 getWithdrawal = request . ReqWithdrawal
 
-getWithdrawals :: Applicative m => ContractId -> MarloweQueryClient m (Maybe [Withdrawal])
-getWithdrawals = request . ReqWithdrawals
+getWithdrawals :: Applicative m => WithdrawalFilter -> Range TxId -> MarloweQueryClient m (Maybe (Page TxId Withdrawal))
+getWithdrawals = fmap request . ReqWithdrawals
 
 getContractHeaders :: Applicative m => Range ContractId -> MarloweQueryClient m (Maybe (Page ContractId ContractHeader))
 getContractHeaders = request . ReqContractHeaders

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Server.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Server.hs
@@ -23,7 +23,7 @@ marloweQueryServer
   -> (TxId -> m (Maybe SomeTransaction))
   -> (ContractId -> m (Maybe SomeTransactions))
   -> (TxId -> m (Maybe Withdrawal))
-  -> (ContractId -> m (Maybe [Withdrawal]))
+  -> (WithdrawalFilter -> Range TxId -> m (Maybe (Page TxId Withdrawal)))
   -> MarloweQueryServer m ()
 marloweQueryServer getContractHeaders getContractState getTransaction getTransactions getWithdrawal getWithdrawals = go
   where
@@ -39,5 +39,5 @@ marloweQueryServer getContractHeaders getContractState getTransaction getTransac
       ReqTransaction txId -> getTransaction txId
       ReqTransactions contractId -> getTransactions contractId
       ReqWithdrawal txId -> getWithdrawal txId
-      ReqWithdrawals contractId -> getWithdrawals contractId
+      ReqWithdrawals wFilter range -> getWithdrawals wFilter range
       ReqBoth a b -> concurrently (serviceRequest a) (serviceRequest b)

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Types.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -14,7 +15,7 @@ import Data.Set (Set)
 import Data.Type.Equality (testEquality, type (:~:)(Refl))
 import GHC.Generics (Generic)
 import GHC.Show (showCommaSpace, showSpace)
-import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, PolicyId, TransactionMetadata, TxId, TxOutRef)
+import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, PolicyId, TokenName, TransactionMetadata, TxId, TxOutRef)
 import Language.Marlowe.Runtime.Core.Api
   ( ContractId
   , MarloweVersion(..)
@@ -362,9 +363,18 @@ deriving instance Eq (ContractState 'V1)
 deriving instance ToJSON (ContractState 'V1)
 deriving instance Binary (ContractState 'V1)
 
+data PayoutRef = PayoutRef
+  { contractId :: ContractId
+  , payout :: TxOutRef
+  , rolesCurrency :: PolicyId
+  , role :: TokenName
+  }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (ToJSON, Binary)
+
 data Withdrawal = Withdrawal
   { block :: BlockHeader
-  , withdrawnPayouts :: Set TxOutRef
+  , withdrawnPayouts :: Map TxOutRef PayoutRef
   , withdrawalTx :: TxId
   }
   deriving stock (Eq, Ord, Show, Generic)

--- a/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Types.hs
+++ b/marlowe-runtime/sync-api/Language/Marlowe/Protocol/Query/Types.hs
@@ -40,13 +40,19 @@ data MarloweQuery where
 instance HasSignature MarloweQuery where
   signature _ = "MarloweQuery"
 
+newtype WithdrawalFilter = WithdrawalFilter
+  { roleCurrencies :: Set PolicyId
+  }
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving anyclass (ToJSON, Binary)
+
 data Request a where
   ReqContractHeaders :: Range ContractId -> Request (Maybe (Page ContractId ContractHeader))
   ReqContractState :: ContractId -> Request (Maybe SomeContractState)
   ReqTransaction :: TxId -> Request (Maybe SomeTransaction)
   ReqTransactions :: ContractId -> Request (Maybe SomeTransactions)
   ReqWithdrawal :: TxId -> Request (Maybe Withdrawal)
-  ReqWithdrawals :: ContractId -> Request (Maybe [Withdrawal])
+  ReqWithdrawals :: WithdrawalFilter -> Range TxId -> Request (Maybe (Page TxId Withdrawal))
   ReqBoth :: Request a -> Request b -> Request (a, b)
 
 data SomeRequest where
@@ -65,7 +71,7 @@ instance Binary SomeRequest where
       0x03 -> SomeRequest . ReqTransaction <$> get
       0x04 -> SomeRequest . ReqTransactions <$> get
       0x05 -> SomeRequest . ReqWithdrawal <$> get
-      0x06 -> SomeRequest . ReqWithdrawals <$> get
+      0x06 -> SomeRequest <$> (ReqWithdrawals <$> get <*> get)
       _ -> fail "Invalid Request tag"
 
   put (SomeRequest req) = case req of
@@ -88,9 +94,10 @@ instance Binary SomeRequest where
     ReqWithdrawal txId -> do
       putWord8 0x05
       put txId
-    ReqWithdrawals contractId -> do
+    ReqWithdrawals wFilter range -> do
       putWord8 0x06
-      put contractId
+      put wFilter
+      put range
 
 deriving instance Eq (Request a)
 deriving instance Show (Request a)
@@ -114,8 +121,11 @@ instance ToJSON (Request a) where
     ReqWithdrawal txId -> object
       [ "get-withdrawal" .= txId
       ]
-    ReqWithdrawals contractId -> object
-      [ "get-withdrawals" .= contractId
+    ReqWithdrawals wFilter range -> object
+      [ "get-withdrawals" .= object
+        [ "filter" .= wFilter
+        , "range" .= range
+        ]
       ]
 
 data StRes a where
@@ -124,7 +134,7 @@ data StRes a where
   TokTransaction :: StRes (Maybe SomeTransaction)
   TokTransactions :: StRes (Maybe SomeTransactions)
   TokWithdrawal :: StRes (Maybe Withdrawal)
-  TokWithdrawals :: StRes (Maybe [Withdrawal])
+  TokWithdrawals :: StRes (Maybe (Page TxId Withdrawal))
   TokBoth :: StRes a -> StRes b -> StRes (a, b)
 
 deriving instance Show (StRes a)
@@ -428,8 +438,8 @@ instance MessageEq MarloweQuery where
       reqEq (ReqTransactions _) _ = False
       reqEq (ReqWithdrawal txId) (ReqWithdrawal txId') = txId == txId'
       reqEq (ReqWithdrawal _) _ = False
-      reqEq (ReqWithdrawals contractId) (ReqWithdrawals contractId') = contractId == contractId'
-      reqEq (ReqWithdrawals _) _ = False
+      reqEq (ReqWithdrawals wFilter range) (ReqWithdrawals filter' range') = wFilter == filter' && range == range'
+      reqEq (ReqWithdrawals _ _) _ = False
 
       resultEq :: StRes a -> StRes b -> a -> b -> Bool
       resultEq (TokBoth ta tb) (TokBoth ta' tb') = \(a, b) (a', b') ->
@@ -455,5 +465,5 @@ requestToSt = \case
   ReqTransaction _ -> TokTransaction
   ReqTransactions _ -> TokTransactions
   ReqWithdrawal _ -> TokWithdrawal
-  ReqWithdrawals _ -> TokWithdrawals
+  ReqWithdrawals _ _ -> TokWithdrawals
   ReqBoth r1 r2 -> TokBoth (requestToSt r1) (requestToSt r2)

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL.hs
@@ -32,4 +32,4 @@ databaseQueries = DatabaseQueries
   (T.transaction T.Serializable T.Read . getTransaction)
   (T.transaction T.Serializable T.Read . getTransactions)
   (T.transaction T.Serializable T.Read . getWithdrawal)
-  (T.transaction T.Serializable T.Read . getWithdrawals)
+  (fmap (T.transaction T.Serializable T.Read) . getWithdrawals)

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetWithdrawal.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetWithdrawal.hs
@@ -7,33 +7,65 @@ module Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetWithdrawal
 
 import Data.ByteString (ByteString)
 import Data.Int (Int16, Int64)
-import qualified Data.Set as Set
+import qualified Data.Map as Map
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Hasql.TH (maybeStatement)
 import qualified Hasql.Transaction as T
 import Language.Marlowe.Protocol.Query.Types
-import Language.Marlowe.Runtime.ChainSync.Api (TxId(..))
-import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetContractState (decodeBlockHeader, decodeTxOutRef)
+import Language.Marlowe.Runtime.ChainSync.Api (PolicyId(..), TokenName(..), TxId(..))
+import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetContractState
+  (decodeBlockHeader, decodeContractId, decodeTxOutRef)
 
 getWithdrawal :: TxId -> T.Transaction (Maybe Withdrawal)
 getWithdrawal txId = fmap decodeWithdrawal <$> T.statement (unTxId txId)
   [maybeStatement|
     SELECT
-      txId :: bytea,
-      slotNo :: bigint,
-      blockId :: bytea,
-      blockNo :: bigint,
-      ARRAY_AGG(payoutTxId) :: bytea[],
-      ARRAY_AGG(payoutTxIx) :: smallint[]
+      withdrawalTxIn.txId :: bytea,
+      withdrawalTxIn.slotNo :: bigint,
+      withdrawalTxIn.blockId :: bytea,
+      withdrawalTxIn.blockNo :: bigint,
+      ARRAY_AGG(withdrawalTxIn.payoutTxId) :: bytea[],
+      ARRAY_AGG(withdrawalTxIn.payoutTxIx) :: smallint[],
+      ARRAY_AGG(withdrawalTxIn.createTxId) :: bytea[],
+      ARRAY_AGG(withdrawalTxIn.createTxIx) :: smallint[],
+      ARRAY_AGG(payoutTxOut.rolesCurrency) :: bytea[],
+      ARRAY_AGG(payoutTxOut.role) :: bytea[]
     FROM marlowe.withdrawalTxIn
-    WHERE txId = $1 :: bytea
-    GROUP BY slotNo, blockId, blockNo, txId
+    JOIN marlowe.payoutTxOut
+      ON withdrawalTxIn.payoutTxId = payoutTxOut.txId
+      AND withdrawalTxIn.payoutTxIx = payoutTxOut.txIx
+    WHERE withdrawalTxIn.txId = $1 :: bytea
+    GROUP BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
   |]
 
-decodeWithdrawal :: (ByteString, Int64, ByteString, Int64, Vector ByteString, Vector Int16) -> Withdrawal
-decodeWithdrawal (txId, slot, hash, block, payoutTxIds, payoutTxIxs) = Withdrawal
+type ResultRow =
+  ( ByteString
+  , Int64
+  , ByteString
+  , Int64
+  , Vector ByteString
+  , Vector Int16
+  , Vector ByteString
+  , Vector Int16
+  , Vector ByteString
+  , Vector ByteString
+  )
+
+decodeWithdrawal :: ResultRow -> Withdrawal
+decodeWithdrawal (txId, slot, hash, block, payoutTxIds, payoutTxIxs, createTxIds, createTxIxs, roleCurrencies, roles) = Withdrawal
   { block = decodeBlockHeader slot hash block
-  , withdrawnPayouts = Set.fromList $ zipWith decodeTxOutRef (V.toList payoutTxIds) (V.toList payoutTxIxs)
+  , withdrawnPayouts = Map.fromList
+      $ V.toList
+      $ V.zip (V.zipWith decodeTxOutRef payoutTxIds payoutTxIxs)
+      $ V.zipWith6 decodePayoutRef createTxIds createTxIxs payoutTxIds payoutTxIxs roleCurrencies roles
   , withdrawalTx = TxId txId
+  }
+
+decodePayoutRef :: ByteString -> Int16 -> ByteString -> Int16 -> ByteString -> ByteString -> PayoutRef
+decodePayoutRef createTxId createTxIx txId txIx rolesCurrency role = PayoutRef
+  { contractId = decodeContractId createTxId createTxIx
+  , payout = decodeTxOutRef txId txIx
+  , rolesCurrency = PolicyId rolesCurrency
+  , role = TokenName role
   }

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetWithdrawals.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetWithdrawals.hs
@@ -61,7 +61,7 @@ getWithdrawals wFilter@WithdrawalFilter{..} Range{..} = Just <$> do
         ORDER BY slotNo DESC, blockId DESC, blockNo DESC, txId DESC
         OFFSET ($1 :: int) ROWS
         FETCH NEXT ($2 :: int) ROWS ONLY
-      |] (foldPage decodeTxId decodeWithdrawal rangeLimit Descending totalCount)
+      |] (foldPage decodeTxId decodeWithdrawal rangeLimit rangeDirection totalCount)
 
     (True, Ascending) -> T.statement nullFilterParams $
       [foldStatement|
@@ -77,7 +77,7 @@ getWithdrawals wFilter@WithdrawalFilter{..} Range{..} = Just <$> do
         ORDER BY slotNo, blockId, blockNo, txId
         OFFSET ($1 :: int) ROWS
         FETCH NEXT ($2 :: int) ROWS ONLY
-      |] (foldPage decodeTxId decodeWithdrawal rangeLimit Descending totalCount)
+      |] (foldPage decodeTxId decodeWithdrawal rangeLimit rangeDirection totalCount)
 
     (False, Descending) -> T.statement nonNullFilterParams $
       [foldStatement|
@@ -97,7 +97,7 @@ getWithdrawals wFilter@WithdrawalFilter{..} Range{..} = Just <$> do
         ORDER BY withdrawalTxIn.slotNo DESC, withdrawalTxIn.blockId DESC, withdrawalTxIn.blockNo DESC, withdrawalTxIn.txId DESC
         OFFSET ($1 :: int) ROWS
         FETCH NEXT ($2 :: int) ROWS ONLY
-      |] (foldPage decodeTxId decodeWithdrawal rangeLimit Descending totalCount)
+      |] (foldPage decodeTxId decodeWithdrawal rangeLimit rangeDirection totalCount)
 
     (False, Ascending) -> T.statement nonNullFilterParams $
       [foldStatement|
@@ -117,7 +117,7 @@ getWithdrawals wFilter@WithdrawalFilter{..} Range{..} = Just <$> do
         ORDER BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
         OFFSET ($1 :: int) ROWS
         FETCH NEXT ($2 :: int) ROWS ONLY
-      |] (foldPage decodeTxId decodeWithdrawal rangeLimit Descending totalCount)
+      |] (foldPage decodeTxId decodeWithdrawal rangeLimit rangeDirection totalCount)
   where
     -- Load one extra item so we can detect when we've hit the end
     nullFilterParams = (fromIntegral rangeOffset, fromIntegral rangeLimit + 1)
@@ -177,7 +177,7 @@ getWithdrawalsFrom WithdrawalFilter{..} totalCount (pivotSlot, pivotTxId) offset
         ORDER BY slotNo DESC, blockId DESC, blockNo DESC, txId DESC
         OFFSET ($3 :: int) ROWS
         FETCH NEXT ($4 :: int) ROWS ONLY
-      |] (foldPage decodeTxId decodeWithdrawal limit Descending totalCount)
+      |] (foldPage decodeTxId decodeWithdrawal limit order totalCount)
 
     (True, Ascending) -> T.statement nullFilterParams $
       [foldStatement|
@@ -194,7 +194,7 @@ getWithdrawalsFrom WithdrawalFilter{..} totalCount (pivotSlot, pivotTxId) offset
         ORDER BY slotNo, blockId, blockNo, txId
         OFFSET ($3 :: int) ROWS
         FETCH NEXT ($4 :: int) ROWS ONLY
-      |] (foldPage decodeTxId decodeWithdrawal limit Descending totalCount)
+      |] (foldPage decodeTxId decodeWithdrawal limit order totalCount)
 
     (False, Descending) -> T.statement nonNullFilterParams $
       [foldStatement|
@@ -215,7 +215,7 @@ getWithdrawalsFrom WithdrawalFilter{..} totalCount (pivotSlot, pivotTxId) offset
         ORDER BY withdrawalTxIn.slotNo DESC, withdrawalTxIn.blockId DESC, withdrawalTxIn.blockNo DESC, withdrawalTxIn.txId DESC
         OFFSET ($3 :: int) ROWS
         FETCH NEXT ($4 :: int) ROWS ONLY
-      |] (foldPage decodeTxId decodeWithdrawal limit Descending totalCount)
+      |] (foldPage decodeTxId decodeWithdrawal limit order totalCount)
 
     (False, Ascending) -> T.statement nonNullFilterParams $
       [foldStatement|
@@ -236,7 +236,7 @@ getWithdrawalsFrom WithdrawalFilter{..} totalCount (pivotSlot, pivotTxId) offset
         ORDER BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
         OFFSET ($3 :: int) ROWS
         FETCH NEXT ($4 :: int) ROWS ONLY
-      |] (foldPage decodeTxId decodeWithdrawal limit Descending totalCount)
+      |] (foldPage decodeTxId decodeWithdrawal limit order totalCount)
   where
     -- Load one extra item so we can detect when we've hit the end
     nullFilterParams = (pivotSlot, pivotTxId, fromIntegral offset, fromIntegral limit + 1)

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetWithdrawals.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/Database/PostgreSQL/GetWithdrawals.hs
@@ -7,36 +7,248 @@ module Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetWithdrawals
 
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT(..))
+import Data.ByteString (ByteString)
+import Data.Int (Int16, Int64)
+import qualified Data.Set as Set
 import qualified Data.Vector as V
-import Hasql.TH (maybeStatement, vectorStatement)
+import Hasql.TH (foldStatement, maybeStatement, singletonStatement)
 import qualified Hasql.Transaction as T
 import Language.Marlowe.Protocol.Query.Types
-import Language.Marlowe.Runtime.ChainSync.Api (TxId(..), TxOutRef(..))
-import Language.Marlowe.Runtime.Core.Api (ContractId(..))
+import Language.Marlowe.Runtime.ChainSync.Api (PolicyId(..), TxId(..))
+import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetHeaders (foldPage)
 import Language.Marlowe.Runtime.Sync.Database.PostgreSQL.GetWithdrawal (decodeWithdrawal)
+import Prelude hiding (init)
 
-getWithdrawals :: ContractId -> T.Transaction (Maybe [Withdrawal])
-getWithdrawals (ContractId TxOutRef{..}) = runMaybeT do
-  let params = (unTxId txId, fromIntegral txIx)
-  _ <- MaybeT $ T.statement params
-    [maybeStatement|
-      SELECT txId :: bytea
-      FROM marlowe.createTxOut
-      WHERE txId = $1 :: bytea
-        AND txIx = $2 :: smallint
+getWithdrawals :: WithdrawalFilter -> Range TxId -> T.Transaction (Maybe (Page TxId Withdrawal))
+getWithdrawals _ Range{..}
+  | rangeLimit <= 0 || rangeOffset < 0 = pure Nothing
+
+getWithdrawals wFilter@WithdrawalFilter{..} Range{rangeStart = Just txId, ..} = runMaybeT do
+  pivot <- MaybeT if Set.null roleCurrencies
+    then T.statement (unTxId txId)
+      [maybeStatement|
+        SELECT slotNo :: bigint, txId :: bytea
+        FROM marlowe.withdrawalTxIn
+        WHERE txId = $1 :: bytea
+      |]
+    else T.statement (unTxId txId, V.fromList $ unPolicyId <$> Set.toList roleCurrencies)
+      [maybeStatement|
+        SELECT withdrawalTxIn.slotNo :: bigint, withdrawalTxIn.txId :: bytea
+        FROM marlowe.withdrawalTxIn
+        JOIN marlowe.payoutTxOut
+          ON withdrawalTxIn.payoutTxId = payoutTxOut.txId
+          AND withdrawalTxIn.payoutTxIx = payoutTxOut.txIx
+        JOIN (SELECT UNNEST($2 :: bytea[]) AS rolesCurrency) as roles USING (rolesCurrency)
+        WHERE withdrawalTxIn.txId = $1 :: bytea
+      |]
+  totalCount <- lift $ getTotalCount wFilter
+  lift $ getWithdrawalsFrom wFilter totalCount pivot rangeOffset rangeLimit rangeDirection
+
+getWithdrawals wFilter@WithdrawalFilter{..} Range{..} = Just <$> do
+  totalCount <- getTotalCount wFilter
+  case (Set.null roleCurrencies, rangeDirection) of
+    (True, Descending) -> T.statement nullFilterParams $
+      [foldStatement|
+        SELECT
+          txId :: bytea,
+          slotNo :: bigint,
+          blockId :: bytea,
+          blockNo :: bigint,
+          ARRAY_AGG(payoutTxId) :: bytea[],
+          ARRAY_AGG(payoutTxIx) :: smallint[]
+        FROM marlowe.withdrawalTxIn
+        GROUP BY slotNo, blockId, blockNo, txId
+        ORDER BY slotNo DESC, blockId DESC, blockNo DESC, txId DESC
+        OFFSET ($1 :: int) ROWS
+        FETCH NEXT ($2 :: int) ROWS ONLY
+      |] (foldPage decodeTxId decodeWithdrawal rangeLimit Descending totalCount)
+
+    (True, Ascending) -> T.statement nullFilterParams $
+      [foldStatement|
+        SELECT
+          txId :: bytea,
+          slotNo :: bigint,
+          blockId :: bytea,
+          blockNo :: bigint,
+          ARRAY_AGG(payoutTxId) :: bytea[],
+          ARRAY_AGG(payoutTxIx) :: smallint[]
+        FROM marlowe.withdrawalTxIn
+        GROUP BY slotNo, blockId, blockNo, txId
+        ORDER BY slotNo, blockId, blockNo, txId
+        OFFSET ($1 :: int) ROWS
+        FETCH NEXT ($2 :: int) ROWS ONLY
+      |] (foldPage decodeTxId decodeWithdrawal rangeLimit Descending totalCount)
+
+    (False, Descending) -> T.statement nonNullFilterParams $
+      [foldStatement|
+        SELECT
+          withdrawalTxIn.txId :: bytea,
+          withdrawalTxIn.slotNo :: bigint,
+          withdrawalTxIn.blockId :: bytea,
+          withdrawalTxIn.blockNo :: bigint,
+          ARRAY_AGG(withdrawalTxIn.payoutTxId) :: bytea[],
+          ARRAY_AGG(withdrawalTxIn.payoutTxIx) :: smallint[]
+        FROM marlowe.withdrawalTxIn
+        JOIN marlowe.payoutTxOut
+          ON withdrawalTxIn.payoutTxId = payoutTxOut.txId
+          AND withdrawalTxIn.payoutTxIx = payoutTxOut.txIx
+        JOIN (SELECT UNNEST($3 :: bytea[]) AS rolesCurrency) as roles USING (rolesCurrency)
+        GROUP BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
+        ORDER BY withdrawalTxIn.slotNo DESC, withdrawalTxIn.blockId DESC, withdrawalTxIn.blockNo DESC, withdrawalTxIn.txId DESC
+        OFFSET ($1 :: int) ROWS
+        FETCH NEXT ($2 :: int) ROWS ONLY
+      |] (foldPage decodeTxId decodeWithdrawal rangeLimit Descending totalCount)
+
+    (False, Ascending) -> T.statement nonNullFilterParams $
+      [foldStatement|
+        SELECT
+          withdrawalTxIn.txId :: bytea,
+          withdrawalTxIn.slotNo :: bigint,
+          withdrawalTxIn.blockId :: bytea,
+          withdrawalTxIn.blockNo :: bigint,
+          ARRAY_AGG(withdrawalTxIn.payoutTxId) :: bytea[],
+          ARRAY_AGG(withdrawalTxIn.payoutTxIx) :: smallint[]
+        FROM marlowe.withdrawalTxIn
+        JOIN marlowe.payoutTxOut
+          ON withdrawalTxIn.payoutTxId = payoutTxOut.txId
+          AND withdrawalTxIn.payoutTxIx = payoutTxOut.txIx
+        JOIN (SELECT UNNEST($3 :: bytea[]) AS rolesCurrency) as roles USING (rolesCurrency)
+        GROUP BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
+        ORDER BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
+        OFFSET ($1 :: int) ROWS
+        FETCH NEXT ($2 :: int) ROWS ONLY
+      |] (foldPage decodeTxId decodeWithdrawal rangeLimit Descending totalCount)
+  where
+    -- Load one extra item so we can detect when we've hit the end
+    nullFilterParams = (fromIntegral rangeOffset, fromIntegral rangeLimit + 1)
+    nonNullFilterParams =
+      ( fromIntegral rangeOffset
+      , fromIntegral rangeLimit + 1
+      , V.fromList $ unPolicyId <$> Set.toList roleCurrencies
+      )
+
+getTotalCount :: WithdrawalFilter -> T.Transaction Int
+getTotalCount WithdrawalFilter{..} = fromIntegral <$> if Set.null roleCurrencies
+  then T.statement ()
+    [singletonStatement|
+      SELECT COUNT(*) :: int
+      FROM
+        ( SELECT txId
+          FROM marlowe.withdrawalTxIn
+          GROUP BY txId
+        ) AS grouped
     |]
-  lift $ V.toList . fmap decodeWithdrawal <$> T.statement params
-    [vectorStatement|
-      SELECT
-        txId :: bytea,
-        slotNo :: bigint,
-        blockId :: bytea,
-        blockNo :: bigint,
-        ARRAY_AGG(payoutTxId) :: bytea[],
-        ARRAY_AGG(payoutTxIx) :: smallint[]
-      FROM marlowe.withdrawalTxIn
-      WHERE createTxId = $1 :: bytea
-        AND createTxIx = $2 :: smallint
-      GROUP BY slotNo, blockId, blockNo, txId
-      ORDER BY slotNo, blockId, blockNo, txId
+  else T.statement (V.fromList $ unPolicyId <$> Set.toList roleCurrencies)
+    [singletonStatement|
+      SELECT COUNT(*) :: int
+      FROM
+        ( SELECT withdrawalTxIn.txId
+          FROM marlowe.withdrawalTxIn
+          JOIN marlowe.payoutTxOut
+            ON withdrawalTxIn.payoutTxId = payoutTxOut.txId
+            AND withdrawalTxIn.payoutTxIx = payoutTxOut.txIx
+          JOIN (SELECT UNNEST($1 :: bytea[]) AS rolesCurrency) as roles USING (rolesCurrency)
+          GROUP BY withdrawalTxIn.txId
+        ) AS grouped
     |]
+
+getWithdrawalsFrom
+  :: WithdrawalFilter
+  -> Int
+  -> (Int64, ByteString)
+  -> Int
+  -> Int
+  -> Order
+  -> T.Transaction (Page TxId Withdrawal)
+getWithdrawalsFrom WithdrawalFilter{..} totalCount (pivotSlot, pivotTxId) offset limit order =
+  case (Set.null roleCurrencies, order) of
+    (True, Descending) -> T.statement nullFilterParams $
+      [foldStatement|
+        SELECT
+          txId :: bytea,
+          slotNo :: bigint,
+          blockId :: bytea,
+          blockNo :: bigint,
+          ARRAY_AGG(payoutTxId) :: bytea[],
+          ARRAY_AGG(payoutTxIx) :: smallint[]
+        FROM marlowe.withdrawalTxIn
+        WHERE slotNo < $1 :: bigint OR (slotNo = $1 :: bigint AND txId <= $2 :: bytea)
+        GROUP BY slotNo, blockId, blockNo, txId
+        ORDER BY slotNo DESC, blockId DESC, blockNo DESC, txId DESC
+        OFFSET ($3 :: int) ROWS
+        FETCH NEXT ($4 :: int) ROWS ONLY
+      |] (foldPage decodeTxId decodeWithdrawal limit Descending totalCount)
+
+    (True, Ascending) -> T.statement nullFilterParams $
+      [foldStatement|
+        SELECT
+          txId :: bytea,
+          slotNo :: bigint,
+          blockId :: bytea,
+          blockNo :: bigint,
+          ARRAY_AGG(payoutTxId) :: bytea[],
+          ARRAY_AGG(payoutTxIx) :: smallint[]
+        FROM marlowe.withdrawalTxIn
+        WHERE slotNo > $1 :: bigint OR (slotNo = $1 :: bigint AND txId >= $2 :: bytea)
+        GROUP BY slotNo, blockId, blockNo, txId
+        ORDER BY slotNo, blockId, blockNo, txId
+        OFFSET ($3 :: int) ROWS
+        FETCH NEXT ($4 :: int) ROWS ONLY
+      |] (foldPage decodeTxId decodeWithdrawal limit Descending totalCount)
+
+    (False, Descending) -> T.statement nonNullFilterParams $
+      [foldStatement|
+        SELECT
+          withdrawalTxIn.txId :: bytea,
+          withdrawalTxIn.slotNo :: bigint,
+          withdrawalTxIn.blockId :: bytea,
+          withdrawalTxIn.blockNo :: bigint,
+          ARRAY_AGG(withdrawalTxIn.payoutTxId) :: bytea[],
+          ARRAY_AGG(withdrawalTxIn.payoutTxIx) :: smallint[]
+        FROM marlowe.withdrawalTxIn
+        JOIN marlowe.payoutTxOut
+          ON withdrawalTxIn.payoutTxId = payoutTxOut.txId
+          AND withdrawalTxIn.payoutTxIx = payoutTxOut.txIx
+        JOIN (SELECT UNNEST($5 :: bytea[]) AS rolesCurrency) as roles USING (rolesCurrency)
+        WHERE withdrawalTxIn.slotNo < $1 :: bigint OR (withdrawalTxIn.slotNo = $1 :: bigint AND withdrawalTxIn.txId <= $2 :: bytea)
+        GROUP BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
+        ORDER BY withdrawalTxIn.slotNo DESC, withdrawalTxIn.blockId DESC, withdrawalTxIn.blockNo DESC, withdrawalTxIn.txId DESC
+        OFFSET ($3 :: int) ROWS
+        FETCH NEXT ($4 :: int) ROWS ONLY
+      |] (foldPage decodeTxId decodeWithdrawal limit Descending totalCount)
+
+    (False, Ascending) -> T.statement nonNullFilterParams $
+      [foldStatement|
+        SELECT
+          withdrawalTxIn.txId :: bytea,
+          withdrawalTxIn.slotNo :: bigint,
+          withdrawalTxIn.blockId :: bytea,
+          withdrawalTxIn.blockNo :: bigint,
+          ARRAY_AGG(withdrawalTxIn.payoutTxId) :: bytea[],
+          ARRAY_AGG(withdrawalTxIn.payoutTxIx) :: smallint[]
+        FROM marlowe.withdrawalTxIn
+        JOIN marlowe.payoutTxOut
+          ON withdrawalTxIn.payoutTxId = payoutTxOut.txId
+          AND withdrawalTxIn.payoutTxIx = payoutTxOut.txIx
+        JOIN (SELECT UNNEST($5 :: bytea[]) AS rolesCurrency) as roles USING (rolesCurrency)
+        WHERE withdrawalTxIn.slotNo > $1 :: bigint OR (withdrawalTxIn.slotNo = $1 :: bigint AND withdrawalTxIn.txId >= $2 :: bytea)
+        GROUP BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
+        ORDER BY withdrawalTxIn.slotNo, withdrawalTxIn.blockId, withdrawalTxIn.blockNo, withdrawalTxIn.txId
+        OFFSET ($3 :: int) ROWS
+        FETCH NEXT ($4 :: int) ROWS ONLY
+      |] (foldPage decodeTxId decodeWithdrawal limit Descending totalCount)
+  where
+    -- Load one extra item so we can detect when we've hit the end
+    nullFilterParams = (pivotSlot, pivotTxId, fromIntegral offset, fromIntegral limit + 1)
+    nonNullFilterParams =
+      ( pivotSlot
+      , pivotTxId
+      , fromIntegral offset
+      , fromIntegral limit + 1
+      , V.fromList $ unPolicyId <$> Set.toList roleCurrencies
+      )
+
+type ResultRow = (ByteString, Int64, ByteString, Int64, V.Vector ByteString, V.Vector Int16)
+
+decodeTxId :: ResultRow -> TxId
+decodeTxId (txId, _, _, _, _, _) = TxId txId

--- a/marlowe-runtime/test/Language/Marlowe/Protocol/QuerySpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Protocol/QuerySpec.hs
@@ -91,6 +91,10 @@ instance Arbitrary a => Arbitrary (Range a) where
   arbitrary = Range <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
   shrink = genericShrink
 
+instance Arbitrary PayoutRef where
+  arbitrary = PayoutRef <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  shrink = genericShrink
+
 instance Arbitrary Withdrawal where
   arbitrary = Withdrawal <$> arbitrary <*> arbitrary <*> arbitrary
   shrink = genericShrink


### PR DESCRIPTION
Changes the parameters of the `GetWithdrawals` query in the following ways:

1. The query is now paginated (it accepts a `Range` and returns a `Page`).
2. The query accepts a `Set PolicyId` to filter by role token currencies. Empty set => no filtering.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
    - [x] Reviewer requested
