### PR TITLE
Introduce "CIP-30 friendly" flow for contracts to the REST API

### DIFF
--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/GetContracts.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/GetContracts.hs
@@ -201,7 +201,7 @@ createCloseContract Wallet{..}= do
   let webExtraAddresses = Set.map toDTO extraAddresses
   let webCollateralUtxos = Set.map toDTO collateralUtxos
 
-  Web.CreateTxBody{txBody = createTxBody, ..} <- postContract
+  Web.CreateTxEnvelope{txBody = createTxBody, ..} <- postContract
     webChangeAddress
     (Just webExtraAddresses)
     (Just webCollateralUtxos)

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/GetContracts.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/GetContracts.hs
@@ -201,7 +201,7 @@ createCloseContract Wallet{..}= do
   let webExtraAddresses = Set.map toDTO extraAddresses
   let webCollateralUtxos = Set.map toDTO collateralUtxos
 
-  Web.CreateTxEnvelope{txBody = createTxBody, ..} <- postContract
+  Web.CreateTxEnvelope{txEnvelope = createTxBody, ..} <- postContract
     webChangeAddress
     (Just webExtraAddresses)
     (Just webCollateralUtxos)

--- a/marlowe-integration/app/Main.hs
+++ b/marlowe-integration/app/Main.hs
@@ -38,7 +38,7 @@ main = withLocalMarloweRuntime \MarloweRuntime{..} -> do
   print webAddress
 
   either throw pure =<< runWebClient do
-    Web.CreateTxEnvelope{txBody = createTxBody, ..} <- postContract webAddress Nothing Nothing Web.PostContractsRequest
+    Web.CreateTxEnvelope{txEnvelope = createTxBody, ..} <- postContract webAddress Nothing Nothing Web.PostContractsRequest
       { metadata = mempty
       , tags = mempty
       , version = Web.V1
@@ -47,7 +47,7 @@ main = withLocalMarloweRuntime \MarloweRuntime{..} -> do
       , minUTxODeposit = 2_000_000
       }
 
-    liftIO $ print CreateTxEnvelope{txBody = createTxBody, ..}
+    liftIO $ print CreateTxEnvelope{txEnvelope = createTxBody, ..}
 
     createTx <- liftIO $ signShelleyTransaction' createTxBody [signingKey]
 
@@ -57,7 +57,7 @@ main = withLocalMarloweRuntime \MarloweRuntime{..} -> do
 
     liftIO $ print contractState
 
-    Web.ApplyInputsTxBody{transactionId, txBody = applyTxBody} <- postTransaction webAddress Nothing Nothing contractId Web.PostTransactionsRequest
+    Web.ApplyInputsTxEnvelope{transactionId, txEnvelope = applyTxBody} <- postTransaction webAddress Nothing Nothing contractId Web.PostTransactionsRequest
       { version = Web.V1
       , tags = mempty
       , metadata = mempty

--- a/marlowe-integration/app/Main.hs
+++ b/marlowe-integration/app/Main.hs
@@ -20,7 +20,7 @@ import Data.Maybe (fromJust)
 import qualified Data.Text as T
 import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
 import Language.Marlowe.Runtime.ChainSync.Api (Address(..), fromBech32, toBech32)
-import Language.Marlowe.Runtime.Web (CreateTxBody(CreateTxBody), PostContractsRequest(..))
+import Language.Marlowe.Runtime.Web (CreateTxEnvelope(CreateTxEnvelope), PostContractsRequest(..))
 import qualified Language.Marlowe.Runtime.Web as Web
 import Language.Marlowe.Runtime.Web.Client
   (getContract, getTransaction, postContract, postTransaction, putContract, putTransaction)
@@ -38,7 +38,7 @@ main = withLocalMarloweRuntime \MarloweRuntime{..} -> do
   print webAddress
 
   either throw pure =<< runWebClient do
-    Web.CreateTxBody{txBody = createTxBody, ..} <- postContract webAddress Nothing Nothing Web.PostContractsRequest
+    Web.CreateTxEnvelope{txBody = createTxBody, ..} <- postContract webAddress Nothing Nothing Web.PostContractsRequest
       { metadata = mempty
       , tags = mempty
       , version = Web.V1
@@ -47,7 +47,7 @@ main = withLocalMarloweRuntime \MarloweRuntime{..} -> do
       , minUTxODeposit = 2_000_000
       }
 
-    liftIO $ print CreateTxBody{txBody = createTxBody, ..}
+    liftIO $ print CreateTxEnvelope{txBody = createTxBody, ..}
 
     createTx <- liftIO $ signShelleyTransaction' createTxBody [signingKey]
 

--- a/marlowe-runtime-web/changelog.d/20230417_165332_tomasz.rybarczyk_SCP_4926_cip30_friendly_web_server.md
+++ b/marlowe-runtime-web/changelog.d/20230417_165332_tomasz.rybarczyk_SCP_4926_cip30_friendly_web_server.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+* These endpoints `POST` handlers were extended so they return transaction as a result (instead of transaction body) if a particular header is present:
+
+  * `contracts` endpoint uses "Accept: application/vendor.iog.marlowe-runtime.contract-tx-json" header
+
+  * `transactions` endpoint uses "Accept: application/vendor.iog.marlowe-runtime.apply-inputs-tx-json" header
+
+  * `withdraw` endpoint uses "Accept: application/vendor.iog.marlowe-runtime.withdraw-tx-json" header
+
+* All the above endpoints accept also `witnessset` as a payload for `PUT` request now.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/marlowe-runtime-web/changelog.d/scriv.ini
+++ b/marlowe-runtime-web/changelog.d/scriv.ini
@@ -1,0 +1,3 @@
+[scriv]
+format = md
+version = 1.0.0.0

--- a/marlowe-runtime-web/marlowe-runtime-web.cabal
+++ b/marlowe-runtime-web/marlowe-runtime-web.cabal
@@ -64,6 +64,7 @@ library
     , base16 >= 0.3.2 && < 0.4
     , bytestring >= 0.10.12 && < 0.12
     , containers >= 0.6.5 && < 0.7
+    -- , http-media
     , lens >= 5.2 && < 6
     , marlowe-cardano ==0.1.0.3
     , mtl >= 2.2 && < 3
@@ -97,11 +98,16 @@ library server
     Language.Marlowe.Runtime.Web.Server.TxClient
   build-depends:
     , base >= 4.9 && < 5
+    -- , bytestring
     , aeson >= 2 && < 3
     , async >= 2.2 && < 3
     , async-components ==0.1.0.0
     , cardano-api ==1.35.4
     , containers >= 0.6.5 && < 0.7
+    -- , cardano-binary
+    -- , cardano-ledger-alonzo
+    -- , cardano-ledger-core
+    -- , cardano-ledger-shelley
     , errors >= 2.3 && < 3
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-dsl ^>= { 0.2 }

--- a/marlowe-runtime-web/marlowe-runtime-web.cabal
+++ b/marlowe-runtime-web/marlowe-runtime-web.cabal
@@ -64,7 +64,7 @@ library
     , base16 >= 0.3.2 && < 0.4
     , bytestring >= 0.10.12 && < 0.12
     , containers >= 0.6.5 && < 0.7
-    -- , http-media
+    , http-media >= 0.8 && < 0.9
     , lens >= 5.2 && < 6
     , marlowe-cardano ==0.1.0.3
     , mtl >= 2.2 && < 3
@@ -98,16 +98,16 @@ library server
     Language.Marlowe.Runtime.Web.Server.TxClient
   build-depends:
     , base >= 4.9 && < 5
-    -- , bytestring
+    , bytestring >= 0.10.12 && < 0.12
     , aeson >= 2 && < 3
     , async >= 2.2 && < 3
     , async-components ==0.1.0.0
     , cardano-api ==1.35.4
     , containers >= 0.6.5 && < 0.7
-    -- , cardano-binary
-    -- , cardano-ledger-alonzo
-    -- , cardano-ledger-core
-    -- , cardano-ledger-shelley
+    , cardano-binary ==1.5.0
+    , cardano-ledger-alonzo ==0.1.0.0
+    , cardano-ledger-core ==0.1.0.0
+    , cardano-ledger-shelley ==0.1.0.0
     , errors >= 2.3 && < 3
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-dsl ^>= { 0.2 }

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/DTO.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/DTO.hs
@@ -15,24 +15,42 @@ module Language.Marlowe.Runtime.Web.Server.DTO
   where
 
 import Cardano.Api
-  ( AsType(AsTxBody)
+  ( AsType(AsTx, AsTxBody)
+  , HasTextEnvelope
+  , HasTypeProxy
   , IsCardanoEra(cardanoEra)
+  , IsShelleyBasedEra(shelleyBasedEra)
+  , SerialiseAsCBOR
+  , ShelleyBasedEra(ShelleyBasedEraAlonzo, ShelleyBasedEraBabbage)
   , TextEnvelope(..)
   , TextEnvelopeType(..)
+  , Tx
   , TxBody
+  , deserialiseFromCBOR
   , deserialiseFromTextEnvelope
   , getTxId
   , metadataValueToJsonNoSchema
+  , proxyToAsType
+  , serialiseToCBOR
   , serialiseToTextEnvelope
   )
+import Cardano.Api.Byron (HasTextEnvelope(textEnvelopeType))
 import Cardano.Api.SerialiseTextEnvelope (TextEnvelopeDescr(..))
+import Cardano.Api.Shelley (ShelleyLedgerEra)
+import qualified Cardano.Binary as Binary
+import qualified Cardano.Ledger.Alonzo.Scripts as Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness)
+import qualified Cardano.Ledger.Core as Ledger.Core
+import Cardano.Ledger.Era (ValidateScript)
 import Control.Arrow (second)
 import Control.Error.Util (hush)
 import Control.Monad ((<=<))
 import Control.Monad.Except (MonadError, throwError)
 import Data.Aeson (Value(..))
 import Data.Bifunctor (bimap)
+import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce (coerce)
+import Data.Data (Typeable)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -493,6 +511,73 @@ instance IsCardanoEra era => FromDTO (TxBody era) where
   fromDTO = hush . deserialiseFromTextEnvelope asType <=< fromDTO
     where
       asType = AsTxBody $ cardanoEraToAsType $ cardanoEra @era
+
+instance HasDTO (Tx era) where
+  type DTO (Tx era) = Web.TextEnvelope
+
+instance IsCardanoEra era => ToDTO (Tx era) where
+  toDTO = toDTO . serialiseToTextEnvelope Nothing
+
+instance IsCardanoEra era => FromDTO (Tx era) where
+  fromDTO = hush . deserialiseFromTextEnvelope asType <=< fromDTO
+    where
+      asType = AsTx $ cardanoEraToAsType $ cardanoEra @era
+
+newtype ShelleyTxWitness era = ShelleyTxWitness (TxWitness (ShelleyLedgerEra era))
+
+instance HasTypeProxy era => HasTypeProxy (ShelleyTxWitness era) where
+    data AsType (ShelleyTxWitness era) = AsShelleyTxWitness (AsType era)
+    proxyToAsType _ = AsShelleyTxWitness (proxyToAsType (Proxy :: Proxy era))
+
+instance
+  ( HasTypeProxy era
+  , Typeable (ShelleyLedgerEra era)
+  , ValidateScript (ShelleyLedgerEra era)
+  , Ledger.Core.Script (ShelleyLedgerEra era) ~ Ledger.Alonzo.Scripts.Script (ShelleyLedgerEra era)
+  ) => SerialiseAsCBOR (ShelleyTxWitness era) where
+
+  serialiseToCBOR (ShelleyTxWitness wit) = Binary.serialize' wit
+
+  deserialiseFromCBOR _ bs = do
+    let
+      lbs = BSL.fromStrict bs
+
+      annotator :: forall s. Binary.Decoder s (Binary.Annotator (TxWitness (ShelleyLedgerEra era)))
+      annotator = Binary.fromCBOR
+
+    (w :: TxWitness (ShelleyLedgerEra era)) <- Binary.decodeAnnotator "Shelley Tx Witness" annotator lbs
+    pure $ ShelleyTxWitness w
+
+instance
+  ( IsShelleyBasedEra era
+  , ValidateScript (ShelleyLedgerEra era)
+  , Ledger.Core.Script (ShelleyLedgerEra era) ~ Ledger.Alonzo.Scripts.Script (ShelleyLedgerEra era)
+  ) => HasTextEnvelope (ShelleyTxWitness era) where
+  textEnvelopeType _ = do
+    "ShelleyTxWitness:" <> case shelleyBasedEra :: ShelleyBasedEra era of
+       ShelleyBasedEraAlonzo -> "Alonzo"
+       ShelleyBasedEraBabbage -> "Babbage"
+
+instance HasDTO (ShelleyTxWitness era) where
+  type DTO (ShelleyTxWitness era) = Web.TextEnvelope
+
+instance
+  ( IsShelleyBasedEra era
+  , ValidateScript (ShelleyLedgerEra era)
+  , Ledger.Core.Script (ShelleyLedgerEra era) ~ Ledger.Alonzo.Scripts.Script (ShelleyLedgerEra era)
+  ) => ToDTO (ShelleyTxWitness era) where
+  toDTO = toDTO . serialiseToTextEnvelope Nothing
+
+instance
+  ( IsShelleyBasedEra era
+  , ValidateScript (ShelleyLedgerEra era)
+  , IsCardanoEra era
+  , Ledger.Core.Script (ShelleyLedgerEra era) ~ Ledger.Alonzo.Scripts.Script (ShelleyLedgerEra era))
+  => FromDTO (ShelleyTxWitness era) where
+  fromDTO = hush . deserialiseFromTextEnvelope asType <=< fromDTO
+    where
+      eraAsType = cardanoEraToAsType $ cardanoEra @era
+      asType = AsShelleyTxWitness eraAsType
 
 instance HasDTO TextEnvelope where
   type DTO TextEnvelope = Web.TextEnvelope

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/DTO.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/DTO.hs
@@ -555,8 +555,8 @@ instance
   ) => HasTextEnvelope (ShelleyTxWitness era) where
   textEnvelopeType _ = do
     "ShelleyTxWitness " <> case shelleyBasedEra :: ShelleyBasedEra era of
-       ShelleyBasedEraAlonzo -> "Alonzo"
-       ShelleyBasedEraBabbage -> "Babbage"
+       ShelleyBasedEraAlonzo -> "AlonzoEra"
+       ShelleyBasedEraBabbage -> "BabbageEra"
 
 instance HasDTO (ShelleyTxWitness era) where
   type DTO (ShelleyTxWitness era) = Web.TextEnvelope

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/DTO.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/DTO.hs
@@ -554,7 +554,7 @@ instance
   , Ledger.Core.Script (ShelleyLedgerEra era) ~ Ledger.Alonzo.Scripts.Script (ShelleyLedgerEra era)
   ) => HasTextEnvelope (ShelleyTxWitness era) where
   textEnvelopeType _ = do
-    "ShelleyTxWitness:" <> case shelleyBasedEra :: ShelleyBasedEra era of
+    "ShelleyTxWitness " <> case shelleyBasedEra :: ShelleyBasedEra era of
        ShelleyBasedEraAlonzo -> "Alonzo"
        ShelleyBasedEraBabbage -> "Babbage"
 

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/ApiError.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/ApiError.hs
@@ -173,7 +173,7 @@ instance ToDTO (ApplyInputsError 'V1) where
     ApplyInputsLoadMarloweContextFailed (PayoutScriptNotPublished _) -> ApiError "Internal error" "InternalError" Null 500
     ApplyInputsLoadMarloweContextFailed (ExtractCreationError _) -> ApiError "Internal error" "InternalError" Null 500
     ApplyInputsLoadMarloweContextFailed (ExtractMarloweTransactionError _) -> ApiError "Internal error" "InternalError" Null 500
-    ApplyInputsConstraintsBuildupFailed (MarloweComputeTransactionFailed _) -> ApiError "Marlowe compute transaction failed" "MarloweComputeTransactionFailed" Null 400
+    ApplyInputsConstraintsBuildupFailed (MarloweComputeTransactionFailed err) -> ApiError ("Marlowe compute transaction failed: " <> err) "MarloweComputeTransactionFailed" Null 400
     ApplyInputsConstraintsBuildupFailed UnableToDetermineTransactionTimeout -> ApiError "Unable to determine transaction timeout" "UnableToDetermineTransactionTimeout" Null 400
     SlotConversionFailed _ -> ApiError "Slot conversion failed" "SlotConversionFailed" Null 400
     TipAtGenesis -> ApiError "Internal error" "InternalError" Null 500

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/ApiError.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/ApiError.hs
@@ -7,11 +7,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
--- | This module defines the data-transfer object (DTO) translation layer for
--- the web server. DTOs are the types served by the API, which notably include
--- no cardano-api dependencies and have nice JSON representations. This module
--- describes how they are mapped to the internal API types of the runtime.
-
 module Language.Marlowe.Runtime.Web.Server.REST.ApiError
   where
 

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Contracts.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Contracts.hs
@@ -9,13 +9,27 @@
 module Language.Marlowe.Runtime.Web.Server.REST.Contracts
   where
 
-import Cardano.Api (AsType(..), deserialiseFromTextEnvelope, getTxBody)
-import qualified Cardano.Api.SerialiseTextEnvelope as Cardano
+import Cardano.Api
+  ( BabbageEra
+  , ScriptValidity(ScriptInvalid, ScriptValid)
+  , TxBody
+  , TxScriptValidity(TxScriptValidity, TxScriptValidityNone)
+  , getTxBody
+  , makeSignedTransaction
+  )
+import qualified Cardano.Api as Cardano
+import Cardano.Api.Shelley (Tx(ShelleyTx), TxBody(ShelleyTxBody))
+import Cardano.Ledger.Alonzo.Tx (ValidatedTx(ValidatedTx))
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness(TxWitness))
+import Cardano.Ledger.BaseTypes (maybeToStrictMaybe)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (Value(Null))
+<<<<<<< HEAD
 import Data.Foldable (traverse_)
 import qualified Data.Map as Map
+import Data.Foldable (for_, traverse_)
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -23,6 +37,7 @@ import Language.Marlowe.Protocol.Query.Types (ContractFilter(..), Page(..))
 import Language.Marlowe.Runtime.ChainSync.Api (Lovelace(..))
 import Language.Marlowe.Runtime.Core.Api
   (MarloweMetadataTag(..), MarloweTransactionMetadata(..), MarloweVersion(..), SomeMarloweVersion(..))
+import Language.Marlowe.Runtime.Core.Api (ContractId, MarloweVersion(..), SomeMarloweVersion(..))
 import Language.Marlowe.Runtime.Transaction.Api (ContractCreated(..), WalletAddresses(..))
 import qualified Language.Marlowe.Runtime.Transaction.Api as Tx
 import Language.Marlowe.Runtime.Web hiding (Unsigned)
@@ -34,6 +49,10 @@ import Language.Marlowe.Runtime.Web.Server.REST.ApiError
 import qualified Language.Marlowe.Runtime.Web.Server.REST.ApiError as ApiError
 import qualified Language.Marlowe.Runtime.Web.Server.REST.Transactions as Transactions
 import Language.Marlowe.Runtime.Web.Server.TxClient (TempTx(TempTx), TempTxStatus(Unsigned), TxClientSelector)
+import Language.Marlowe.Runtime.Web.Server.TxClient (TempTx(TempTx), TempTxStatus(Unsigned))
+import Observe.Event (Event, EventBackend, addField, reference, withEvent)
+import Observe.Event.Backend (narrowEventBackend)
+import Observe.Event.BackendModification (setAncestor)
 import Observe.Event.DSL (FieldSpec(..), SelectorField(Inject), SelectorSpec(..))
 import Observe.Event.Explicit
   ( EventBackend
@@ -69,6 +88,7 @@ compile $ SelectorSpec "contracts"
       , "collateral" ≔ ''TxOutRefs
       , ["post", "error"] ≔ ''String
       , ["post", "response"] ≔ ''CreateTxBody
+      , ["post", "response", "create", "tx"] ≔ ''CreateTx
       ]
   , ["get", "one"] ≔ FieldSpec ["get", "one"]
       [ ["get", "id"] ≔ ''TxOutRef
@@ -87,17 +107,18 @@ server
   :: EventBackend IO r ContractsSelector
   -> ServerT ContractsAPI (AppM r)
 server eb = get eb
-       :<|> post eb
+       :<|> (postCreateTxBodyResponse eb :<|> postCreateTxResponse eb)
        :<|> contractServer eb
 
 post
-  :: EventBackend IO r ContractsSelector
+  -- :: EventBackend IO r ContractsSelector
+  :: Event (AppM r) r1 s PostField
   -> PostContractsRequest
   -> Address
   -> Maybe (CommaList Address)
   -> Maybe (CommaList TxOutRef)
-  -> AppM r PostContractsResponse
-post eb req@PostContractsRequest{..} changeAddressDTO mAddresses mCollateralUtxos = withEvent (hoistEventBackend liftIO eb) Post \ev -> do
+  -> AppM r (ContractId, TxBody BabbageEra)
+postCreateTxBody ev req@PostContractsRequest{..} changeAddressDTO mAddresses mCollateralUtxos = do
   addField ev $ NewContract req
   addField ev $ ChangeAddress changeAddressDTO
   traverse_ (addField ev . Addresses) mAddresses
@@ -116,10 +137,36 @@ post eb req@PostContractsRequest{..} changeAddressDTO mAddresses mCollateralUtxo
       addField ev $ PostError $ show err
       throwDTOError err
     Right ContractCreated{contractId, txBody} -> do
-      let (contractId', txBody') = toDTO (contractId, txBody)
-      let body = CreateTxBody contractId' txBody'
-      addField ev $ PostResponse body
-      pure $ IncludeLink (Proxy @"contract") body
+      pure (contractId, txBody)
+
+postCreateTxBodyResponse
+  :: EventBackend (AppM r) r ContractsSelector
+  -> PostContractsRequest
+  -> Address
+  -> Maybe (CommaList Address)
+  -> Maybe (CommaList TxOutRef)
+  -> AppM r PostContractsResponse
+postCreateTxBodyResponse eb req changeAddressDTO mAddresses mCollateralUtxos = withEvent (hoistEventBackend liftIO eb) Post \ev -> do
+  res <- postCreateTxBody ev req changeAddressDTO mAddresses mCollateralUtxos
+  let (contractId', txBody') = toDTO res
+  let body = CreateTxBody contractId' txBody'
+  addField ev $ PostResponse body
+  pure $ IncludeLink (Proxy @"contract") body
+
+postCreateTxResponse
+  :: EventBackend (AppM r) r ContractsSelector
+  -> PostContractsRequest
+  -> Address
+  -> Maybe (CommaList Address)
+  -> Maybe (CommaList TxOutRef)
+  -> AppM r PostContractsCreateTxResponse
+postCreateTxResponse eb req changeAddressDTO mAddresses mCollateralUtxos = withEvent (hoistEventBackend liftIO eb) Post \ev -> do
+  (contractId, txBody) <- postCreateTxBody ev req changeAddressDTO mAddresses mCollateralUtxos
+  let tx = makeSignedTransaction [] txBody
+  let (contractId', tx') = toDTO (contractId, tx)
+  let body = CreateTx contractId' tx'
+  addField ev $ PostResponseCreateTx body
+  pure $ IncludeLink (Proxy @"contract") body
 
 get
   :: EventBackend IO r ContractsSelector
@@ -179,18 +226,74 @@ put
 put eb contractId body = withEvent (hoistEventBackend liftIO eb) Put \ev -> do
   addField ev $ PutId contractId
   contractId' <- fromDTOThrow (badRequest' "Invalid contract id value") contractId
+
   loadContract contractId' >>= \case
     Nothing -> throwError $ notFound' "Contract not found"
     Just (Left (TempTx _ Unsigned Tx.ContractCreated{txBody})) -> do
-      textEnvelope <- fromDTOThrow (badRequest' "Invalid body value") body
-      addField ev $ Body textEnvelope
-      tx <- either (const $ throwError $ badRequest' "Invalid body text envelope content") pure $ deserialiseFromTextEnvelope (AsTx AsBabbage) textEnvelope
-      unless (getTxBody tx == txBody) $ throwError (badRequest' "Provided transaction body differs from the original one")
-      submitContract contractId' (narrowEventBackend (injectSelector RunTx) $ setAncestorEventBackend (reference ev) eb) tx >>= \case
+-- <<<<<<< HEAD
+--       textEnvelope <- fromDTOThrow (badRequest' "Invalid body value") body
+--       addField ev $ Body textEnvelope
+--       tx <- either (const $ throwError $ badRequest' "Invalid body text envelope content") pure $ deserialiseFromTextEnvelope (AsTx AsBabbage) textEnvelope
+--       unless (getTxBody tx == txBody) $ throwError (badRequest' "Provided transaction body differs from the original one")
+--       submitContract contractId' (narrowEventBackend (injectSelector RunTx) $ setAncestorEventBackend (reference ev) eb) tx >>= \case
+-- =======
+      let
+        -- `<|>` gives me error here
+        req :: Maybe (Either (Cardano.Tx BabbageEra) (ShelleyTxWitness BabbageEra))
+        req = case fromDTO (Left body) of
+          Just res -> pure res
+          Nothing -> fromDTO (Right body)
+
+      for_ (fromDTO body :: Maybe Cardano.TextEnvelope) \te ->
+        addField ev $ Body te
+
+      tx <- case req of
+        Nothing -> throwError $ badRequest' "Invalid body value"
+        Just (Left tx) -> do
+          unless (getTxBody tx == txBody) $ throwError (badRequest' "Provided transaction body differs from the original one")
+          pure tx
+        -- It seems that wallets provide nearly empty `TxWitness` back. Here is a quoat from `CIP-30` docs:
+        --
+        -- > Only the portions of the witness set that were signed as a result of this call are returned to
+        -- > encourage dApps to verify the contents returned by this endpoint while building the final transaction.
+        Just (Right (ShelleyTxWitness (TxWitness wtKeys _ _ _ _))) -> do
+          let
+            txScriptValidityToScriptValidity :: TxScriptValidity era -> ScriptValidity
+            txScriptValidityToScriptValidity TxScriptValidityNone = ScriptValid
+            txScriptValidityToScriptValidity (TxScriptValidity _ scriptValidity) = scriptValidity
+
+            scriptValidityToIsValid :: ScriptValidity -> Alonzo.IsValid
+            scriptValidityToIsValid ScriptInvalid = Alonzo.IsValid False
+            scriptValidityToIsValid ScriptValid = Alonzo.IsValid True
+
+            txScriptValidityToIsValid :: TxScriptValidity era -> Alonzo.IsValid
+            txScriptValidityToIsValid = scriptValidityToIsValid . txScriptValidityToScriptValidity
+
+            tx = case (txBody, makeSignedTransaction [] txBody) of
+              (ShelleyTxBody era txBody' _ _ txmetadata scriptValidity, ShelleyTx _ (ValidatedTx _ bkTxWitness _ _)) -> do
+                let
+                  TxWitness _ bkBoot bkScripts bkDats bkRdmrs = bkTxWitness
+                  wt' =
+                    TxWitness
+                      wtKeys
+                      bkBoot
+                      bkScripts
+                      bkDats
+                      bkRdmrs
+
+                ShelleyTx era $ ValidatedTx
+                  txBody'
+                  wt'
+                  (txScriptValidityToIsValid scriptValidity)
+                  (maybeToStrictMaybe txmetadata)
+          pure tx
+      submitContract contractId' (setAncestor $ reference ev) tx >>= \case
         Nothing -> pure NoContent
         Just err -> do
           addField ev $ Error $ show err
           throwError $ ApiError.toServerError $ ApiError (show err) "SubmissionError" Null 403
+
+
     Just _  -> throwError $
       ApiError.toServerError $
       ApiError "Contract already submitted" "ContractAlreadySubmitted" Null 409

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
@@ -72,8 +72,8 @@ compile $ SelectorSpec "transactions"
       , "addresses" ≔ ''Addresses
       , "collateral" ≔ ''TxOutRefs
       , ["post", "error"] ≔ ''String
-      , ["post", "response", "txBody"] ≔ [t|ApplyInputsTxBody CardanoTxBody|]
-      , ["post", "response", "tx"] ≔ [t|ApplyInputsTxBody CardanoTx|]
+      , ["post", "response", "txBody"] ≔ [t|ApplyInputsTxEnvelope CardanoTxBody|]
+      , ["post", "response", "tx"] ≔ [t|ApplyInputsTxEnvelope CardanoTx|]
       ]
   , ["get", "one"] ≔ FieldSpec ["get", "one"]
       [ ["get", "one", "contract", "id"] ≔ ''TxOutRef
@@ -162,7 +162,7 @@ postCreateTxBodyResponse eb contractId req changeAddressDTO mAddresses mCollater
   txBody <- postCreateTxBody ev contractId req changeAddressDTO mAddresses mCollateralUtxos
   let txBody' = toDTO txBody
   let txId = toDTO $ fromCardanoTxId $ getTxId txBody
-  let body = ApplyInputsTxBody contractId txId txBody'
+  let body = ApplyInputsTxEnvelope contractId txId txBody'
   addField ev $ PostResponseTxBody body
   pure $ IncludeLink (Proxy @"transaction") body
 
@@ -179,7 +179,7 @@ postCreateTxResponse eb contractId req changeAddressDTO mAddresses mCollateralUt
   let txId = toDTO $ fromCardanoTxId $ getTxId txBody
   let tx = makeSignedTransaction [] txBody
   let tx' = toDTO tx
-  let body = ApplyInputsTxBody contractId txId tx'
+  let body = ApplyInputsTxEnvelope contractId txId tx'
   addField ev $ PostResponseTx body
   pure $ IncludeLink (Proxy @"transaction") body
 

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Transactions.hs
@@ -9,13 +9,15 @@
 module Language.Marlowe.Runtime.Web.Server.REST.Transactions
   where
 
-import Cardano.Api (AsType(..), deserialiseFromTextEnvelope, getTxBody, getTxId)
-import qualified Cardano.Api.SerialiseTextEnvelope as Cardano
+import Cardano.Api (BabbageEra, TxBody, getTxBody, getTxId, makeSignedTransaction)
+import qualified Cardano.Api as Cardano
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness(TxWitness))
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (Value(Null))
 import Data.Foldable (traverse_)
 import qualified Data.Map as Map
+import Data.Foldable (for_, traverse_)
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Language.Marlowe.Protocol.Query.Types (Page(..))
@@ -45,6 +47,11 @@ import Observe.Event.Explicit
   , setAncestorEventBackend
   , withEvent
   )
+import Language.Marlowe.Runtime.Web.Server.TxClient (TempTx(TempTx), TempTxStatus(..))
+import Language.Marlowe.Runtime.Web.Server.Util (makeSignedTxWithWitnessKeys)
+import Observe.Event (Event, EventBackend, addField, reference, withEvent)
+import Observe.Event.BackendModification (setAncestor)
+import Observe.Event.DSL (FieldSpec(..), SelectorSpec(..))
 import Observe.Event.Render.JSON.DSL.Compile (compile)
 import Observe.Event.Syntax ((≔))
 import Servant
@@ -69,7 +76,8 @@ compile $ SelectorSpec "transactions"
       , "addresses" ≔ ''Addresses
       , "collateral" ≔ ''TxOutRefs
       , ["post", "error"] ≔ ''String
-      , ["post", "response"] ≔ ''ApplyInputsTxBody
+      , ["post", "response", "txBody"] ≔ [t|ApplyInputsTxBody CardanoTxBody|]
+      , ["post", "response", "tx"] ≔ [t|ApplyInputsTxBody CardanoTx|]
       ]
   , ["get", "one"] ≔ FieldSpec ["get", "one"]
       [ ["get", "one", "contract", "id"] ≔ ''TxOutRef
@@ -90,7 +98,7 @@ server
   -> TxOutRef
   -> ServerT TransactionsAPI (AppM r)
 server eb contractId = get eb contractId
-                  :<|> post eb contractId
+                  :<|> (postCreateTxBodyResponse eb contractId :<|> postCreateTxResponse eb contractId)
                   :<|> transactionServer eb contractId
 
 get
@@ -117,15 +125,15 @@ get eb contractId ranges = withEvent (hoistEventBackend liftIO eb) Get \ev -> do
       addField ev $ TxHeaders headers'
       addHeader totalCount . fmap ListObject <$> returnRange range (IncludeLink (Proxy @"transaction") <$> headers')
 
-post
-  :: EventBackend IO r TransactionsSelector
+postCreateTxBody
+  :: Event (AppM r) r' s PostField
   -> TxOutRef
   -> PostTransactionsRequest
   -> Address
   -> Maybe (CommaList Address)
   -> Maybe (CommaList TxOutRef)
-  -> AppM r PostTransactionsResponse
-post eb contractId req@PostTransactionsRequest{..} changeAddressDTO mAddresses mCollateralUtxos = withEvent (hoistEventBackend liftIO eb) Post \ev -> do
+  -> AppM r (TxBody BabbageEra)
+postCreateTxBody ev contractId req@PostTransactionsRequest{..} changeAddressDTO mAddresses mCollateralUtxos = do
   addField ev $ NewContract req
   addField ev $ ChangeAddress changeAddressDTO
   traverse_ (addField ev . Addresses) mAddresses
@@ -144,11 +152,41 @@ post eb contractId req@PostTransactionsRequest{..} changeAddressDTO mAddresses m
       addField ev $ PostError $ show err
       throwDTOError err
     Right InputsApplied{txBody} -> do
-      let txBody' = toDTO txBody
-      let txId = toDTO $ fromCardanoTxId $ getTxId txBody
-      let body = ApplyInputsTxBody contractId txId txBody'
-      addField ev $ PostResponse body
-      pure $ IncludeLink (Proxy @"transaction") body
+      pure txBody
+
+postCreateTxBodyResponse
+  :: EventBackend IO r TransactionsSelector
+  -> TxOutRef
+  -> PostTransactionsRequest
+  -> Address
+  -> Maybe (CommaList Address)
+  -> Maybe (CommaList TxOutRef)
+  -> AppM r (PostTransactionsResponse CardanoTxBody)
+postCreateTxBodyResponse eb contractId req changeAddressDTO mAddresses mCollateralUtxos = withEvent eb Post \ev -> do
+  txBody <- postCreateTxBody ev contractId req changeAddressDTO mAddresses mCollateralUtxos
+  let txBody' = toDTO txBody
+  let txId = toDTO $ fromCardanoTxId $ getTxId txBody
+  let body = ApplyInputsTxBody contractId txId txBody'
+  addField ev $ PostResponseTxBody body
+  pure $ IncludeLink (Proxy @"transaction") body
+
+postCreateTxResponse
+  :: EventBackend IO r TransactionsSelector
+  -> TxOutRef
+  -> PostTransactionsRequest
+  -> Address
+  -> Maybe (CommaList Address)
+  -> Maybe (CommaList TxOutRef)
+  -> AppM r (PostTransactionsResponse CardanoTx)
+postCreateTxResponse eb contractId req changeAddressDTO mAddresses mCollateralUtxos = withEvent eb Post \ev -> do
+  txBody <- postCreateTxBody ev contractId req changeAddressDTO mAddresses mCollateralUtxos
+  let txId = toDTO $ fromCardanoTxId $ getTxId txBody
+  let tx = makeSignedTransaction [] txBody
+  let tx' = toDTO tx
+  let body = ApplyInputsTxBody contractId txId tx'
+  addField ev $ PostResponseTx body
+  pure $ IncludeLink (Proxy @"transaction") body
+
 
 transactionServer
   :: EventBackend IO r TransactionsSelector
@@ -191,10 +229,23 @@ put eb contractId txId body = withEvent (hoistEventBackend liftIO eb) Put \ev ->
   loadTransaction contractId' txId' >>= \case
     Nothing -> throwError $ notFound' "Transaction not found"
     Just (Left (TempTx _ Unsigned Tx.InputsApplied{txBody})) -> do
-      textEnvelope <- fromDTOThrow (badRequest' "Invalid body value") body
-      addField ev $ Body textEnvelope
-      tx <- either (const $ throwError $ badRequest' "Invalid body text envelope content") pure $ deserialiseFromTextEnvelope (AsTx AsBabbage) textEnvelope
-      unless (getTxBody tx == txBody) $ throwError (badRequest' "Provided transaction body differs from the original one")
+      (req :: Maybe (Either (Cardano.Tx BabbageEra) (ShelleyTxWitness BabbageEra))) <- case teType body of
+        "Tx BabbageEra" -> pure $ Left <$> fromDTO body
+        "ShelleyTxWitness BabbageEra" -> pure $ Right <$> fromDTO body
+        _ -> throwError $ badRequest' "Unknown envelope type - allowed types are: \"Tx BabbageEra\", \"ShelleyTxWitness BabbageEra\""
+
+      for_ (fromDTO body :: Maybe Cardano.TextEnvelope) \te ->
+        addField ev $ Body te
+
+      tx <- case req of
+        Nothing -> throwError $ badRequest' "Invalid text envelope cbor value"
+        Just (Left tx) -> do
+          unless (getTxBody tx == txBody) $ throwError (badRequest' "Provided transaction body differs from the original one")
+          pure tx
+        Just (Right (ShelleyTxWitness (TxWitness wtKeys _ _ _ _))) -> do
+          case makeSignedTxWithWitnessKeys txBody wtKeys of
+            Just tx -> pure tx
+            Nothing -> throwError $ badRequest' "Invalid witness keys"
       submitTransaction contractId' txId' (narrowEventBackend (injectSelector RunTx) $ setAncestorEventBackend (reference ev) eb) tx >>= \case
         Nothing -> pure NoContent
         Just err -> do

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Withdrawals.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Withdrawals.hs
@@ -9,13 +9,14 @@
 module Language.Marlowe.Runtime.Web.Server.REST.Withdrawals
   where
 
-import Cardano.Api
-  (AsType(..), BabbageEra, TxBody, deserialiseFromTextEnvelope, getTxBody, getTxId, makeSignedTransaction)
+import Cardano.Api (BabbageEra, TxBody, getTxBody, getTxId, makeSignedTransaction)
+import qualified Cardano.Api as Cardano
 import qualified Cardano.Api.SerialiseTextEnvelope as Cardano
+import Cardano.Ledger.Alonzo.TxWitness
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (Value(..))
-import Data.Foldable (traverse_)
+import Data.Foldable (for_, traverse_)
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Language.Marlowe.Protocol.Query.Types (Page(..), WithdrawalFilter(..))
@@ -30,6 +31,7 @@ import Language.Marlowe.Runtime.Web.Server.REST.ApiError
 import qualified Language.Marlowe.Runtime.Web.Server.REST.ApiError as ApiError
 import qualified Language.Marlowe.Runtime.Web.Server.REST.Transactions as Transactions
 import Language.Marlowe.Runtime.Web.Server.TxClient (TempTx(..), TempTxStatus(..), TxClientSelector, Withdrawn(..))
+import Language.Marlowe.Runtime.Web.Server.Util
 import Observe.Event.Backend (Event)
 import Observe.Event.DSL (FieldSpec(..), SelectorField(..), SelectorSpec(..))
 import Observe.Event.Explicit
@@ -203,10 +205,23 @@ put eb contractId body = withEvent (hoistEventBackend liftIO eb) Put \ev -> do
   loadWithdrawal contractId' >>= \case
     Nothing -> throwError $ notFound' "Withdrawal not found"
     Just (Left (TempTx _ Unsigned (Withdrawn txBody))) -> do
-      textEnvelope <- fromDTOThrow (badRequest' "Invalid body value") body
-      addField ev $ Body textEnvelope
-      tx <- either (const $ throwError $ badRequest' "Invalid body text envelope content") pure $ deserialiseFromTextEnvelope (AsTx AsBabbage) textEnvelope
-      unless (getTxBody tx == txBody) $ throwError (badRequest' "Provided transaction body differs from the original one")
+      (req :: Maybe (Either (Cardano.Tx BabbageEra) (ShelleyTxWitness BabbageEra))) <- case teType body of
+        "Tx BabbageEra" -> pure $ Left <$> fromDTO body
+        "ShelleyTxWitness BabbageEra" -> pure $ Right <$> fromDTO body
+        _ -> throwError $ badRequest' "Unknown envelope type - allowed types are: \"Tx BabbageEra\", \"ShelleyTxWitness BabbageEra\""
+
+      for_ (fromDTO body :: Maybe Cardano.TextEnvelope) \te ->
+        addField ev $ Body te
+
+      tx <- case req of
+        Nothing -> throwError $ badRequest' "Invalid text envelope cbor value"
+        Just (Left tx) -> do
+          unless (getTxBody tx == txBody) $ throwError (badRequest' "Provided transaction body differs from the original one")
+          pure tx
+        Just (Right (ShelleyTxWitness (TxWitness wtKeys _ _ _ _))) -> do
+          case makeSignedTxWithWitnessKeys txBody wtKeys of
+            Just tx -> pure tx
+            Nothing -> throwError $ badRequest' "Invalid witness keys"
       submitWithdrawal contractId' (narrowEventBackend (injectSelector RunTx) $ setAncestorEventBackend (reference ev) eb) tx >>= \case
         Nothing -> pure NoContent
         Just err -> do

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Withdrawals.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Withdrawals.hs
@@ -11,7 +11,6 @@ module Language.Marlowe.Runtime.Web.Server.REST.Withdrawals
 
 import Cardano.Api (BabbageEra, TxBody, getTxBody, getTxId, makeSignedTransaction)
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Api.SerialiseTextEnvelope as Cardano
 import Cardano.Ledger.Alonzo.TxWitness
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/Util.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/Util.hs
@@ -1,9 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 module Language.Marlowe.Runtime.Web.Server.Util
   where
 
 import Data.Function (on)
 import qualified Data.List as List
-import Servant.Pagination (RangeOrder(..))
+
+import Cardano.Api
+  ( ScriptValidity(ScriptInvalid, ScriptValid)
+  , TxScriptValidity(TxScriptValidity, TxScriptValidityNone)
+  , makeSignedTransaction
+  )
+import Cardano.Api.Shelley (ShelleyLedgerEra, Tx(ShelleyTx), TxBody(ShelleyTxBody))
+import qualified Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.Tx (ValidatedTx(ValidatedTx))
+import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
+import Cardano.Ledger.Alonzo.TxWitness (TxWitness(TxWitness))
+import Cardano.Ledger.BaseTypes (maybeToStrictMaybe)
+import qualified Cardano.Ledger.Core
+import Cardano.Ledger.Era (Era(Crypto))
+import Cardano.Ledger.Keys (KeyRole(Witness))
+import Cardano.Ledger.Shelley.TxBody (WitVKey)
+import Data.Set (Set)
+import Servant.Pagination
 
 applyRangeToAscList :: Eq f => (a -> f) -> Maybe f -> Int -> Int -> RangeOrder -> [a] -> Maybe [a]
 applyRangeToAscList getField startFrom limit offset order =
@@ -19,3 +39,41 @@ applyRangeToAscList getField startFrom limit offset order =
         RangeDesc -> reverse
         RangeAsc -> id
     . List.nubBy (on (==) getField)
+
+type WitVKeys era = Set (WitVKey 'Witness (Crypto (ShelleyLedgerEra era)))
+
+makeSignedTxWithWitnessKeys ::
+  ( ShelleyLedgerEra era ~ shelleyLedgerEra
+  , Cardano.Ledger.Era.Era shelleyLedgerEra
+  , Cardano.Ledger.Core.Tx shelleyLedgerEra ~ ValidatedTx shelleyLedgerEra
+  , Cardano.Ledger.Core.Script shelleyLedgerEra ~ Cardano.Ledger.Alonzo.Scripts.Script shelleyLedgerEra
+  ) => TxBody era
+    -> WitVKeys era
+    -> Maybe (Tx era)
+makeSignedTxWithWitnessKeys txBody wtKeys = do
+  let
+    txScriptValidityToIsValid :: TxScriptValidity era -> Alonzo.IsValid
+    txScriptValidityToIsValid TxScriptValidityNone = Alonzo.IsValid True
+    txScriptValidityToIsValid (TxScriptValidity _ scriptValidity) = case scriptValidity of
+      ScriptValid -> Alonzo.IsValid True
+      ScriptInvalid -> Alonzo.IsValid False
+
+  case (txBody, makeSignedTransaction [] txBody) of
+    (ShelleyTxBody era txBody' _ _ txmetadata scriptValidity, ShelleyTx _ (ValidatedTx _ bkTxWitness _ _)) -> do
+      let
+        TxWitness _ bkBoot bkScripts bkDats bkRdmrs = bkTxWitness
+        wt' =
+          TxWitness
+            wtKeys
+            bkBoot
+            bkScripts
+            bkDats
+            bkRdmrs
+
+      Just $ ShelleyTx era $ ValidatedTx
+        txBody'
+        wt'
+        (txScriptValidityToIsValid scriptValidity)
+        (maybeToStrictMaybe txmetadata)
+    _ -> Nothing
+

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/API.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/API.hs
@@ -94,7 +94,7 @@ instance HasNamedLink ContractHeader API "transactions" where
     "contracts" :> Capture "contractId" TxOutRef :> "transactions" :> GetTransactionsAPI
   namedLink _ _ mkLink ContractHeader{..} = guard (status == Confirmed) $> mkLink contractId
 
-type PostContractsResponse tx = WithLink "contract" (CreateTxBody tx)
+type PostContractsResponse tx = WithLink "contract" (CreateTxEnvelope tx)
 
 data TxJSON a
 
@@ -109,18 +109,11 @@ instance MimeRender (TxJSON ContractTx) (PostContractsResponse CardanoTx) where
 instance MimeUnrender (TxJSON ContractTx) (PostContractsResponse CardanoTx) where
   mimeUnrender _ bs = eitherDecode bs
 
-instance HasNamedLink CreateTx API "contract" where
-  type Endpoint CreateTx API "contract" =
+instance HasNamedLink (CreateTxEnvelope tx) API "contract" where
+  type Endpoint (CreateTxEnvelope tx) API "contract" =
     "contracts" :> Capture "contractId" TxOutRef :> GetContractAPI
-  namedLink _ _ mkLink CreateTx{..} = Just $ mkLink contractId
+  namedLink _ _ mkLink CreateTxEnvelope{..} = Just $ mkLink contractId
 
-instance HasNamedLink (CreateTxBody tx) API "contract" where
-  type Endpoint (CreateTxBody tx) API "contract" =
-    "contracts" :> Capture "contractId" TxOutRef :> GetContractAPI
-  namedLink _ _ mkLink CreateTxBody{..} = Just $ mkLink contractId
-
-data CardanoTx
-data CardanoTxBody
 
 -- | POST /contracts sub-API
 type PostContractsAPI

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/API.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/API.hs
@@ -239,12 +239,6 @@ instance MimeRender (TxJSON WithdrawTx) (PostWithdrawalsResponse CardanoTx) wher
 instance MimeUnrender (TxJSON WithdrawTx) (PostWithdrawalsResponse CardanoTx) where
   mimeUnrender _ bs = eitherDecode bs
 
--- instance HasNamedLink (CreateTxEnvelope tx) API "contract" where
---   type Endpoint (CreateTxEnvelope tx) API "contract" =
---     "contracts" :> Capture "contractId" TxOutRef :> GetContractAPI
---   namedLink _ _ mkLink CreateTxEnvelope{..} = Just $ mkLink contractId
---
-
 instance HasNamedLink (WithdrawTxEnvelope tx) API "withdrawal" where
   type Endpoint (WithdrawTxEnvelope tx) API "withdrawal" =
     "withdrawals" :> Capture "withdrawalId" TxId :> GetWithdrawalAPI

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/API.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/API.hs
@@ -157,16 +157,16 @@ type PostTransactionsAPI
   =  ReqBody '[JSON] PostTransactionsRequest :> PostTxAPI (PostCreated '[JSON] (PostTransactionsResponse CardanoTxBody))
   :<|> ReqBody '[JSON] PostTransactionsRequest :> PostTxAPI (PostCreated '[TxJSON ApplyInputsTx] (PostTransactionsResponse CardanoTx))
 
-type PostTransactionsResponse tx = WithLink "transaction" (ApplyInputsTxBody tx)
+type PostTransactionsResponse tx = WithLink "transaction" (ApplyInputsTxEnvelope tx)
 
-instance HasNamedLink (ApplyInputsTxBody tx) API "transaction" where
-  type Endpoint (ApplyInputsTxBody tx) API "transaction" =
+instance HasNamedLink (ApplyInputsTxEnvelope tx) API "transaction" where
+  type Endpoint (ApplyInputsTxEnvelope tx) API "transaction" =
     "contracts"
     :> Capture "contractId" TxOutRef
     :> "transactions"
     :> Capture "transactionId" TxId
     :> GetTransactionAPI
-  namedLink _ _ mkLink ApplyInputsTxBody{..} = Just $ mkLink contractId transactionId
+  namedLink _ _ mkLink ApplyInputsTxEnvelope{..} = Just $ mkLink contractId transactionId
 
 -- | GET /contracts/:contractId/transactions sup-API
 type GetTransactionsAPI = PaginatedGet '["transactionId"] GetTransactionsResponse

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Client.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Client.hs
@@ -187,7 +187,7 @@ postTransaction
   -> Maybe (Set TxOutRef)
   -> TxOutRef
   -> PostTransactionsRequest
-  -> ClientM (ApplyInputsTxBody CardanoTxBody)
+  -> ClientM (ApplyInputsTxEnvelope CardanoTxBody)
 postTransaction changeAddress otherAddresses collateralUtxos contractId request = do
   let contractsClient :<|> _ = client
   let _ :<|> _ :<|> contractApi = contractsClient
@@ -205,7 +205,7 @@ postTransactionCreateTx
   -> Maybe (Set TxOutRef)
   -> TxOutRef
   -> PostTransactionsRequest
-  -> ClientM (ApplyInputsTxBody CardanoTx)
+  -> ClientM (ApplyInputsTxEnvelope CardanoTx)
 postTransactionCreateTx changeAddress otherAddresses collateralUtxos contractId request = do
   let (_ :<|> _ :<|> contractApi) :<|> _ = client
   let _ :<|> _ :<|> _ :<|> (_ :<|> postTransactionCreateTx') :<|> _ = contractApi contractId

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Client.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Client.hs
@@ -14,8 +14,8 @@ module Language.Marlowe.Runtime.Web.Client
   , postContract
   , postContractCreateTx
   , postTransaction
-  , postWithdrawal
   , postTransactionCreateTx
+  , postWithdrawal
   , putContract
   , putTransaction
   , putWithdrawal
@@ -31,7 +31,7 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Language.Marlowe.Runtime.Web.API
-  (API, CardanoTx, CardanoTxBody, GetContractsResponse, GetTransactionsResponse, GetWithdrawalsResponse, ListObject(..), api, retractLink)
+  (API, GetContractsResponse, GetTransactionsResponse, GetWithdrawalsResponse, ListObject(..), api, retractLink)
 import Language.Marlowe.Runtime.Web.Types
 import Servant (ResponseHeader(..), getResponse, lookupResponseHeader, type (:<|>)((:<|>)))
 import Servant.Client (Client, ClientM)
@@ -77,7 +77,7 @@ postContract
   -> Maybe (Set Address)
   -> Maybe (Set TxOutRef)
   -> PostContractsRequest
-  -> ClientM (CreateTxBody CardanoTxBody)
+  -> ClientM (CreateTxEnvelope CardanoTxBody)
 postContract changeAddress otherAddresses collateralUtxos request = do
   let (_ :<|> (postContractCreateTxBody' :<|> _) :<|> _) :<|> _ = client
   response <- postContractCreateTxBody'
@@ -92,7 +92,7 @@ postContractCreateTx
   -> Maybe (Set Address)
   -> Maybe (Set TxOutRef)
   -> PostContractsRequest
-  -> ClientM (CreateTxBody CardanoTx)
+  -> ClientM (CreateTxEnvelope CardanoTx)
 postContractCreateTx changeAddress otherAddresses collateralUtxos request = do
   let (_ :<|> (_ :<|> postContractCreateTx') :<|> _) :<|> _ = client
   response <- postContractCreateTx'

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Client.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Client.hs
@@ -12,6 +12,8 @@ module Language.Marlowe.Runtime.Web.Client
   , getWithdrawals
   , healthcheck
   , postContract
+  , postContractsCreateTx
+  , postContractsCreateTxBody
   , postTransaction
   , postWithdrawal
   , putContract
@@ -70,16 +72,24 @@ getContracts roleCurrencies tags range = do
     , items = retractLink @"contract" . retractLink @"transactions" <$> items
     }
 
-postContract
+postContractsCreateTxBody changeAddress otherAddresses collateralUtxos request = do
+  let _ :<|> (postContractCreateTxBody' :<|> _) :<|> _ = client
+  response <- postContractCreateTxBody'
+    request
+    changeAddress
+    (setToCommaList <$> otherAddresses)
+    (setToCommaList <$> collateralUtxos)
+  pure $ retractLink response
+
+postContractCreateTx
   :: Address
   -> Maybe (Set Address)
   -> Maybe (Set TxOutRef)
   -> PostContractsRequest
-  -> ClientM CreateTxBody
-postContract changeAddress otherAddresses collateralUtxos request = do
-  let contractsClient :<|> _ = client
-  let _ :<|> postContract' :<|> _ = contractsClient
-  response <- postContract'
+  -> ClientM CreateTx
+postContractCreateTx changeAddress otherAddresses collateralUtxos request = do
+  let _ :<|> (_ :<|> postContractCreateTx') :<|> _ = client
+  response <- postContractCreateTx'
     request
     changeAddress
     (setToCommaList <$> otherAddresses)

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
@@ -388,23 +388,36 @@ instance ToJSON WithdrawTxBody
 instance FromJSON WithdrawTxBody
 instance ToSchema WithdrawTxBody
 
-data CreateTxBody tx = CreateTxBody
+data CreateTxEnvelope tx = CreateTxEnvelope
   { contractId :: TxOutRef
   , txBody :: TextEnvelope
   } deriving (Show, Eq, Ord, Generic)
 
-instance ToJSON (CreateTxBody tx)
-instance FromJSON (CreateTxBody tx)
-instance Typeable tx => ToSchema (CreateTxBody tx)
+data CardanoTx
+data CardanoTxBody
 
-data CreateTx = CreateTx
-  { contractId :: TxOutRef
-  , tx :: TextEnvelope
-  } deriving (Show, Eq, Ord, Generic)
+instance ToJSON (CreateTxEnvelope CardanoTx) where
+  toJSON CreateTxEnvelope{..} = object
+    [ ("contractId", toJSON contractId)
+    , ("tx", toJSON txBody)
+    ]
+instance ToJSON (CreateTxEnvelope CardanoTxBody) where
+  toJSON CreateTxEnvelope{..} = object
+    [ ("contractId", toJSON contractId)
+    , ("txBody", toJSON txBody)
+    ]
 
-instance ToJSON CreateTx
-instance FromJSON CreateTx
-instance ToSchema CreateTx
+instance FromJSON (CreateTxEnvelope CardanoTx) where
+  parseJSON = withObject "CreateTxEnvelope" \obj -> CreateTxEnvelope
+    <$> obj .: "contractId"
+    <*> obj .: "tx"
+
+instance FromJSON (CreateTxEnvelope CardanoTxBody) where
+  parseJSON = withObject "CreateTxEnvelope" \obj -> CreateTxEnvelope
+    <$> obj .: "contractId"
+    <*> obj .: "txBody"
+
+instance Typeable tx => ToSchema (CreateTxEnvelope tx)
 
 data TextEnvelope = TextEnvelope
   { teType :: Text

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
@@ -652,6 +652,7 @@ data ApplyInputsTxEnvelope tx = ApplyInputsTxEnvelope
 instance ToJSON (ApplyInputsTxEnvelope CardanoTx) where
   toJSON ApplyInputsTxEnvelope{..} = object
     [ ("contractId", toJSON contractId)
+    , ("transactionId", toJSON transactionId)
     , ("tx", toJSON txEnvelope)
     ]
 instance ToJSON (ApplyInputsTxEnvelope CardanoTxBody) where

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
@@ -421,7 +421,7 @@ instance ToSchema (WithdrawTxEnvelope CardanoTx) where
 
 instance ToSchema (WithdrawTxEnvelope CardanoTxBody) where
   declareNamedSchema _ = do
-    withdrawalIdSchema <- declareSchemaRef (Proxy :: Proxy TxOutRef)
+    withdrawalIdSchema <- declareSchemaRef (Proxy :: Proxy TxId)
     txEnvelopeSchema <- declareSchemaRef (Proxy :: Proxy TextEnvelope)
     return $ NamedSchema (Just "ApplyInputsTxEnvelope") $ mempty
       & type_ ?~ OpenApiObject

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
@@ -21,6 +21,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.ByteString.Base16 (decodeBase16, encodeBase16)
 import Data.Char (isSpace)
+import Data.Data (Typeable)
 import Data.Foldable (fold)
 import Data.Map (Map)
 import Data.OpenApi
@@ -387,14 +388,14 @@ instance ToJSON WithdrawTxBody
 instance FromJSON WithdrawTxBody
 instance ToSchema WithdrawTxBody
 
-data CreateTxBody = CreateTxBody
+data CreateTxBody tx = CreateTxBody
   { contractId :: TxOutRef
   , txBody :: TextEnvelope
   } deriving (Show, Eq, Ord, Generic)
 
-instance ToJSON CreateTxBody
-instance FromJSON CreateTxBody
-instance ToSchema CreateTxBody
+instance ToJSON (CreateTxBody tx)
+instance FromJSON (CreateTxBody tx)
+instance Typeable tx => ToSchema (CreateTxBody tx)
 
 data CreateTx = CreateTx
   { contractId :: TxOutRef
@@ -457,8 +458,6 @@ data PostContractsRequest = PostContractsRequest
 instance FromJSON PostContractsRequest
 instance ToJSON PostContractsRequest
 instance ToSchema PostContractsRequest
-
-newtype PostContractsConstructTx = PostContractsConstructTx Bool
 
 data RolesConfig
   = UsePolicy PolicyId
@@ -609,13 +608,13 @@ instance FromJSON PostTransactionsRequest
 instance ToJSON PostTransactionsRequest
 instance ToSchema PostTransactionsRequest
 
-data ApplyInputsTxBody = ApplyInputsTxBody
+data ApplyInputsTxBody tx = ApplyInputsTxBody
   { contractId :: TxOutRef
   , transactionId :: TxId
   , txBody :: TextEnvelope
   } deriving (Show, Eq, Ord, Generic)
 
-instance ToJSON ApplyInputsTxBody
-instance FromJSON ApplyInputsTxBody
-instance ToSchema ApplyInputsTxBody
+instance ToJSON (ApplyInputsTxBody tx)
+instance FromJSON (ApplyInputsTxBody tx)
+instance Typeable tx => ToSchema (ApplyInputsTxBody tx)
 

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE StrictData #-}
@@ -395,6 +396,15 @@ instance ToJSON CreateTxBody
 instance FromJSON CreateTxBody
 instance ToSchema CreateTxBody
 
+data CreateTx = CreateTx
+  { contractId :: TxOutRef
+  , tx :: TextEnvelope
+  } deriving (Show, Eq, Ord, Generic)
+
+instance ToJSON CreateTx
+instance FromJSON CreateTx
+instance ToSchema CreateTx
+
 data TextEnvelope = TextEnvelope
   { teType :: Text
   , teDescription :: Text
@@ -447,6 +457,8 @@ data PostContractsRequest = PostContractsRequest
 instance FromJSON PostContractsRequest
 instance ToJSON PostContractsRequest
 instance ToSchema PostContractsRequest
+
+newtype PostContractsConstructTx = PostContractsConstructTx Bool
 
 data RolesConfig
   = UsePolicy PolicyId
@@ -606,3 +618,4 @@ data ApplyInputsTxBody = ApplyInputsTxBody
 instance ToJSON ApplyInputsTxBody
 instance FromJSON ApplyInputsTxBody
 instance ToSchema ApplyInputsTxBody
+

--- a/marlowe-runtime-web/test/Spec.hs
+++ b/marlowe-runtime-web/test/Spec.hs
@@ -143,7 +143,7 @@ instance Arbitrary Web.PostTransactionsRequest where
     <*> arbitraryNormal  -- FIXME: This should handle merkleized input, too.
   shrink = genericShrink
 
-instance Arbitrary Web.CreateTxBody where
+instance Arbitrary (Web.CreateTxBody tx) where
   arbitrary = Web.CreateTxBody <$> arbitrary <*> arbitrary
   shrink = genericShrink
 
@@ -151,7 +151,7 @@ instance Arbitrary Web.WithdrawTxBody where
   arbitrary = Web.WithdrawTxBody <$> arbitrary <*> arbitrary
   shrink = genericShrink
 
-instance Arbitrary Web.ApplyInputsTxBody where
+instance Arbitrary (Web.ApplyInputsTxBody tx) where
   arbitrary = Web.ApplyInputsTxBody <$> arbitrary <*> arbitrary <*> arbitrary
   shrink = genericShrink
 

--- a/marlowe-runtime-web/test/Spec.hs
+++ b/marlowe-runtime-web/test/Spec.hs
@@ -143,8 +143,8 @@ instance Arbitrary Web.PostTransactionsRequest where
     <*> arbitraryNormal  -- FIXME: This should handle merkleized input, too.
   shrink = genericShrink
 
-instance Arbitrary (Web.CreateTxBody tx) where
-  arbitrary = Web.CreateTxBody <$> arbitrary <*> arbitrary
+instance Arbitrary (Web.CreateTxEnvelope tx) where
+  arbitrary = Web.CreateTxEnvelope <$> arbitrary <*> arbitrary
   shrink = genericShrink
 
 instance Arbitrary Web.WithdrawTxBody where

--- a/marlowe-runtime-web/test/Spec.hs
+++ b/marlowe-runtime-web/test/Spec.hs
@@ -151,8 +151,8 @@ instance Arbitrary Web.WithdrawTxBody where
   arbitrary = Web.WithdrawTxBody <$> arbitrary <*> arbitrary
   shrink = genericShrink
 
-instance Arbitrary (Web.ApplyInputsTxBody tx) where
-  arbitrary = Web.ApplyInputsTxBody <$> arbitrary <*> arbitrary <*> arbitrary
+instance Arbitrary (Web.ApplyInputsTxEnvelope tx) where
+  arbitrary = Web.ApplyInputsTxEnvelope <$> arbitrary <*> arbitrary <*> arbitrary
   shrink = genericShrink
 
 instance Arbitrary Web.MarloweVersion where

--- a/marlowe-runtime-web/test/Spec.hs
+++ b/marlowe-runtime-web/test/Spec.hs
@@ -147,8 +147,8 @@ instance Arbitrary (Web.CreateTxEnvelope tx) where
   arbitrary = Web.CreateTxEnvelope <$> arbitrary <*> arbitrary
   shrink = genericShrink
 
-instance Arbitrary Web.WithdrawTxBody where
-  arbitrary = Web.WithdrawTxBody <$> arbitrary <*> arbitrary
+instance Arbitrary (Web.WithdrawTxEnvelope tx) where
+  arbitrary = Web.WithdrawTxEnvelope <$> arbitrary <*> arbitrary
   shrink = genericShrink
 
 instance Arbitrary (Web.ApplyInputsTxEnvelope tx) where


### PR DESCRIPTION
This change adds an alternative flow to the transaction submission:

* if the user provides an accept header to the `post`: "application/vendor.iog.marlowe-runtime.create-tx-json" we return back an `tx` text envelope instead of `txBody`.
* `put` endpoint is able to accept now both `tx` or `TxWitness`


Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested
