### PR TITLE
Hack to get Hydra to build with version changes pushed directly to main

### DIFF
--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -2,7 +2,7 @@ cabal-version: 3.0
 name: marlowe-chain-sync
 version: 0.0.1
 synopsis:
-  Cardano chain sync system for thee Marlowe Runtime
+  Cardano chain sync system for thee Marlowe Runtime.
 description:
   Marlowe runtime component for Cardano node synchronization. Communicates with
   downstream compoents using the Chain Sync protocol, which provides


### PR DESCRIPTION
Not sure why my version bump did not prompt Hydra to build the project, but it didn't even evaluate the change. Maybe related to us dropping materialization? Creating a PR should trigger it.