### PR TITLE
PLT-6142 Fixed transaction submission in `marlowe-apps`

### DIFF
--- a/marlowe-apps/changelog.d/20230603_174929_brian.bush_PLT_6142.rst
+++ b/marlowe-apps/changelog.d/20230603_174929_brian.bush_PLT_6142.rst
@@ -1,0 +1,14 @@
+ Removed
+ -------
+
+ - Removed `MarloweRequest(Wait)` from `Languge.Marlowe.Runtime.App.Types`.
+
+ Deprecated
+ ----------
+
+ - Deprecated `submit'` and `waitForTx'` in `Language.Marlowe.Runtime.App.Submit`.
+
+ Fixed
+ -----
+
+ - `exe:marlowe-scaling` now successfully submits transactions.

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App.hs
@@ -19,7 +19,7 @@ import Language.Marlowe.Runtime.App.Build (buildApplication, buildCreation, buil
 import Language.Marlowe.Runtime.App.List (allContracts, allHeaders, getContract)
 import Language.Marlowe.Runtime.App.Run (runClientWithConfig)
 import Language.Marlowe.Runtime.App.Sign (sign)
-import Language.Marlowe.Runtime.App.Submit (submit, waitForTx)
+import Language.Marlowe.Runtime.App.Submit (submit)
 import Language.Marlowe.Runtime.App.Types (Config(timeoutSeconds), MarloweRequest(..), MarloweResponse(..), mkBody)
 import Language.Marlowe.Runtime.Core.Api
   (MarloweVersion(MarloweV1), MarloweVersionTag(V1), decodeMarloweTransactionMetadataLenient)
@@ -42,7 +42,9 @@ handle config request =
           Withdraw{..} -> second (uncurry mkBody) <$> buildWithdrawal MarloweV1 reqContractId reqRole reqAddresses reqChange reqCollateral
           Sign{..} -> pure . Right . uncurry Tx $ sign reqTxBody reqPaymentKeys reqPaymentExtendedKeys
           Submit{..} -> second TxId <$> submit reqTx
+{-
           Wait{..} -> second TxInfo <$> waitForTx reqPollingSeconds reqTxId
+-}
     withTimeout (timeoutSeconds config)
       $ runClientWithConfig config run
       `catch` \(err :: SomeException) -> pure . Left $ show err

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -153,15 +153,17 @@ transactWithEvents backend config@Config{buildSeconds, confirmSeconds, retryLimi
               $ \case
                 Tx{..}   -> pure resTx
                 response -> unexpected response
-          txId' <-
+          _txId' <-
             handleWithEvents subBackend "Submit" config (Submit tx)
               $ \case
                 TxId{..} -> pure resTxId
                 response -> unexpected response
+{-
           handleWithEvents subBackend "Confirm" config (Wait txId' 1)
             $ \case
               TxInfo{} -> pure ()
               response -> unexpected response
+-}
           when (confirmSeconds > 0)
             . withEvent subBackend (DynamicEventSelector "WaitAfterConfirm")
             . const

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
@@ -213,11 +213,12 @@ data MarloweRequest v =
   | Submit
     { reqTx :: C.Tx C.BabbageEra
     }
+{-
   | Wait
     { reqTxId :: TxId
     , reqPollingSeconds :: Int
     }
-
+-}
 
 instance A.FromJSON (MarloweRequest 'V1) where
   parseJSON =
@@ -264,10 +265,12 @@ instance A.FromJSON (MarloweRequest 'V1) where
             "submit" -> do
                         reqTx <- textEnvelopeFromJSON (C.AsTx C.AsBabbageEra) =<< o A..: "tx"
                         pure Submit{..}
+{-
             "wait" -> do
                         reqTxId <- fromString <$> o A..: "txId"
                         reqPollingSeconds <- o A..: "pollingSeconds"
                         pure Wait{..}
+-}
             request -> fail $ "Invalid request: " <> request <> "."
 
 instance A.ToJSON (MarloweRequest 'V1) where
@@ -328,13 +331,14 @@ instance A.ToJSON (MarloweRequest 'V1) where
       [ "request" A..= ("submit" :: String)
       , "tx" A..= textEnvelopeToJSON reqTx
       ]
+{-
   toJSON Wait{..} =
     A.object
       [ "request" A..= ("wait" :: String)
       , "txId" A..= reqTxId
       , "pollingSeconds" A..= reqPollingSeconds
       ]
-
+-}
 
 data MarloweResponse v =
     Contracts


### PR DESCRIPTION
This switches transaction submission in `marlowe-apps` to use `marlowe-tx` instead of `marlowe-chain-sync`.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested
