### PR TITLE
PLT-5957 Fixed uncommented comments in operables derivation.

### DIFF
--- a/deploy/operables.nix
+++ b/deploy/operables.nix
@@ -130,7 +130,7 @@ in
       #################
       # OPTIONAL VARS #
       #################
-      OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
+      # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
 
       [ -z "''${NODE_CONFIG:-}" ] && echo "NODE_CONFIG env var must be set -- aborting" && exit 1
       [ -z "''${CARDANO_NODE_SOCKET_PATH:-}" ] && echo "CARDANO_NODE_SOCKET_PATH env var must be set -- aborting" && exit 1
@@ -197,7 +197,7 @@ in
       #################
       # OPTIONAL VARS #
       #################
-      OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
+      # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
 
       [ -z "''${HOST:-}" ] && echo "HOST env var must be set -- aborting" && exit 1
       [ -z "''${PORT:-}" ] && echo "PORT env var must be set -- aborting" && exit 1
@@ -256,7 +256,7 @@ in
       #################
       # OPTIONAL VARS #
       #################
-      OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
+      # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
 
       [ -z "''${DB_NAME:-}" ] && echo "DB_NAME env var must be set -- aborting" && exit 1
       [ -z "''${DB_USER:-}" ] && echo "DB_USER env var must be set -- aborting" && exit 1
@@ -313,7 +313,7 @@ in
       #################
       # OPTIONAL VARS #
       #################
-      OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
+      # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
 
       [ -z "''${HOST:-}" ] && echo "HOST env var must be set -- aborting" && exit 1
       [ -z "''${MARLOWE_SYNC_PORT:-}" ] && echo "MARLOWE_SYNC_PORT env var must be set -- aborting" && exit 1
@@ -359,7 +359,7 @@ in
       #################
       # OPTIONAL VARS #
       #################
-      OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
+      # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
 
       [ -z "''${HOST:-}" ] && echo "HOST env var must be set -- aborting" && exit 1
       [ -z "''${PORT:-}" ] && echo "PORT env var must be set -- aborting" && exit 1
@@ -398,7 +398,7 @@ in
       #################
       # OPTIONAL VARS #
       #################
-      OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
+      # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
 
       [ -z "''${HOST:-}" ] && echo "HOST env var must be set -- aborting" && exit 1
       [ -z "''${PORT:-}" ] && echo "PORT env var must be set -- aborting" && exit 1
@@ -440,7 +440,7 @@ in
       #################
       # OPTIONAL VARS #
       #################
-      OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
+      # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
 
       [ -z "''${PORT:-}" ] && echo "PORT env var must be set -- aborting" && exit 1
       [ -z "''${RUNTIME_HOST:-}" ] && echo "RUNTIME_HOST env var must be set -- aborting" && exit 1


### PR DESCRIPTION
A comment that wasn't commented out in the docker images has been causing `/bin/entrypoint` to fail for the Marlowe Runtime docker images.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [x] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested