### PR TITLE
PLT-5462 Check Plutus logs in validator tests

### DIFF
--- a/marlowe-test/marlowe-test.cabal
+++ b/marlowe-test/marlowe-test.cabal
@@ -75,11 +75,26 @@ source-repository head
   type: git
   location: https://github.com/input-output-hk/marlowe-cardano
 
+
 flag defer-plugin-errors
     description:
         Defer errors from the plugin, useful for things like Haddock that can't handle it.
     default: False
     manual: True
+
+flag limit-static-analysis-time
+  description:
+    This flag sets the timeout seconds for static analysis testing of arbitrary
+    contracts, which can take so much time on a complex contract that it exceeds
+    hydra/CI resource limits, see SCP-4267.
+  default: True
+
+flag trace-plutus
+    description:
+        Enable Plutus trace log for Marlowe validators.
+    default: False
+    manual: True
+
 
 common lang
   default-language: Haskell2010
@@ -92,13 +107,6 @@ common lang
     -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wredundant-constraints -Widentities
     -Wunused-packages
-
-flag limit-static-analysis-time
-  description:
-    This flag sets the timeout seconds for static analysis testing of arbitrary
-    contracts, which can take so much time on a complex contract that it exceeds
-    hydra/CI resource limits, see SCP-4267.
-  default: True
 
 
 library
@@ -172,6 +180,8 @@ library
     , tasty-quickcheck >= 0.10 && < 0.11
     , text >= 1.2.4 && < 2
     , these >= 1.1 && < 2
+  if flag(trace-plutus)
+     cpp-options: -DTRACE_PLUTUS
 
 
 test-suite marlowe-test

--- a/marlowe-test/src/Spec/Marlowe/Marlowe.hs
+++ b/marlowe-test/src/Spec/Marlowe/Marlowe.hs
@@ -11,6 +11,7 @@
 -----------------------------------------------------------------------------
 
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -145,19 +146,30 @@ tests = testGroup "Contracts"
   ]
 
 
+maxAlternateMarloweValidatorSize :: Int
+maxMarloweValidatorSize :: Int
+#ifdef TRACE_PLUTUS
+maxAlternateMarloweValidatorSize = 15361
+maxMarloweValidatorSize = 12840
+#else
+maxAlternateMarloweValidatorSize = 14821
+maxMarloweValidatorSize = 12296
+#endif
+
+
 -- | Test that the typed validator is not too large.
 alternateMarloweValidatorSize :: IO ()
 alternateMarloweValidatorSize = do
     let validator = Scripts.validatorScript alternateMarloweValidator
     let vsize = SBS.length . SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    assertBool ("alternateMarloweValidator is too large " <> show vsize) (vsize <= 14821)
+    assertBool ("alternateMarloweValidator is too large " <> show vsize) (vsize <= maxAlternateMarloweValidatorSize)
 
 -- | Test that the untyped validator is not too large.
 marloweValidatorSize :: IO ()
 marloweValidatorSize = do
     let validator = Scripts.validatorScript marloweValidator
     let vsize = SBS.length . SBS.toShort . LB.toStrict $ Serialise.serialise validator
-    assertBool ("marloweValidator is too large " <> show vsize) (vsize <= 12296)
+    assertBool ("marloweValidator is too large " <> show vsize) (vsize <= maxMarloweValidatorSize)
 
 
 -- | Test `extractNonMerkleizedContractRoles`.

--- a/marlowe/CHANGELOG.md
+++ b/marlowe/CHANGELOG.md
@@ -1,46 +1,45 @@
-# Changelog for the `marlowe-cardano` Package
 
 
-## Start of changelog, December 2022
-
-The tag SCP-4415 (commit `23f3d56f22bf992ddb0b0c8a52bb7a5a188f9e9`) marks the version of this package that was subject to audit.
-
-
-## SCP-5126: Differences between Marlowe's Isabelle semantics and its Plutus validator
+# SCP-5126: Differences between Marlowe's Isabelle semantics and its Plutus validator
 
 Based on audit findings, we annotated Marlowe's Plutus validator with comments indicating how differences between `PlutusTx.AssocMap` and Isabelle's `MList` are inconsequential with respect to behavior of the validator, provided the Marlowe contract's initial state does not contain duplicate accounts, choices, or bound values.
 
 
-## SCP-5123: Semantically negative deposits do not withdraw funds from the script
+# SCP-5123: Semantically negative deposits do not withdraw funds from the script
 
 Based on audit findings, we corrected the accounting equation so that negative deposits are treated as zero by the validator. This prevents a negative deposit from removing value from the script's UTxO, which would have left the total value in accounts unequal to the value in the script UTxO.
 
 
-## SCP-5129: Fixed `(==)` for `ReduceAssertionFailed`
+# SCP-5129: Fixed `(==)` for `ReduceAssertionFailed`
 
 Based on audit finding, we corrected `instance Eq ReduceWarning` so that when a comparison of `ReduceAssertionFailed` to itself yields `True`.
 
 
-## SCP-5128: Rationale for multiple payments to address parties
+# SCP-5128: Rationale for multiple payments to address parties
 
 Based on audit finding, we added detailed comment in the Marlowe semantics validator about why multiple outputs to an address are allowed.
 
 
-## SCP-5124: Validator checks consistency of script output and internal accounts
+# SCP-5124: Validator checks consistency of script output and internal accounts
 
 Based on audit findings, we added "Constraint 18. Final balance" to the Marlowe-Cardano specification, requiring that the value output to the script address match the total value of the accounts in the output state, along with a corresponding check in the Marlowe semantics validator.
 
 
-## SCP-5143: Removed tracing from validator
+# SCP-5143: Removed tracing from validator
 
 In order to reduces the validator size, calls to Plutus tracing functions were removed.
 
 
-## SCP-5141: Valid initial and final states
+# SCP-5141: Valid initial and final states
 
 Based on audit findings, we added "Constraint 19. No duplicates" to the Marlowe-Cardano specification and require that the validator ensure that both the intial and final states of the contract obey the invariants of correct total value, positive balances, and non-duplication of keys for accounts, choices, and bound values.
 
 
-## SCP-5215: Single statisfaction
+# SCP-5215: Single statisfaction
 
 Based on audit findings, we added "Constraint 20. Single satisfaction" to the Marlowe-Cardano specification and require that the validator be the only script running in the transaction if any payments are made.
+
+
+# Start of changelog, December 2022
+
+The tag SCP-4415 (commit `23f3d56f22bf992ddb0b0c8a52bb7a5a188f9e9`) marks the version of this package that was subject to audit.

--- a/marlowe/changelog.d/20230418_154551_brian.bush_PLT_5462.md
+++ b/marlowe/changelog.d/20230418_154551_brian.bush_PLT_5462.md
@@ -1,0 +1,5 @@
+### Changed
+
+PLT-5462 adds a cabal flag `--flag trace-plutus` for the `marlowe-cardano` and `marlowe-test` packages. In production this flag should not be set because it enlarges the validator and changes its hash. If the flag is turned on, however, the test suite `test:marlowe-test` will check the Plutus logs to see that the correct error is occurring in cases where the validator should fail.
+
+This flag is also useful in `marlowe-cli` for creating a tracing validator for on-chain usage.

--- a/marlowe/marlowe-cardano.cabal
+++ b/marlowe/marlowe-cardano.cabal
@@ -29,6 +29,12 @@ flag defer-plugin-errors
     default: False
     manual: True
 
+flag trace-plutus
+    description:
+        Enable Plutus trace log for Marlowe validators.
+    default: False
+    manual: True
+
 common lang
   default-language: Haskell2010
   default-extensions: ExplicitForAll ScopedTypeVariables
@@ -90,3 +96,6 @@ library
     Language.Marlowe.Pretty
     Language.Marlowe.Analysis.FSSemantics
     Plutus.Debug
+
+  if flag(trace-plutus)
+     cpp-options: -DTRACE_PLUTUS

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -11,6 +11,7 @@
 -----------------------------------------------------------------------------
 
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
@@ -100,7 +101,13 @@ import qualified Prelude as Haskell
 import Unsafe.Coerce (unsafeCoerce)
 
 
--- Suppress traces, in order to save bytes.
+-- Conditionally suppress traces, in order to save bytes.
+
+#ifdef TRACE_PLUTUS
+
+import PlutusTx.Prelude (traceError, traceIfFalse)
+
+#else
 
 {-# INLINABLE traceError #-}
 traceError :: BuiltinString -> a
@@ -109,6 +116,8 @@ traceError _ = error ()
 {-# INLINABLE traceIfFalse #-}
 traceIfFalse :: BuiltinString -> a -> a
 traceIfFalse _ = id
+
+#endif
 
 
 -- | Input to a Marlowe transaction.


### PR DESCRIPTION
This PR adds a cabal flag `--flag trace-plutus` for the `marlowe-cardano` and `marlowe-test` packages. In production this flag should not be set because it enlarges the validator and changes its hash. If the flag is turned on, however, the test suite `test:marlowe-test` will check the Plutus logs to see that the correct error is occurring in cases where the validator should fail.

With this flag turned on, 10,000 repetitions of the semantics validator tests all passed. We need to discuss whether to turn on this flag in the CI, or just run it nightly. In any case, that will be a separate PR.

This flag is also useful in `marlowe-cli` for creating a tracing validator for on-chain usage.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [x] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested