### PR TITLE
SCP-5126 MList annotations and tests

### DIFF
--- a/marlowe-test/marlowe-test.cabal
+++ b/marlowe-test/marlowe-test.cabal
@@ -65,6 +65,7 @@ library
     Spec.Marlowe.Plutus.Arbitrary
     Spec.Marlowe.Plutus.AssocMap
     Spec.Marlowe.Plutus.Lens
+    Spec.Marlowe.Plutus.MList
     Spec.Marlowe.Plutus.Prelude
     Spec.Marlowe.Plutus.Script
     Spec.Marlowe.Plutus.ScriptContext

--- a/marlowe-test/src/Spec/Marlowe/Plutus.hs
+++ b/marlowe-test/src/Spec/Marlowe/Plutus.hs
@@ -20,6 +20,7 @@ module Spec.Marlowe.Plutus
 import Test.Tasty (TestTree, testGroup)
 
 import qualified Spec.Marlowe.Plutus.AssocMap (tests)
+import qualified Spec.Marlowe.Plutus.MList (tests)
 import qualified Spec.Marlowe.Plutus.Prelude (tests)
 import qualified Spec.Marlowe.Plutus.ScriptContext (tests)
 import qualified Spec.Marlowe.Plutus.Specification (tests)
@@ -33,6 +34,7 @@ tests =
     [
       Spec.Marlowe.Plutus.Prelude.tests
     , Spec.Marlowe.Plutus.AssocMap.tests
+    , Spec.Marlowe.Plutus.MList.tests
     , Spec.Marlowe.Plutus.Value.tests
     , Spec.Marlowe.Plutus.ScriptContext.tests
     , Spec.Marlowe.Plutus.Specification.tests

--- a/marlowe-test/src/Spec/Marlowe/Plutus/MList.hs
+++ b/marlowe-test/src/Spec/Marlowe/Plutus/MList.hs
@@ -1,0 +1,298 @@
+-----------------------------------------------------------------------------
+--
+-- Module      :  $Headers
+-- License     :  Apache 2.0
+--
+-- Stability   :  Experimental
+-- Portability :  Portable
+--
+-- | Compare the `PlutusTx.AssocMap` to Isabelle's `MList`.
+--
+-----------------------------------------------------------------------------
+
+
+{-# ANN module "HLint: Use guards" #-}
+
+
+module Spec.Marlowe.Plutus.MList
+  ( -- * Testing
+    tests
+  ) where
+
+
+import Prelude hiding (lookup)
+import Data.Function (on)
+import Data.Maybe (isJust, fromMaybe)
+import Data.List (sortBy, nubBy)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, assertBool)
+import Test.Tasty.QuickCheck (Arbitrary(..), Gen, Property, elements, forAll, property, testProperty, shuffle, elements)
+
+import qualified PlutusTx.AssocMap as AM (Map, delete, empty, fromList, insert, lookup, member, null, singleton, toList, unionWith)
+
+
+-- | An association list in Isabelle.
+type MList a b = [(a, b)]
+
+
+-- | Empty Isabelle `MList`.
+--
+-- @
+-- definition empty :: "('a::linorder \<times> 'b) list" where
+--   "empty = Nil"
+-- @
+empty :: MList a b
+empty = []
+
+
+-- | Insert into Isabelle `MList`.
+--
+-- @
+-- fun insert :: "'a::linorder \<Rightarrow> 'b \<Rightarrow> ('a \<times> 'b) list \<Rightarrow> ('a \<times> 'b) list" where
+--   "insert a b Nil = Cons (a, b) Nil" |
+--   "insert a b (Cons (x, y) z) =
+--     (if a < x
+--      then (Cons (a, b) (Cons (x, y) z))
+--      else (if a > x
+--            then (Cons (x, y) (insert a b z))
+--            else (Cons (x, b) z)))"
+-- @
+insert :: Ord a => a -> b -> MList a b -> MList a b
+insert a b [] = (a, b) : []
+insert a b ((x, y) : z) =
+  if a < x
+    then (a, b) : (x, y) : z
+    else if a > x
+      then (x, y) : insert a b z
+      else (x, b) : z
+
+
+-- | Delete from Isabelle `MList`.
+--
+-- @
+-- fun delete :: "'a::linorder \<Rightarrow> ('a \<times> 'b) list \<Rightarrow> ('a \<times> 'b) list" where
+--   "delete a Nil = Nil" |
+--   "delete a (Cons (x, y) z) =
+--     (if a = x
+--      then z
+--      else (if a > x
+--            then (Cons (x, y) (delete a z))
+--            else (Cons (x, y) z)))"
+-- @
+delete :: Ord a => a -> MList a b -> MList a b
+delete _a [] = []
+delete a ((x, y) : z) =
+  if a == x
+    then z
+    else if a > x
+      then (x, y) : delete a z
+      else (x, y) : z
+
+
+-- | Lookup in Isabelle `MList`.
+--
+-- @
+-- fun lookup :: "'a::linorder \<Rightarrow> ('a \<times> 'b) list \<Rightarrow> 'b option" where
+--   "lookup a Nil = None" |
+--   "lookup a (Cons (x, y) z) =
+--     (if a = x
+--      then Some y
+--      else (if a > x
+--            then lookup a z
+--            else None))"
+-- @
+lookup :: Ord a => a -> MList a b -> Maybe b
+lookup _a [] = Nothing
+lookup a ((x, y) : z) =
+  if a == x
+    then Just y
+    else if a > x
+      then lookup a z
+      else Nothing
+
+
+-- | Union with Isabelle `MList`.
+--
+-- @
+-- fun unionWith :: "('b \<Rightarrow> 'b \<Rightarrow> 'b) \<Rightarrow> ('a \<times> 'b) list \<Rightarrow>
+--                   ('a \<times> 'b) list \<Rightarrow> (('a::linorder) \<times> 'b) list" where
+--   "unionWith f (Cons (x, y) t) (Cons (x2, y2) t2) =
+--     (if x < x2
+--      then Cons (x, y) (unionWith f t (Cons (x2, y2) t2))
+--      else (if x > x2
+--            then Cons (x2, y2) (unionWith f (Cons (x, y) t) t2)
+--            else Cons (x, f y y2) (unionWith f t t2)))" |
+--   "unionWith f Nil l = l" |
+--   "unionWith f l Nil = l"
+-- @
+unionWith :: Ord a => (b -> b -> b) -> MList a b -> MList a b -> MList a b
+unionWith f ((x, y) : t) ((x2, y2) : t2) =
+  if x < x2
+    then (x, y) : unionWith f t ((x2, y2) : t2)
+    else if x > x2
+      then (x2, y2) : unionWith f ((x, y) : t) t2
+      else (x, f y y2) : unionWith f t t2
+unionWith _f [] l = l
+unionWith _f l [] = l
+
+
+-- | Find with default for Isabelle `MList`.
+--
+-- @
+-- fun findWithDefault :: "'b \<Rightarrow> 'a \<Rightarrow> (('a::linorder) \<times> 'b) list \<Rightarrow> 'b" where
+--   "findWithDefault d k l = (case lookup k l of
+--                               None \<Rightarrow> d
+--                             | Some x \<Rightarrow> x)"
+-- @
+findWithDefault :: Ord a => b -> a -> MList a b -> b
+findWithDefault d k l =
+  case lookup k l of
+    Nothing -> d
+    Just x -> x
+
+
+-- | Run tests.
+tests :: TestTree
+tests =
+  testGroup "MList vs AssocMap"
+    [
+      testCase     "`empty` is equivalent"           checkEmpty
+    , testProperty "`null` is equivalent"            checkNull
+    , testProperty "`singleton` is equivalent"       checkSingleton
+    , testProperty "`insert` is equivalent"          checkInsert
+    , testProperty "`delete` is equivalent"          checkDelete
+    , testProperty "`lookup` is equivalent"          checkLookup
+    , testProperty "`member` is equivalent"          checkMember
+    , testProperty "`unionWith` is equivalent"       checkUnionWith
+    , testProperty "`findWithDefault` is equivalent" checkFindWithDefault
+    ]
+
+
+-- | Generate a sorted `MList` with no duplicates.
+arbitraryMList :: Gen (MList Integer [()])
+arbitraryMList = nubBy ((==) `on` fst) . sortBy (compare `on` fst) <$> arbitrary
+
+
+-- | Compare an `MList` to an `AssocMap`.
+equivalent :: Ord a => Eq b => MList a b -> AM.Map a b -> Bool
+equivalent mlist assocmap = mlist == sortBy (compare `on` fst) (AM.toList assocmap)
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkEmpty :: Assertion
+checkEmpty = assertBool "Empty MList and AssocMap" $ (empty :: MList [()] Integer) `equivalent` AM.empty
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkNull :: Property
+checkNull = property $ do
+  let
+    gen = do
+      mlist <- arbitraryMList
+      assocmap <- AM.fromList <$> shuffle mlist
+      pure (mlist, assocmap)
+  forAll gen 
+    $ \(mlist, assocmap) -> (== empty) mlist == AM.null assocmap
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkSingleton :: Property
+checkSingleton = property $ do
+  let
+    gen = do
+      a <- arbitrary :: Gen Integer
+      b <- arbitrary :: Gen [()]
+      pure (a, b)
+  forAll gen 
+    $ \(a, b) -> [(a, b)] `equivalent` AM.singleton a b
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkInsert :: Property
+checkInsert = property $ do
+  let
+    gen = do
+      mlist <- arbitraryMList
+      assocmap <- AM.fromList <$> shuffle mlist
+      a <- arbitrary
+      b <- arbitrary
+      pure (mlist, assocmap, a, b)
+  forAll gen 
+    $ \(mlist, assocmap, a, b) -> insert a b mlist `equivalent` AM.insert a b assocmap
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkDelete :: Property
+checkDelete = property $ do
+  let
+    gen = do
+      mlist <- arbitraryMList
+      assocmap <- AM.fromList <$> shuffle mlist
+      a <- arbitrary
+      pure (mlist, assocmap, a)
+  forAll gen 
+    $ \(mlist, assocmap, a) -> delete a mlist `equivalent` AM.delete a assocmap
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkLookup :: Property
+checkLookup = property $ do
+  let
+    gen = do
+      mlist <- arbitraryMList
+      assocmap <- AM.fromList <$> shuffle mlist
+      a <- arbitrary
+      pure (mlist, assocmap, a)
+  forAll gen 
+    $ \(mlist, assocmap, a) -> lookup a mlist == AM.lookup a assocmap
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkMember :: Property
+checkMember = property $ do
+  let
+    gen = do
+      mlist <- arbitraryMList
+      assocmap <- AM.fromList <$> shuffle mlist
+      a <- arbitrary
+      pure (mlist, assocmap, a)
+  forAll gen 
+    $ \(mlist, assocmap, a) -> isJust (lookup a mlist) == AM.member a assocmap
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkUnionWith :: Property
+checkUnionWith = property $ do
+  let
+    gen = do
+      mlist <- arbitraryMList
+      assocmap <- AM.fromList <$> shuffle mlist
+      mlist' <- arbitraryMList
+      assocmap' <- AM.fromList <$> shuffle mlist'
+      function <- elements ["concat", "shortest", "longest", "first", "second"]
+      pure (mlist, assocmap, mlist', assocmap', function)
+  forAll gen 
+    $ \(mlist, assocmap, mlist', assocmap', function) ->
+      let
+        f = case function of
+              "shortest" -> \x y -> if length x < length y then x else y
+              "longest"  -> \x y -> if length x > length y then x else y
+              "first"    -> \x _ -> x
+              "second"   -> \_ y -> y
+              _          -> (<>)
+      in
+        unionWith f mlist mlist' `equivalent` AM.unionWith f assocmap assocmap'
+
+
+-- | Compare `empty` for `MList` and `AssocMap`.
+checkFindWithDefault :: Property
+checkFindWithDefault = property $ do
+  let
+    gen = do
+      mlist <- arbitraryMList
+      assocmap <- AM.fromList <$> shuffle mlist
+      a <- arbitrary
+      b <- arbitrary
+      pure (mlist, assocmap, a, b)
+  forAll gen 
+    $ \(mlist, assocmap, a, b) -> findWithDefault b a mlist == fromMaybe b (AM.lookup a assocmap)

--- a/marlowe-test/src/Spec/Marlowe/Plutus/MList.hs
+++ b/marlowe-test/src/Spec/Marlowe/Plutus/MList.hs
@@ -175,22 +175,22 @@ tests =
     ]
 
 
--- | Generate a sorted `MList` with no duplicates.
+-- | Generate a sorted `MList` with no duplicate keys.
 arbitraryMList :: Gen (MList Integer [()])
 arbitraryMList = nubBy ((==) `on` fst) . sortBy (compare `on` fst) <$> arbitrary
 
 
--- | Compare an `MList` to an `AssocMap`.
+-- | Compare an `MList` to an `AssocMap`, ignoring ordering.
 equivalent :: Ord a => Eq b => MList a b -> AM.Map a b -> Bool
 equivalent mlist assocmap = mlist == sortBy (compare `on` fst) (AM.toList assocmap)
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `empty` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkEmpty :: Assertion
 checkEmpty = assertBool "Empty MList and AssocMap" $ (empty :: MList [()] Integer) `equivalent` AM.empty
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `null` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkNull :: Property
 checkNull = property $ do
   let
@@ -202,7 +202,7 @@ checkNull = property $ do
     $ \(mlist, assocmap) -> (== empty) mlist == AM.null assocmap
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `singleton` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkSingleton :: Property
 checkSingleton = property $ do
   let
@@ -214,7 +214,7 @@ checkSingleton = property $ do
     $ \(a, b) -> [(a, b)] `equivalent` AM.singleton a b
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `insert` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkInsert :: Property
 checkInsert = property $ do
   let
@@ -228,7 +228,7 @@ checkInsert = property $ do
     $ \(mlist, assocmap, a, b) -> insert a b mlist `equivalent` AM.insert a b assocmap
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `delete` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkDelete :: Property
 checkDelete = property $ do
   let
@@ -241,7 +241,7 @@ checkDelete = property $ do
     $ \(mlist, assocmap, a) -> delete a mlist `equivalent` AM.delete a assocmap
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `lookup` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkLookup :: Property
 checkLookup = property $ do
   let
@@ -254,7 +254,7 @@ checkLookup = property $ do
     $ \(mlist, assocmap, a) -> lookup a mlist == AM.lookup a assocmap
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `member` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkMember :: Property
 checkMember = property $ do
   let
@@ -267,7 +267,7 @@ checkMember = property $ do
     $ \(mlist, assocmap, a) -> isJust (lookup a mlist) == AM.member a assocmap
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `unionWith` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkUnionWith :: Property
 checkUnionWith = property $ do
   let
@@ -291,7 +291,7 @@ checkUnionWith = property $ do
         unionWith f mlist mlist' `equivalent` AM.unionWith f assocmap assocmap'
 
 
--- | Compare `empty` for `MList` and `AssocMap`.
+-- | Compare `findWithDefault` for `MList` and `AssocMap`, provided the `MList` is sorted and neither contains duplicate keys.
 checkFindWithDefault :: Property
 checkFindWithDefault = property $ do
   let

--- a/marlowe/CHANGELOG.md
+++ b/marlowe/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog for the `marlowe-cardano` Package
+
+
+## Start of Changelog, December 2022
+
+The tag SCP-4415 (commit `23f3d56f22bf992ddb0b0c8a52bb7a5a188f9e9`) marks the version of this package that was subject to audit.

--- a/marlowe/CHANGELOG.md
+++ b/marlowe/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog for the `marlowe-cardano` Package
 
 
-## Start of Changelog, December 2022
+## Start of changelog, December 2022
 
 The tag SCP-4415 (commit `23f3d56f22bf992ddb0b0c8a52bb7a5a188f9e9`) marks the version of this package that was subject to audit.
+
+
+## SCP-5126: Differences between Marlowe's Isabelle semantics and its Plutus validator
+
+Based on audit findings, we annotated Marlowe's Plutus validator with comments indicating how differences between `PlutusTx.AssocMap` and Isabelle's `MList` are inconsequential with respect to behavior of the validator, provided the Marlowe contract's initial state does not contain duplicate accounts, choices, or bound values.
+

--- a/marlowe/marlowe-cardano.cabal
+++ b/marlowe/marlowe-cardano.cabal
@@ -17,6 +17,7 @@ description:
   on Cardano Computation Layer.
 category: Language
 extra-doc-files: README.md
+                 CHANGELOG.md
 
 source-repository head
   type: git
@@ -63,7 +64,6 @@ library
     plutus-ledger-api,
     plutus-script-utils,
     plutus-tx,
-    prettyprinter,
     sbv >=8.4,
     scientific,
     serialise,

--- a/marlowe/specification/marlowe-cardano-specification.md
+++ b/marlowe/specification/marlowe-cardano-specification.md
@@ -97,6 +97,17 @@ data Input =
 In the above, the `BuiltinByteString` is the hash of the serialized continuation `Contract`.
 
 
+### Variations from Isabelle Semantics
+
+Marlowe's semantics validator uses Plutus's association list `PlutuxTx.AssocMap` that differs from the `MList` in Isabelle semantics in several respects:
+
+1.  The `insert`, `delete`, `member`, and `lookup` functions of `AssocMap` haven an equality (`Eq`) constraint whereas `MList` has a ordering (`Ord`) constraint.
+2.  If the elements of an `MList` are not in lexicographic order, then result of `insert`, `delete`, `member`, and `lookup` may differ from that in `AssocMap`.
+3.  The ordering of the result of `toList` may differ between `AssocMap` and `MList`.
+
+Provided that the initial state of the Marlowe contract does not contain duplicate entries in `accounts`, `choices`, or `boundValues` and also provided that the behavior of Marlowe's semantics validator is compared to Isabelle semantics with the Isabelle initial state for `accounts`, `choices`, and `boundValues` lexicographic ordered, the behavior of the Marlowe semantics validator does not differ from Isabelle semantics aside from the ordering of `accounts`, `choices`, and `boundValues` in Marlowe's state in the datum. Typically, Marlowe contracts start with an empty state, so this is not an issue, but one can in principle start a Marlowe contract with a non-empty state, even with one that contains duplicate entries. Internally to the validator, `computeTransaction` might order payments upon `Close` differently from Isabelle semantics, but that is undetectable at the validation or transaction level.
+
+
 ## Merkelization
 
 A contract can be represented as a tree of continuations ("sub-contracts") where each vertex is a contract and each edge follows either an `InputContent` made by a participant or a timeout. A `When` contract includes terms that are either (1) a `Case` which contains the `Action` that matches a particular `InputContent` via `NormalInput` and that explicitly includes the `Contract` continuation or (2) a `MerkleizedCase` which contains the `Action` that matches a particular `InputContent` via `MerkleizedInput` and that implicitly includes the continuation by reference to its Merkle hash. In the latter case `MerkleizedInput` includes both the Merkle hash of the continuation and the continuation `Contract` itself. The Plutus code must verify that the hash in the contract matches the hash in the input before it proceeds to use the continuation that was provided as input.

--- a/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Core/V1/Semantics.hs
@@ -523,7 +523,9 @@ refundOne accounts = case Map.toList accounts of
     -- SCP-5126: The return value of this function differs from
     -- Isabelle semantics in that it returns the least-recently
     -- added account-token combination rather than the first
-    -- lexicographically ordered one.
+    -- lexicographically ordered one. Also, the sequence
+    -- `Map.fromList . tail . Map.toList` preserves the
+    -- invariants of order and non-duplication.
     ((accId, token), balance) : rest ->
         if balance > 0
         then Just ((accId, token, balance), Map.fromList rest)

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cardano.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-cardano.nix
@@ -28,7 +28,7 @@
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [ "README.md" ];
+      extraDocFiles = [ "README.md" "CHANGELOG.md" ];
       };
     components = {
       "library" = {
@@ -48,7 +48,6 @@
           (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-script-utils" or (errorHandler.buildDepError "plutus-script-utils"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."sbv" or (errorHandler.buildDepError "sbv"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))

--- a/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-test.nix
+++ b/nix/pkgs/haskell/materialized-darwin/.plan.nix/marlowe-test.nix
@@ -76,6 +76,7 @@
           "Spec/Marlowe/Plutus/Arbitrary"
           "Spec/Marlowe/Plutus/AssocMap"
           "Spec/Marlowe/Plutus/Lens"
+          "Spec/Marlowe/Plutus/MList"
           "Spec/Marlowe/Plutus/Prelude"
           "Spec/Marlowe/Plutus/Script"
           "Spec/Marlowe/Plutus/ScriptContext"

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cardano.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-cardano.nix
@@ -28,7 +28,7 @@
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [ "README.md" ];
+      extraDocFiles = [ "README.md" "CHANGELOG.md" ];
       };
     components = {
       "library" = {
@@ -48,7 +48,6 @@
           (hsPkgs."plutus-ledger-api" or (errorHandler.buildDepError "plutus-ledger-api"))
           (hsPkgs."plutus-script-utils" or (errorHandler.buildDepError "plutus-script-utils"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-          (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."sbv" or (errorHandler.buildDepError "sbv"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))

--- a/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-test.nix
+++ b/nix/pkgs/haskell/materialized-linux/.plan.nix/marlowe-test.nix
@@ -76,6 +76,7 @@
           "Spec/Marlowe/Plutus/Arbitrary"
           "Spec/Marlowe/Plutus/AssocMap"
           "Spec/Marlowe/Plutus/Lens"
+          "Spec/Marlowe/Plutus/MList"
           "Spec/Marlowe/Plutus/Prelude"
           "Spec/Marlowe/Plutus/Script"
           "Spec/Marlowe/Plutus/ScriptContext"


### PR DESCRIPTION
1. Discussion and justification for using `PlutusTx.AssocMap` instead of Isabelle's `MList` were added as comments to all usages in Marlowe's semantics implementation.
2. A paragraph was added to the Marlowe-Cardano specification about `MList`.
3. Property-based tests were added for all `AssocMap` functions used the Marlowe validator, to verify that if there are no duplicates entries and the `MList` is sorted, then the behavior matches `AssocMap`.
4. The change log was updated.

***Reviewers: Does this adequately address the following audit findings?***

![image](https://user-images.githubusercontent.com/2235898/221977388-1bda84a3-2581-424a-9d24-3a113bce904c.png)

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [x] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested