### PR TITLE
SCP-5128 Commented on rationale for allowing multiple outputs to an address

### DIFF
--- a/marlowe/CHANGELOG.md
+++ b/marlowe/CHANGELOG.md
@@ -19,3 +19,8 @@ Based on audit findings, we corrected the accounting equation so that negative d
 ## SCP-5129: Fixed `(==)` for `ReduceAssertionFailed`
 
 Based on audit finding, we corrected `instance Eq ReduceWarning` so that when a comparison of `ReduceAssertionFailed` to itself yields `True`.
+
+
+## SCP-5128: Rationale for multiple payments to address parties
+
+Based on audit finding, we added detailed comment in the Marlowe semantics validator about why multiple outputs to an address are allowed.

--- a/marlowe/specification/marlowe-cardano-specification.md
+++ b/marlowe/specification/marlowe-cardano-specification.md
@@ -358,6 +358,8 @@ all sufficient (txOutPayments transactionOutput)
 
 Note that the comparison is `leq` instead of equality because additional Ada may be required in the payment in order to satisfy the ledger's `minimum UTxO` constraint.
 
+The payment to a role must be in a single output, but the payment to an address may be split in multiple outputs, so long as the total output to the address is sufficient. (Note that allowing the multiple outputs to an address may increase transaction fees and wallet fragmentation, but the magnitude of this is severely limited by the Plutus execution budget, which strongly depends upon the number of UTxOs output. The flexibily of multiple outputs accommodates wallet-related practicalities (e.g., limitations in coin-selection and transaction balancing) such as the change and the return of the role token being in separate UTxOs in situations where a contract is also paying to the address where that change and that role token are sent.)
+
 
 ## Plutus Validator for Marlowe Payouts
 

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -378,6 +378,11 @@ mkMarloweValidator
       where
         payoutToTxOut :: (Party, Val.Value) -> Bool
         payoutToTxOut (party, value) = case party of
+            -- [Marlowe-Cardano Specification: "Constraint 15. Sufficient Payment".]
+            -- SCP-5128: Note that the payment to an address may be split into several outputs but the payment to a role must be
+            -- a single output. The flexibily of multiple outputs accommodates wallet-related practicalities such as the change and
+            -- the return of the role token being in separate UTxOs in situations where a contract is also paying to the address
+            -- where that change and that role token are sent.
             Address _ address  -> traceIfFalse "p" $ value `Val.leq` valuePaidToAddress address  -- At least sufficient value paid.
             Role role -> let
                 hsh = findDatumHash' (rolesCurrency, role)


### PR DESCRIPTION
1. Added comment to validator about why a payment to an address may be split in several outputs.
2. Added similar comment to the Marlowe-Cardano specification.
3. Also update the change log.

***Reviewers: Does this adequately address the following audit findings?***

![image](https://user-images.githubusercontent.com/2235898/222301066-c1d8a800-6f8e-4b75-b8f8-65ce4d2aa80a.png)

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, materialized Nix files, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [x] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested