### PR TITLE
Updated Readme and Flake.nix regarding Nix Settings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -140,8 +140,9 @@ To set up the cache:
 . On non-NixOS, edit `/etc/nix/nix.conf` and add the following lines:
 +
 ----
-substituters        = https://cache.iog.io https://iohk.cachix.org https://cache.nixos.org/
-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+substituters = https://cache.zw3rk.com https://cache.iog.io https://cache.nixos.org/
+trusted-public-keys = loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+extra-experimental-features = nix-command flakes
 ----
 +
 [NOTE]
@@ -152,9 +153,9 @@ You must be a https://nixos.org/nix/manual/#ssec-multi-user[trusted user] to do 
 . On NixOS, set the following NixOS options:
 +
 ----
-nix.settings = {
-  substituters        = [ "https://cache.iog.io" "https://iohk.cachix.org" ];
-  trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" "iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo=" ];
+nix = {
+  binaryCaches          = [ "https://cache.zw3rk.com" "https://cache.iog.io" ];
+  binaryCachePublicKeys = [ "loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=" "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
 };
 ----
 

--- a/flake.nix
+++ b/flake.nix
@@ -202,7 +202,7 @@
     extra-substituters = [
       # TODO: spongix
       "https://cache.iog.io"
-      # "https://cache.zw3rk.com"
+      "https://cache.zw3rk.com"
     ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="


### PR DESCRIPTION
By calling nix-develop on the repository, I ended up starting to download/build unexpected artifacts (e.g : building ghc-8-x-x...)... The documentation regarding Nix Settings was not updated, this PR updates the readme and uncomment a substituter in `Flake.nix`


