### PR TITLE
PLT-6202 Fix Console Logging

### DIFF
--- a/async-components/async-components.cabal
+++ b/async-components/async-components.cabal
@@ -56,3 +56,4 @@ library
     , servant-server >= 0.19 && < 0.20
     , unliftio >= 0.2.1 && < 0.3
     , warp >= 3.3 && < 4
+    , co-log >= 0.5.0.0 && < 0.6.0.0

--- a/async-components/src/Control/Concurrent/Component/Probes.hs
+++ b/async-components/src/Control/Concurrent/Component/Probes.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Control.Concurrent.Component.Probes
   where
 
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Monad.IO.Class (liftIO)
 import Data.Proxy (Proxy(..))
@@ -44,6 +46,6 @@ data ProbeServerDependencies = ProbeServerDependencies
   , port :: Port
   }
 
-probeServer :: MonadUnliftIO m => Component m ProbeServerDependencies ()
+probeServer :: (WithLog env Message m, MonadUnliftIO m) => Component m ProbeServerDependencies ()
 probeServer = component_ "probe-server" \ProbeServerDependencies{..} ->
   liftIO $ run port $ serve api (server probes)

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App.hs
@@ -41,7 +41,7 @@ handle config request =
           Apply{..} -> second (uncurry mkBody) <$> buildApplication MarloweV1 reqContractId reqInputs reqValidityLowerBound reqValidityUpperBound (decodeMarloweTransactionMetadataLenient reqMetadata) reqAddresses reqChange reqCollateral
           Withdraw{..} -> second (uncurry mkBody) <$> buildWithdrawal MarloweV1 reqContractId reqRole reqAddresses reqChange reqCollateral
           Sign{..} -> pure . Right . uncurry Tx $ sign reqTxBody reqPaymentKeys reqPaymentExtendedKeys
-          Submit{..} -> second TxId <$> submit reqTx
+          Submit{..} -> second TxId <$> submit reqPollingSeconds reqTx
 {-
           Wait{..} -> second TxInfo <$> waitForTx reqPollingSeconds reqTxId
 -}

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -1,6 +1,3 @@
-
-
-
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -154,7 +151,7 @@ transactWithEvents backend config@Config{buildSeconds, confirmSeconds, retryLimi
                 Tx{..}   -> pure resTx
                 response -> unexpected response
           _txId' <-
-            handleWithEvents subBackend "Submit" config (Submit tx)
+            handleWithEvents subBackend "Submit" config (Submit tx 1)
               $ \case
                 TxId{..} -> pure resTxId
                 response -> unexpected response

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
@@ -212,6 +212,7 @@ data MarloweRequest v =
     }
   | Submit
     { reqTx :: C.Tx C.BabbageEra
+    , reqPollingSeconds :: Int
     }
 {-
   | Wait
@@ -264,6 +265,7 @@ instance A.FromJSON (MarloweRequest 'V1) where
                         pure Sign{..}
             "submit" -> do
                         reqTx <- textEnvelopeFromJSON (C.AsTx C.AsBabbageEra) =<< o A..: "tx"
+                        reqPollingSeconds <- o A..: "pollingSeconds"
                         pure Submit{..}
 {-
             "wait" -> do

--- a/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer.hs
+++ b/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer.hs
@@ -12,6 +12,7 @@ module Language.Marlowe.Runtime.ChainIndexer
   ) where
 
 import Cardano.Api (CardanoMode, LocalNodeClientProtocolsInMode)
+import Colog (Message, WithLog)
 import Control.Arrow (returnA)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes
@@ -43,6 +44,7 @@ chainIndexer
      , MonadEvent r s m
      , Inject NodeClientSelector s
      , Inject (ChainStoreSelector r) s
+     , WithLog env Message m
      )
   => Component m (ChainIndexerDependencies r m) Probes
 chainIndexer = proc ChainIndexerDependencies{..} -> do

--- a/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/NodeClient.hs
+++ b/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/NodeClient.hs
@@ -42,6 +42,7 @@ import Cardano.Api.ChainSync.ClientPipelined
   , pipelineDecisionLowHighMark
   , runPipelineDecision
   )
+import Colog (Message, WithLog)
 import Control.Arrow ((&&&))
 import Control.Concurrent.Component
 import Control.Concurrent.STM (STM, TVar, modifyTVar, newTVar, readTVar, writeTVar)
@@ -137,8 +138,8 @@ data RollBackwardField
 
 -- | Create a new NodeClient component.
 nodeClient
-  :: forall r s m
-   . (MonadInjectEvent r NodeClientSelector s m, MonadUnliftIO m)
+  :: forall r s env m
+   . (MonadInjectEvent r NodeClientSelector s m, MonadUnliftIO m, WithLog env Message m)
   => Component m (NodeClientDependencies r m) (NodeClient r)
 nodeClient = component "indexer-node-client" \NodeClientDependencies{..} -> do
   changesVar <- newTVar emptyChanges

--- a/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/Store.hs
+++ b/marlowe-chain-sync/chain-indexer/Language/Marlowe/Runtime/ChainIndexer/Store.hs
@@ -9,6 +9,7 @@ module Language.Marlowe.Runtime.ChainIndexer.Store
   , chainStore
   ) where
 
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Concurrent.STM (STM, newTVar, readTVar)
 import Control.Concurrent.STM.Delay (Delay, newDelay, waitDelay)
@@ -50,7 +51,10 @@ data ChainStoreDependencies r m = ChainStoreDependencies
   }
 
 -- | Create a ChainStore component.
-chainStore :: forall r s m. (MonadUnliftIO m, MonadInjectEvent r (ChainStoreSelector r) s m) => Component m (ChainStoreDependencies r m) (STM Bool)
+chainStore
+  :: forall r s env m
+   . (MonadUnliftIO m, MonadInjectEvent r (ChainStoreSelector r) s m, WithLog env Message m)
+  => Component m (ChainStoreDependencies r m) (STM Bool)
 chainStore = component "indexer-chain-store" \ChainStoreDependencies{..} -> do
   readyVar <- newTVar False
   let

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync.hs
@@ -14,6 +14,7 @@ module Language.Marlowe.Runtime.ChainSync
 import Cardano.Api (CardanoEra, CardanoMode, Tx, TxValidationErrorInMode)
 import qualified Cardano.Api as Cardano
 import Cardano.Api.Shelley (AcquiringFailure)
+import Colog (Message, WithLog)
 import Control.Arrow (returnA)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes
@@ -48,7 +49,7 @@ data ChainSyncDependencies r s m = ChainSyncDependencies
   }
 
 chainSync
-  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, MonadFail m)
+  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, MonadFail m, WithLog env Message m)
   => Component m (ChainSyncDependencies r s m) Probes
 chainSync = proc ChainSyncDependencies{..} -> do
   let DatabaseQueries{..} = databaseQueries

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/JobServer.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/JobServer.hs
@@ -10,6 +10,7 @@ module Language.Marlowe.Runtime.ChainSync.JobServer
   where
 
 import Cardano.Api (CardanoEra(..), CardanoMode, ScriptDataSupportedInEra(..), Tx, TxValidationErrorInMode)
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Monad.Event.Class
 import Language.Marlowe.Runtime.ChainSync.Api (ChainSyncCommand(..))
@@ -29,7 +30,7 @@ data ChainSyncJobServerDependencies r s m = ChainSyncJobServerDependencies
   }
 
 chainSyncJobServer
-  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r)
+  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, WithLog env Message m)
   => Component m (ChainSyncJobServerDependencies r s m) ()
 chainSyncJobServer = serverComponent "chain-sync-job-server" worker \ChainSyncJobServerDependencies{..} -> do
   connector <- acceptSomeConnectorTraced jobSource
@@ -45,7 +46,7 @@ data WorkerDependencies r s m = WorkerDependencies
   }
 
 worker
-  :: forall r s m. (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r)
+  :: forall r s env m. (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, WithLog env Message m)
   => Component m (WorkerDependencies r s m) ()
 worker = component_ "chain-sync-job-worker" \WorkerDependencies{..} -> do
   let

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/NodeClient.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/NodeClient.hs
@@ -34,6 +34,7 @@ import Control.Concurrent.STM.TMVar (TMVar, putTMVar, takeTMVar)
 import Data.Bifunctor (first)
 import Observe.Event (addField)
 
+import Colog (Message, WithLog)
 import Control.Monad.Event.Class (MonadInjectEvent, withEvent)
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Client as Q
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Q
@@ -69,7 +70,9 @@ data NodeClientSelector f where
   Query :: NodeClientSelector (Q.Some (QueryInMode CardanoMode))
 
 
-nodeClient :: (MonadInjectEvent r NodeClientSelector s m, MonadUnliftIO m) => Component m NodeClientDependencies (NodeClient m)
+nodeClient
+  :: (MonadInjectEvent r NodeClientSelector s m, MonadUnliftIO m, WithLog env Message m)
+  => Component m NodeClientDependencies (NodeClient m)
 nodeClient =
   component "chain-sync-node-client" \NodeClientDependencies{..} ->
     do

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/QueryServer.hs
@@ -23,6 +23,8 @@ import Cardano.Api
   )
 import qualified Cardano.Api as Cardano
 import Cardano.Api.Shelley (AcquiringFailure)
+import Colog (WithLog)
+import qualified Colog as C
 import Control.Concurrent.Component
 import Control.Monad.Event.Class
 import Control.Monad.Trans.Except (ExceptT(ExceptT), except, runExceptT, throwE, withExceptT)
@@ -45,7 +47,7 @@ data ChainSyncQueryServerDependencies r s m = ChainSyncQueryServerDependencies
   }
 
 chainSyncQueryServer
-  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, MonadFail m)
+  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, MonadFail m, WithLog env C.Message m)
   => Component m (ChainSyncQueryServerDependencies r s m) ()
 chainSyncQueryServer = serverComponent "chain-sync-query-server" worker \ChainSyncQueryServerDependencies{..} -> do
   connector <- acceptSomeConnectorTraced querySource
@@ -62,7 +64,7 @@ data WorkerDependencies r s m = WorkerDependencies
   }
 
 worker
-  :: forall r s m. (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, MonadFail m)
+  :: forall r s env m. (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, MonadFail m, WithLog env C.Message m)
   => Component m (WorkerDependencies r s m) ()
 worker = component_ "chain-sync-query-worker" \WorkerDependencies{..} -> do
   let

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/Server.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/Server.hs
@@ -7,6 +7,7 @@
 module Language.Marlowe.Runtime.ChainSync.Server
   where
 
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Monad.Event.Class (MonadEvent)
 import Data.Functor (void, (<&>))
@@ -24,7 +25,7 @@ data ChainSyncServerDependencies r s m = ChainSyncServerDependencies
   }
 
 chainSyncServer
-  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r)
+  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, WithLog env Message m)
   => Component m (ChainSyncServerDependencies r s m) ()
 chainSyncServer = serverComponent "chain-seek-server" worker \ChainSyncServerDependencies{..} -> do
   connector <- acceptSomeConnectorTraced syncSource
@@ -37,7 +38,7 @@ data WorkerDependencies r s m = WorkerDependencies
   }
 
 worker
-  :: forall r s m. (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r)
+  :: forall r s env m. (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, WithLog env Message m)
   => Component m (WorkerDependencies r s m) ()
 worker = component_ "chain-seek-worker" \WorkerDependencies{..} -> do
   let

--- a/marlowe-chain-sync/marlowe-chain-indexer/Main.hs
+++ b/marlowe-chain-sync/marlowe-chain-indexer/Main.hs
@@ -45,10 +45,14 @@ import Observe.Event.Render.OpenTelemetry (tracerEventBackend)
 import OpenTelemetry.Trace
 import Options (Options(..), getOptions)
 import Paths_marlowe_chain_sync (version)
-import UnliftIO (MonadIO, MonadUnliftIO, liftIO, newMVar, throwIO, withMVar)
+import UnliftIO
+  (BufferMode(LineBuffering), MonadIO, MonadUnliftIO, hSetBuffering, liftIO, newMVar, stderr, stdout, throwIO, withMVar)
 
 main :: IO ()
-main = run =<< getOptions (showVersion version)
+main = do
+  hSetBuffering stderr LineBuffering
+  hSetBuffering stdout LineBuffering
+  run =<< getOptions (showVersion version)
 
 run :: Options -> IO ()
 run Options{..} = do

--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -99,6 +99,7 @@ library libchainsync
     , bytestring >= 0.10.12 && < 0.12
     , cardano-api ==1.35.4
     , cardano-binary ==1.5.0
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
@@ -142,6 +143,7 @@ library chain-indexer
     , cardano-ledger-byron ==0.1.0.0
     , cardano-ledger-core ==0.1.0.0
     , cardano-ledger-shelley ==0.1.0.0
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
@@ -236,6 +238,7 @@ executable marlowe-chain-indexer
     , cardano-api ==1.35.4
     , cardano-crypto-wrapper ==1.3.0
     , cardano-ledger-byron ==0.1.0.0
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1
@@ -271,6 +274,7 @@ executable marlowe-chain-sync
     , bytestring >= 0.10.12 && < 0.12
     , cardano-api ==1.35.4
     , cardano-ledger-byron ==0.1.0.0
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1

--- a/marlowe-chain-sync/marlowe-chain-sync/Main.hs
+++ b/marlowe-chain-sync/marlowe-chain-sync/Main.hs
@@ -20,14 +20,16 @@ import Cardano.Api
   , TxInMode(..)
   )
 import qualified Cardano.Api as Cardano (connectToLocalNode)
+import Colog (LogAction, Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
 import Control.Exception (bracket)
 import Control.Monad.Event.Class
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Reader (ask)
+import Control.Monad.Reader (MonadReader(..), asks, withReaderT)
 import Control.Monad.Trans.Reader (ReaderT(..))
 import Control.Monad.With (MonadWith(..))
+import Data.Bifunctor (first)
 import Data.GeneralAllocate
 import Data.String (IsString(fromString))
 import qualified Data.Text as T
@@ -134,11 +136,15 @@ run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseU
       }
 
 runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend). unAppM
+runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend, cmap fmtMessage logTextStdout). unAppM
 
 newtype AppM r a = AppM
-  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector) IO a
+  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a
   } deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadFail)
+
+instance MonadReader (LogAction (AppM r) Message) (AppM r) where
+  ask = AppM $ asks snd
+  local f (AppM m) = AppM $ withReaderT (fmap f) m
 
 instance MonadWith (AppM r) where
   type WithException (AppM r) = WithException IO
@@ -161,5 +167,5 @@ instance MonadWith (AppM r) where
     stateThreadingGeneralWith (GeneralAllocate allocA') (flip (runReaderT . unAppM) r . go)
 
 instance MonadEvent r RootSelector (AppM r) where
-  localBackend = localBackendReaderT AppM unAppM id
-  askBackend = askBackendReaderT AppM id
+  localBackend = localBackendReaderT AppM unAppM first
+  askBackend = askBackendReaderT AppM fst

--- a/marlowe-chain-sync/marlowe-chain-sync/Main.hs
+++ b/marlowe-chain-sync/marlowe-chain-sync/Main.hs
@@ -20,7 +20,7 @@ import Cardano.Api
   , TxInMode(..)
   )
 import qualified Cardano.Api as Cardano (connectToLocalNode)
-import Colog (LogAction, Message, cmap, fmtMessage, logTextStdout)
+import Colog (LogAction(LogAction), Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
 import Control.Exception (bracket)
@@ -55,7 +55,7 @@ import Observe.Event.Render.OpenTelemetry (tracerEventBackend)
 import OpenTelemetry.Trace
 import Options (Options(..), getOptions)
 import Paths_marlowe_chain_sync (version)
-import UnliftIO (MonadUnliftIO, throwIO)
+import UnliftIO (MonadUnliftIO, newMVar, throwIO, withMVar)
 
 main :: IO ()
 main = run =<< getOptions (showVersion version)
@@ -136,7 +136,15 @@ run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseU
       }
 
 runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend, cmap fmtMessage logTextStdout). unAppM
+runAppM eventBackend (AppM action) = do
+  logAction <- concurrentLogger
+  runReaderT action (hoistEventBackend liftIO eventBackend, logAction)
+
+concurrentLogger :: MonadUnliftIO m => IO (LogAction m Message)
+concurrentLogger = do
+  lock <- newMVar ()
+  let LogAction baseAction = cmap fmtMessage logTextStdout
+  pure $ LogAction $ withMVar lock . const . baseAction
 
 newtype AppM r a = AppM
   { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a

--- a/marlowe-chain-sync/marlowe-chain-sync/Main.hs
+++ b/marlowe-chain-sync/marlowe-chain-sync/Main.hs
@@ -55,10 +55,13 @@ import Observe.Event.Render.OpenTelemetry (tracerEventBackend)
 import OpenTelemetry.Trace
 import Options (Options(..), getOptions)
 import Paths_marlowe_chain_sync (version)
-import UnliftIO (MonadUnliftIO, newMVar, throwIO, withMVar)
+import UnliftIO (BufferMode(LineBuffering), MonadUnliftIO, hSetBuffering, newMVar, stderr, stdout, throwIO, withMVar)
 
 main :: IO ()
-main = run =<< getOptions (showVersion version)
+main = do
+  hSetBuffering stderr LineBuffering
+  hSetBuffering stdout LineBuffering
+  run =<< getOptions (showVersion version)
 
 run :: Options -> IO ()
 run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseUri)) Pool.release \pool -> do

--- a/marlowe-integration-tests/marlowe-integration-tests.cabal
+++ b/marlowe-integration-tests/marlowe-integration-tests.cabal
@@ -88,6 +88,7 @@ executable marlowe-integration-tests
     , base16
     , bytestring
     , cardano-api
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers
     , eventuo11y-extras
     , hspec

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Contract.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Contract.hs
@@ -208,6 +208,7 @@ type TestM = ReaderT TestHandle (NoopEventT TestRef AnySelector (ResourceT IO))
 data TestHandle = TestHandle
   { loadConnector :: SomeClientConnectorTraced MarloweLoadClient TestRef AnySelector TestM
   , queryConnector :: SomeClientConnectorTraced (QueryClient Api.ContractRequest) TestRef AnySelector TestM
+  , logAction :: LogAction TestM Message
   }
 
 instance HasLog TestHandle Message TestM where

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Contract.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Contract.hs
@@ -7,6 +7,7 @@ module Language.Marlowe.Runtime.Integration.Contract
   where
 
 import Cardano.Api.Byron (ScriptData(ScriptDataBytes), hashScriptData)
+import Colog (HasLog(..), LogAction, Message)
 import Control.Concurrent.Component
 import Control.Monad (foldM)
 import Control.Monad.Event.Class (Inject(..), NoopEventT(runNoopEventT))
@@ -193,6 +194,7 @@ runContractTest test = runResourceT do
     testHandle = TestHandle
       { loadConnector = SomeConnectorTraced inject $ clientConnector loadPair
       , queryConnector = SomeConnectorTraced inject $ clientConnector queryPair
+      , logAction = mempty
       }
   runNoopEventT $ flip runReaderT testHandle $ race_ test $ runComponent_ (void Contract.contract) Contract.ContractDependencies
     { batchSize = unsafeIntToNat 10
@@ -207,6 +209,9 @@ data TestHandle = TestHandle
   { loadConnector :: SomeClientConnectorTraced MarloweLoadClient TestRef AnySelector TestM
   , queryConnector :: SomeClientConnectorTraced (QueryClient Api.ContractRequest) TestRef AnySelector TestM
   }
+
+instance HasLog TestHandle Message TestM where
+  logActionL f TestHandle{..} = (\logAction' -> TestHandle{logAction = logAction', ..}) <$> f logAction
 
 newtype TestRef = TestRef ()
   deriving newtype (Semigroup, Monoid)

--- a/marlowe-integration/marlowe-integration.cabal
+++ b/marlowe-integration/marlowe-integration.cabal
@@ -59,6 +59,7 @@ library
     , cardano-crypto-wrapper
     , cardano-integration
     , cardano-ledger-byron
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras
@@ -87,6 +88,7 @@ library
     , marlowe-runtime:sync-api
     , marlowe-runtime:tx
     , marlowe-runtime:tx-api
+    , mtl >= 2.2 && < 3
     , network
     , nonempty-containers
     , ouroboros-network

--- a/marlowe-integration/src/Test/Integration/Marlowe/Local.hs
+++ b/marlowe-integration/src/Test/Integration/Marlowe/Local.hs
@@ -322,6 +322,8 @@ withLocalMarloweRuntime' MarloweRuntimeOptions{..} test = withRunInIO \runInIO -
 
     let chainSyncConnector = SomeConnectorTraced inject $ clientConnector chainSyncPair
     let chainSyncJobConnector = SomeConnectorTraced inject $ clientConnector chainSyncJobPair
+    let confirmationTimeout = 60
+    let pollingInterval = 0.1
     let mkSubmitJob = Submit.mkSubmitJob SubmitJobDependencies{..}
     let baseUrl = BaseUrl Http "localhost" webPort ""
     let clientEnv = mkClientEnv manager baseUrl

--- a/marlowe-protocols/marlowe-protocols.cabal
+++ b/marlowe-protocols/marlowe-protocols.cabal
@@ -78,6 +78,7 @@ library
     , base16 >= 0.3.2 && < 0.4
     , binary >= 0.8.8 && < 0.9
     , bytestring >= 0.10.12 && < 0.12
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0

--- a/marlowe-protocols/src/Network/Protocol/Driver.hs
+++ b/marlowe-protocols/src/Network/Protocol/Driver.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -6,6 +7,8 @@
 module Network.Protocol.Driver
   where
 
+import qualified Colog as C
+import Colog.Monad (WithLog)
 import Control.Concurrent.Component
 import Control.Concurrent.STM (newEmptyTMVar, newTQueue, readTMVar, readTQueue, tryPutTMVar)
 import Control.Concurrent.STM.TQueue (writeTQueue)
@@ -82,7 +85,7 @@ data TcpServerDependencies ps server m = forall (st :: ps). TcpServerDependencie
   }
 
 tcpServer
-  :: (MonadIO m', MonadUnliftIO m)
+  :: (MonadIO m', MonadUnliftIO m, WithLog env C.Message m)
   => String -> Component m (TcpServerDependencies ps server m') (ConnectionSource ps server m')
 tcpServer name = component (name <> "-tcp-server") \TcpServerDependencies{..} -> do
   socketQueue <- newTQueue

--- a/marlowe-protocols/src/Network/Protocol/Driver/Trace.hs
+++ b/marlowe-protocols/src/Network/Protocol/Driver/Trace.hs
@@ -5,10 +5,13 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Network.Protocol.Driver.Trace
   where
 
+import Colog (WithLog)
+import qualified Colog as C
 import Control.Concurrent.Component
 import Control.Concurrent.STM (newEmptyTMVar, newTQueue, readTMVar, readTQueue, tryPutTMVar)
 import Control.Concurrent.STM.TQueue (writeTQueue)
@@ -218,7 +221,7 @@ data ConnectedField
   | ConnectedPeer SockAddr
 
 tcpServerTraced
-  :: (MonadIO m', MonadUnliftIO m, MonadEvent r s m', HasSpanContext r)
+  :: (MonadIO m', MonadUnliftIO m, MonadEvent r s m', HasSpanContext r, WithLog env C.Message m)
   => String
   -> InjectSelector (TcpServerSelector (Handshake ps)) s
   -> Component m (TcpServerDependencies ps server m') (ConnectionSourceTraced ps server r TcpServerSelector m')

--- a/marlowe-runtime-web/marlowe-runtime-web.cabal
+++ b/marlowe-runtime-web/marlowe-runtime-web.cabal
@@ -107,6 +107,7 @@ library server
     , cardano-ledger-alonzo ==0.1.0.0
     , cardano-ledger-core ==0.1.0.0
     , cardano-ledger-shelley ==0.1.0.0
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , errors >= 2.3 && < 3
     , eventuo11y ^>= { 0.9, 0.10 }
@@ -154,6 +155,7 @@ executable marlowe-web-server
   build-depends:
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-otel ^>= 0.1
     , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
@@ -167,6 +169,7 @@ executable marlowe-web-server
     , network
     , optparse-applicative
     , text >= 1.2.4 && < 2
+    , unliftio >= 0.2.1 && < 0.3
     , wai >= 3.2 && < 4
     , warp
   ghc-options: -threaded

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server.hs
@@ -28,13 +28,13 @@ module Language.Marlowe.Runtime.Web.Server
 import Control.Concurrent.Component
 import Control.Monad.Event.Class
 import Control.Monad.IO.Unlift (liftIO, withRunInIO)
-import Control.Monad.Reader (runReaderT)
+import Control.Monad.Reader (ReaderT(ReaderT), runReaderT)
 import Control.Monad.Trans.Marlowe (MarloweTracedContext(..))
 import Language.Marlowe.Protocol.Types (MarloweRuntime)
 import Language.Marlowe.Runtime.ChainSync.Api (TxId)
 import Language.Marlowe.Runtime.Core.Api (ContractId)
 import qualified Language.Marlowe.Runtime.Web as Web
-import Language.Marlowe.Runtime.Web.Server.Monad (AppEnv(..), AppM(..), BackendM)
+import Language.Marlowe.Runtime.Web.Server.Monad (AppEnv(..), AppM(..), BackendM(BackendM))
 import qualified Language.Marlowe.Runtime.Web.Server.OpenAPI as OpenAPI
 import qualified Language.Marlowe.Runtime.Web.Server.REST as REST
 import Language.Marlowe.Runtime.Web.Server.SyncClient
@@ -189,6 +189,7 @@ webServer = component_ "web-server" \WebServerDependencies{..} -> withRunInIO \r
   runApplication \req handleRes ->
     runInIO $ withEventFields (ServeRequest req) [ReqField req] \ev -> do
       _eventBackend <- askBackend
+      _logAction <- BackendM $ ReaderT \(_, logAction) -> pure logAction
       let _requestParent = reference ev
       let
         mkApp

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
@@ -10,6 +10,7 @@ module Language.Marlowe.Runtime.Web.Server.TxClient
   where
 
 import Cardano.Api (BabbageEra, Tx, TxBody, getTxId)
+import Colog (Message, WithLog)
 import Control.Concurrent.Async (concurrently_)
 import Control.Concurrent.Component
 import Control.Concurrent.STM
@@ -133,8 +134,8 @@ type WithMapUpdate k tx a
 data SomeTVarWithMapUpdate = forall k tx a. Ord k => SomeTVarWithMapUpdate (TVar a) (WithMapUpdate k tx a)
 
 txClient
-  :: forall r s m
-   . (MonadEvent r s m, MonadUnliftIO m, HasSpanContext r)
+  :: forall r s env m
+   . (MonadEvent r s m, MonadUnliftIO m, HasSpanContext r, WithLog env Message m)
   => Component m (TxClientDependencies r s m) (TxClient r m)
 txClient = component "web-tx-client" \TxClientDependencies{..} -> do
   tempContracts <- newTVar mempty

--- a/marlowe-runtime/changelog.d/20230612_154054_jhbertra_plt_6202_console_logging.md
+++ b/marlowe-runtime/changelog.d/20230612_154054_jhbertra_plt_6202_console_logging.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Console log formatting.
+- Increased the maximum confirmation wait time in `marlowe-tx` to 1 hour.
+
+### Fixed
+
+- Console logs are new thread-safe.
+- `marlowe-scaling` did not delay polling at all when submitting a transaction.

--- a/marlowe-runtime/changelog.d/20230612_154054_jhbertra_plt_6202_console_logging.md
+++ b/marlowe-runtime/changelog.d/20230612_154054_jhbertra_plt_6202_console_logging.md
@@ -5,5 +5,5 @@
 
 ### Fixed
 
-- Console logs are new thread-safe.
+- Console logs are now thread-safe.
 - `marlowe-scaling` did not delay polling at all when submitting a transaction.

--- a/marlowe-runtime/contract/Language/Marlowe/Runtime/Contract.hs
+++ b/marlowe-runtime/contract/Language/Marlowe/Runtime/Contract.hs
@@ -6,6 +6,8 @@
 module Language.Marlowe.Runtime.Contract
   where
 
+import Colog (WithLog)
+import qualified Colog as C
 import Control.Arrow (returnA)
 import Control.Concurrent.Component (Component)
 import Control.Concurrent.Component.Probes
@@ -34,6 +36,7 @@ contract
     , MonadEvent r s m
     , Inject LoadServerSelector s
     , HasSpanContext r
+    , WithLog env C.Message m
     )
   => Component m (ContractDependencies r s m) Probes
 contract = proc deps -> do

--- a/marlowe-runtime/contract/Language/Marlowe/Runtime/Contract/LoadServer.hs
+++ b/marlowe-runtime/contract/Language/Marlowe/Runtime/Contract/LoadServer.hs
@@ -6,6 +6,8 @@
 module Language.Marlowe.Runtime.Contract.LoadServer
   where
 
+import Colog (WithLog)
+import qualified Colog as C
 import Control.Concurrent.Component
 import Control.Monad.Event.Class
 import Data.Functor (void)
@@ -29,7 +31,7 @@ data LoadServerDependencies r s m = forall n. LoadServerDependencies
   }
 
 loadServer
-  :: (MonadUnliftIO m, MonadInjectEvent r LoadServerSelector s m, HasSpanContext r)
+  :: (MonadUnliftIO m, MonadInjectEvent r LoadServerSelector s m, HasSpanContext r, WithLog env C.Message m)
   => Component m (LoadServerDependencies r s m) ()
 loadServer = serverComponent "contract-load-server" worker \LoadServerDependencies{..} -> do
   connector <- acceptSomeConnectorTraced loadSource
@@ -42,10 +44,11 @@ data WorkerDependencies r s m = forall n. WorkerDependencies
   }
 
 worker
-  :: forall r s m.
+  :: forall r s env m.
     ( MonadUnliftIO m
     , MonadInjectEvent r LoadServerSelector s m
     , HasSpanContext r
+    , WithLog env C.Message m
     )
   => Component m (WorkerDependencies r s m) ()
 worker = component_ "contract-load-worker" \WorkerDependencies{..} -> case connector of

--- a/marlowe-runtime/contract/Language/Marlowe/Runtime/Contract/QueryServer.hs
+++ b/marlowe-runtime/contract/Language/Marlowe/Runtime/Contract/QueryServer.hs
@@ -6,6 +6,7 @@
 module Language.Marlowe.Runtime.Contract.QueryServer
   where
 
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Monad.Event.Class
 import Language.Marlowe.Runtime.Contract.Api hiding (getContract, merkleizeInputs)
@@ -21,7 +22,7 @@ data QueryServerDependencies r s m = QueryServerDependencies
   }
 
 queryServer
-  :: (MonadUnliftIO m, HasSpanContext r, MonadEvent r s m)
+  :: (MonadUnliftIO m, HasSpanContext r, MonadEvent r s m, WithLog env Message m)
   => Component m (QueryServerDependencies r s m) ()
 queryServer = serverComponent "contract-query-server" (component_ "contract-query-worker" worker) \QueryServerDependencies{..} -> do
   connector <- acceptSomeConnectorTraced querySource

--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer.hs
@@ -7,6 +7,7 @@
 module Language.Marlowe.Runtime.Indexer
   where
 
+import Colog (Message, WithLog)
 import Control.Arrow (returnA)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes
@@ -43,6 +44,7 @@ marloweIndexer
      , Inject (ChainSeekClientSelector r) s
      , MonadFail m
      , HasSpanContext r
+     , WithLog env Message m
      )
   => Component m (MarloweIndexerDependencies r s m) Probes
 marloweIndexer = proc MarloweIndexerDependencies{..} -> do

--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/ChainSeekClient.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/ChainSeekClient.hs
@@ -8,6 +8,7 @@ module Language.Marlowe.Runtime.Indexer.ChainSeekClient
   where
 
 import Cardano.Api (SystemStart)
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Concurrent.STM (STM, TVar, newTQueue, newTVar, readTQueue, readTVar, writeTQueue, writeTVar)
 import Control.Monad.Event.Class (MonadInjectEvent, withEvent)
@@ -65,8 +66,8 @@ data ChainEvent r
 -- extract blocks of Marlowe transactions. The sequence of changes to the chain
 -- can be read by repeatedly running the resulting STM action.
 chainSeekClient
-  :: forall r s m
-   . (MonadUnliftIO m, MonadInjectEvent r (ChainSeekClientSelector r) s m, MonadFail m, HasSpanContext r)
+  :: forall r s env m
+   . (MonadUnliftIO m, MonadInjectEvent r (ChainSeekClientSelector r) s m, MonadFail m, HasSpanContext r, WithLog env Message m)
   => Component m (ChainSeekClientDependencies r s m) (STM Bool, STM (ChainEvent r))
 chainSeekClient = component "indexer-chain-seek-client" \ChainSeekClientDependencies{..} -> do
   -- Initialize a TQueue for emitting ChainEvents.

--- a/marlowe-runtime/marlowe-contract/Main.hs
+++ b/marlowe-runtime/marlowe-contract/Main.hs
@@ -9,6 +9,7 @@
 module Main
   where
 
+import Colog (LogAction, Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
 import Control.Exception (bracket)
@@ -16,8 +17,10 @@ import Control.Monad (when)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Event.Class
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Reader (MonadReader(..), asks, withReaderT)
 import Control.Monad.Trans.Reader (ReaderT(..))
 import Control.Monad.With
+import Data.Bifunctor (first)
 import Data.GeneralAllocate
 import qualified Data.Text as T
 import Data.Version (showVersion)
@@ -103,11 +106,15 @@ run Options{..} = do
     probeServer -< ProbeServerDependencies { port = fromIntegral httpPort, .. }
 
 runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend) . unAppM
+runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend, cmap fmtMessage logTextStdout) . unAppM
 
 newtype AppM r a = AppM
-  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector) IO a
+  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a
   } deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadFail, MonadThrow, MonadCatch, MonadMask)
+
+instance MonadReader (LogAction (AppM r) Message) (AppM r) where
+  ask = AppM $ asks snd
+  local f (AppM m) = AppM $ withReaderT (fmap f) m
 
 instance MonadWith (AppM r) where
   type WithException (AppM r) = WithException IO
@@ -130,8 +137,8 @@ instance MonadWith (AppM r) where
     stateThreadingGeneralWith (GeneralAllocate allocA') (flip (runReaderT . unAppM) r . go)
 
 instance MonadEvent r RootSelector (AppM r) where
-  askBackend = askBackendReaderT AppM id
-  localBackend = localBackendReaderT AppM unAppM id
+  askBackend = askBackendReaderT AppM fst
+  localBackend = localBackendReaderT AppM unAppM first
 
 data Options = Options
   { host :: HostName

--- a/marlowe-runtime/marlowe-contract/Main.hs
+++ b/marlowe-runtime/marlowe-contract/Main.hs
@@ -59,11 +59,12 @@ import Options.Applicative
   , value
   )
 import Paths_marlowe_runtime
-import UnliftIO (BufferMode(LineBuffering), MonadUnliftIO, hSetBuffering, newMVar, stdout, withMVar)
+import UnliftIO (BufferMode(LineBuffering), MonadUnliftIO, hSetBuffering, newMVar, stderr, stdout, withMVar)
 
 main :: IO ()
 main = do
   hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
   options <- getOptions
   withTracer \tracer ->
     runAppM (tracerEventBackend tracer renderRootSelectorOTel) $ run options

--- a/marlowe-runtime/marlowe-indexer/Main.hs
+++ b/marlowe-runtime/marlowe-indexer/Main.hs
@@ -64,10 +64,13 @@ import Options.Applicative
   , value
   )
 import Paths_marlowe_runtime (version)
-import UnliftIO (MonadUnliftIO, newMVar, throwIO, withMVar)
+import UnliftIO (BufferMode(LineBuffering), MonadUnliftIO, hSetBuffering, newMVar, stderr, stdout, throwIO, withMVar)
 
 main :: IO ()
-main = run =<< getOptions
+main = do
+  hSetBuffering stderr LineBuffering
+  hSetBuffering stdout LineBuffering
+  run =<< getOptions
 
 clientHints :: AddrInfo
 clientHints = defaultHints { addrSocketType = Stream }

--- a/marlowe-runtime/marlowe-indexer/Main.hs
+++ b/marlowe-runtime/marlowe-indexer/Main.hs
@@ -11,7 +11,7 @@
 module Main
   where
 
-import Colog (LogAction, Message, cmap, fmtMessage, logTextStdout)
+import Colog (LogAction(LogAction), Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
 import Control.Exception (bracket)
@@ -64,7 +64,7 @@ import Options.Applicative
   , value
   )
 import Paths_marlowe_runtime (version)
-import UnliftIO (MonadUnliftIO, throwIO)
+import UnliftIO (MonadUnliftIO, newMVar, throwIO, withMVar)
 
 main :: IO ()
 main = run =<< getOptions
@@ -129,7 +129,15 @@ run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseU
     queryChainSync = runConnectorTraced (injectSelector ChainQueryClient) chainSyncQueryConnector
 
 runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend, cmap fmtMessage logTextStdout) . unAppM
+runAppM eventBackend (AppM action) = do
+  logAction <- concurrentLogger
+  runReaderT action (hoistEventBackend liftIO eventBackend, logAction)
+
+concurrentLogger :: MonadUnliftIO m => IO (LogAction m Message)
+concurrentLogger = do
+  lock <- newMVar ()
+  let LogAction baseAction = cmap fmtMessage logTextStdout
+  pure $ LogAction $ withMVar lock . const . baseAction
 
 newtype AppM r a = AppM
   { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a

--- a/marlowe-runtime/marlowe-indexer/Main.hs
+++ b/marlowe-runtime/marlowe-indexer/Main.hs
@@ -11,14 +11,16 @@
 module Main
   where
 
+import Colog (LogAction, Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
 import Control.Exception (bracket)
 import Control.Monad.Event.Class
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Reader (ask)
+import Control.Monad.Reader (MonadReader(..), asks, withReaderT)
 import Control.Monad.Trans.Reader (ReaderT(..))
 import Control.Monad.With
+import Data.Bifunctor (first)
 import Data.GeneralAllocate
 import qualified Data.Set.NonEmpty as NESet
 import Data.String (fromString)
@@ -127,11 +129,15 @@ run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseU
     queryChainSync = runConnectorTraced (injectSelector ChainQueryClient) chainSyncQueryConnector
 
 runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend) . unAppM
+runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend, cmap fmtMessage logTextStdout) . unAppM
 
 newtype AppM r a = AppM
-  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector) IO a
+  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a
   } deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadFail)
+
+instance MonadReader (LogAction (AppM r) Message) (AppM r) where
+  ask = AppM $ asks snd
+  local f (AppM m) = AppM $ withReaderT (fmap f) m
 
 instance MonadWith (AppM r) where
   type WithException (AppM r) = WithException IO
@@ -154,8 +160,8 @@ instance MonadWith (AppM r) where
     stateThreadingGeneralWith (GeneralAllocate allocA') (flip (runReaderT . unAppM) r . go)
 
 instance MonadEvent r RootSelector (AppM r) where
-  askBackend = askBackendReaderT AppM id
-  localBackend = localBackendReaderT AppM unAppM id
+  askBackend = askBackendReaderT AppM fst
+  localBackend = localBackendReaderT AppM unAppM first
 
 data Options = Options
   { chainSeekPort :: PortNumber

--- a/marlowe-runtime/marlowe-proxy/Main.hs
+++ b/marlowe-runtime/marlowe-proxy/Main.hs
@@ -55,10 +55,12 @@ import Options.Applicative
   , value
   )
 import Paths_marlowe_runtime
-import UnliftIO (MonadUnliftIO, newMVar, withMVar)
+import UnliftIO (BufferMode(LineBuffering), MonadUnliftIO, hSetBuffering, newMVar, stderr, stdout, withMVar)
 
 main :: IO ()
 main = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
   options <- getOptions
   withTracer \tracer ->
     runAppM (tracerEventBackend tracer renderRootSelectorOTel) $ run options

--- a/marlowe-runtime/marlowe-proxy/Main.hs
+++ b/marlowe-runtime/marlowe-proxy/Main.hs
@@ -10,7 +10,7 @@
 module Main
   where
 
-import Colog (LogAction, Message, cmap, fmtMessage, logTextStdout)
+import Colog (LogAction(LogAction), Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
 import Control.Exception (bracket)
@@ -55,7 +55,7 @@ import Options.Applicative
   , value
   )
 import Paths_marlowe_runtime
-import UnliftIO (MonadUnliftIO)
+import UnliftIO (MonadUnliftIO, newMVar, withMVar)
 
 main :: IO ()
 main = do
@@ -103,7 +103,15 @@ run = runComponent_ proc Options{..} -> do
   probeServer -< ProbeServerDependencies { port = fromIntegral httpPort, .. }
 
 runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend, cmap fmtMessage logTextStdout) . unAppM
+runAppM eventBackend (AppM action) = do
+  logAction <- concurrentLogger
+  runReaderT action (hoistEventBackend liftIO eventBackend, logAction)
+
+concurrentLogger :: MonadUnliftIO m => IO (LogAction m Message)
+concurrentLogger = do
+  lock <- newMVar ()
+  let LogAction baseAction = cmap fmtMessage logTextStdout
+  pure $ LogAction $ withMVar lock . const . baseAction
 
 newtype AppM r a = AppM
   { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a

--- a/marlowe-runtime/marlowe-proxy/Main.hs
+++ b/marlowe-runtime/marlowe-proxy/Main.hs
@@ -10,13 +10,16 @@
 module Main
   where
 
+import Colog (LogAction, Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
 import Control.Exception (bracket)
 import Control.Monad.Event.Class
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Reader (MonadReader(..), asks, withReaderT)
 import Control.Monad.Trans.Reader (ReaderT(..))
 import Control.Monad.With
+import Data.Bifunctor (first)
 import Data.GeneralAllocate
 import qualified Data.Text as T
 import Data.Version (showVersion)
@@ -100,11 +103,15 @@ run = runComponent_ proc Options{..} -> do
   probeServer -< ProbeServerDependencies { port = fromIntegral httpPort, .. }
 
 runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend) . unAppM
+runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend, cmap fmtMessage logTextStdout) . unAppM
 
 newtype AppM r a = AppM
-  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector) IO a
+  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a
   } deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadFail)
+
+instance MonadReader (LogAction (AppM r) Message) (AppM r) where
+  ask = AppM $ asks snd
+  local f (AppM m) = AppM $ withReaderT (fmap f) m
 
 instance MonadWith (AppM r) where
   type WithException (AppM r) = WithException IO
@@ -127,8 +134,8 @@ instance MonadWith (AppM r) where
     stateThreadingGeneralWith (GeneralAllocate allocA') (flip (runReaderT . unAppM) r . go)
 
 instance MonadEvent r RootSelector (AppM r) where
-  askBackend = askBackendReaderT AppM id
-  localBackend = localBackendReaderT AppM unAppM id
+  askBackend = askBackendReaderT AppM fst
+  localBackend = localBackendReaderT AppM unAppM first
 
 data Options = Options
   { host :: HostName

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -164,6 +164,7 @@ library indexer
     , binary >= 0.8.8 && < 0.9
     , bytestring >= 0.10.12 && < 0.12
     , cardano-api ==1.35.4
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
@@ -176,7 +177,7 @@ library indexer
     , marlowe-protocols ==0.1.0.0
     , marlowe-runtime ==0.0.1
     , marlowe-runtime:history-api ==0.0.1
-    , mtl
+    , mtl >= 2.2 && < 3
     , nonempty-containers >= 0.3.4 && < 0.4
     , plutus-ledger-api ==1.0.0.1
     , stm >= 2.5 && < 2.6
@@ -247,6 +248,7 @@ library contract
     , binary >= 0.8.8 && < 0.9
     , bytestring >= 0.10.12 && < 0.12
     , cardano-api ==1.35.4
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
@@ -296,6 +298,7 @@ library sync
     , base >= 4.9 && < 5
     , binary >= 0.8.8 && < 0.9
     , bytestring >= 0.10.12 && < 0.12
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
@@ -377,6 +380,7 @@ library tx
     , base >= 4.9 && < 5
     , cardano-api ==1.35.4
     , cardano-ledger-core ==0.1.0.0
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , errors >= 2.3 && < 3
     , eventuo11y ^>= { 0.9, 0.10 }
@@ -429,6 +433,7 @@ library proxy
   build-depends:
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , marlowe-protocols ==0.1.0.0
@@ -488,6 +493,7 @@ executable marlowe-indexer
     , base >= 4.9 && < 5
     , bytestring >= 0.10.12 && < 0.12
     , containers >= 0.6.5 && < 0.7
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1
@@ -523,6 +529,7 @@ executable marlowe-sync
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
     , bytestring >= 0.10.12 && < 0.12
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1
@@ -559,6 +566,7 @@ executable marlowe-tx
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
     , cardano-api ==1.35.4
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
@@ -572,6 +580,7 @@ executable marlowe-tx
     , marlowe-runtime:contract-api ==0.0.1
     , marlowe-runtime:tx ==0.0.1
     , marlowe-runtime:tx-api ==0.0.1
+    , mtl >= 2.2 && < 3
     , network >= 3.1 && < 4
     , optparse-applicative >= 0.17 && < 0.18
     , text >= 1.2.4 && < 2
@@ -592,6 +601,7 @@ executable marlowe-contract
     , aeson >= 2 && < 3
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>=  0.1
@@ -603,6 +613,7 @@ executable marlowe-contract
     , marlowe-protocols ==0.1.0.0
     , marlowe-runtime:contract ==0.0.1
     , marlowe-runtime:contract-api ==0.0.1
+    , mtl >= 2.2 && < 3
     , network >= 3.1 && < 4
     , optparse-applicative >= 0.17 && < 0.18
     , text >= 1.2.4 && < 2
@@ -623,6 +634,7 @@ executable marlowe-proxy
   build-depends:
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
+    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>=  0.1
@@ -638,6 +650,7 @@ executable marlowe-proxy
     , marlowe-runtime:proxy-api ==0.0.1
     , marlowe-runtime:sync-api ==0.0.1
     , marlowe-runtime:tx-api ==0.0.1
+    , mtl >= 2.2 && < 3
     , network >= 3.1 && < 4
     , optparse-applicative >= 0.17 && < 0.18
     , text >= 1.2.4 && < 2

--- a/marlowe-runtime/marlowe-sync/Main.hs
+++ b/marlowe-runtime/marlowe-sync/Main.hs
@@ -60,10 +60,14 @@ import Options.Applicative
   , value
   )
 import Paths_marlowe_runtime (version)
-import UnliftIO (MonadIO, MonadUnliftIO, liftIO, newMVar, throwIO, withMVar)
+import UnliftIO
+  (BufferMode(LineBuffering), MonadIO, MonadUnliftIO, hSetBuffering, liftIO, newMVar, stderr, stdout, throwIO, withMVar)
 
 main :: IO ()
-main = run =<< getOptions
+main = do
+  hSetBuffering stderr LineBuffering
+  hSetBuffering stdout LineBuffering
+  run =<< getOptions
 
 run :: Options -> IO ()
 run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseUri)) Pool.release \pool -> do

--- a/marlowe-runtime/marlowe-tx/Main.hs
+++ b/marlowe-runtime/marlowe-tx/Main.hs
@@ -110,6 +110,8 @@ run Options{..} = flip runComponent_ () proc _ -> do
         { chainSyncJobConnector = SomeConnectorTraced (injectSelector ChainSyncJobClient)
             $ handshakeClientConnectorTraced
             $ tcpClientTraced (injectSelector ChainSyncJobClient) chainSeekHost chainSeekCommandPort jobClientPeer
+        , pollingInterval = 1.5
+        , confirmationTimeout = 3600 -- 1 hour
         , ..
         }
     , loadMarloweContext = \v contractId -> do

--- a/marlowe-runtime/marlowe-tx/Main.hs
+++ b/marlowe-runtime/marlowe-tx/Main.hs
@@ -61,10 +61,12 @@ import Options.Applicative
   , value
   )
 import Paths_marlowe_runtime (version)
-import UnliftIO (MonadUnliftIO, bracket, newMVar, withMVar)
+import UnliftIO (BufferMode(LineBuffering), MonadUnliftIO, bracket, hSetBuffering, newMVar, stderr, stdout, withMVar)
 
 main :: IO ()
 main = do
+  hSetBuffering stdout LineBuffering
+  hSetBuffering stderr LineBuffering
   options <- getOptions
   withTracer \tracer ->
     runAppM (tracerEventBackend tracer renderRootSelectorOTel) $ run options

--- a/marlowe-runtime/marlowe-tx/Main.hs
+++ b/marlowe-runtime/marlowe-tx/Main.hs
@@ -10,12 +10,15 @@
 module Main
   where
 
+import Colog (LogAction, Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
 import Control.Monad.Event.Class
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Reader (MonadReader(..), asks, withReaderT)
 import Control.Monad.Trans.Reader (ReaderT(..))
 import Control.Monad.With
+import Data.Bifunctor (first)
 import Data.GeneralAllocate
 import qualified Data.Text as T
 import Data.Version (showVersion)
@@ -118,11 +121,15 @@ run Options{..} = flip runComponent_ () proc _ -> do
   probeServer -< ProbeServerDependencies { port = fromIntegral httpPort, .. }
 
 runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend) . unAppM
+runAppM eventBackend = flip runReaderT (hoistEventBackend liftIO eventBackend, cmap fmtMessage logTextStdout) . unAppM
 
 newtype AppM r a = AppM
-  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector) IO a
+  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a
   } deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadFail)
+
+instance MonadReader (LogAction (AppM r) Message) (AppM r) where
+  ask = AppM $ asks snd
+  local f (AppM m) = AppM $ withReaderT (fmap f) m
 
 instance MonadWith (AppM r) where
   type WithException (AppM r) = WithException IO
@@ -145,8 +152,8 @@ instance MonadWith (AppM r) where
     stateThreadingGeneralWith (GeneralAllocate allocA') (flip (runReaderT . unAppM) r . go)
 
 instance MonadEvent r RootSelector (AppM r) where
-  askBackend = askBackendReaderT AppM id
-  localBackend = localBackendReaderT AppM unAppM id
+  askBackend = askBackendReaderT AppM fst
+  localBackend = localBackendReaderT AppM unAppM first
 
 data Options = Options
   { chainSeekPort :: PortNumber

--- a/marlowe-runtime/proxy/Language/Marlowe/Runtime/Proxy.hs
+++ b/marlowe-runtime/proxy/Language/Marlowe/Runtime/Proxy.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -9,6 +10,8 @@
 module Language.Marlowe.Runtime.Proxy
   where
 
+import Colog (WithLog)
+import qualified Colog as C
 import Control.Arrow (returnA)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (Probes(..))
@@ -54,7 +57,7 @@ data ProxyDependencies r s m = ProxyDependencies
   }
 
 proxy
-  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, MonadFail m)
+  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, MonadFail m, WithLog env C.Message m)
   => Component m (ProxyDependencies r s (ResourceT m)) Probes
 proxy = proc deps -> do
   (serverComponent "marlowe-runtime-server-traced" (component_ "marlowe-runtime-worker-traced" workerTraced) \ProxyDependencies{..} -> do

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync.hs
@@ -4,6 +4,7 @@
 module Language.Marlowe.Runtime.Sync
   where
 
+import Colog (Message, WithLog)
 import Control.Arrow (returnA)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes
@@ -26,7 +27,7 @@ data SyncDependencies r s m = SyncDependencies
   , querySource :: SomeConnectionSourceTraced MarloweQueryServer r s m
   }
 
-sync :: (MonadUnliftIO m, HasSpanContext r, MonadEvent r s m) => Component m (SyncDependencies r s m) Probes
+sync :: (MonadUnliftIO m, HasSpanContext r, MonadEvent r s m, WithLog env Message m) => Component m (SyncDependencies r s m) Probes
 sync = proc SyncDependencies{..} -> do
   marloweSyncServer -< MarloweSyncServerDependencies{..}
   marloweHeaderSyncServer -< MarloweHeaderSyncServerDependencies{..}

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/MarloweHeaderSyncServer.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/MarloweHeaderSyncServer.hs
@@ -6,6 +6,7 @@
 module Language.Marlowe.Runtime.Sync.MarloweHeaderSyncServer
   where
 
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Monad.Event.Class (MonadEvent)
 import Language.Marlowe.Protocol.HeaderSync.Server
@@ -21,7 +22,7 @@ data MarloweHeaderSyncServerDependencies r s m = MarloweHeaderSyncServerDependen
   }
 
 marloweHeaderSyncServer
-  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r)
+  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, WithLog env Message m)
   => Component m (MarloweHeaderSyncServerDependencies r s m) ()
 marloweHeaderSyncServer = serverComponent "marlowe-header-sync-server" (component_ "marlowe-header-sync-worker" worker) \MarloweHeaderSyncServerDependencies{..} -> do
   connector <- acceptSomeConnectorTraced headerSyncSource

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/MarloweSyncServer.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/MarloweSyncServer.hs
@@ -6,6 +6,7 @@
 module Language.Marlowe.Runtime.Sync.MarloweSyncServer
   where
 
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Monad.Event.Class
 import Data.Type.Equality (testEquality, type (:~:)(Refl))
@@ -24,7 +25,7 @@ data MarloweSyncServerDependencies r s m = MarloweSyncServerDependencies
   }
 
 marloweSyncServer
-  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r)
+  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, WithLog env Message m)
   => Component m (MarloweSyncServerDependencies r s m) ()
 marloweSyncServer = serverComponent "marlowe-sync-server" (component_ "marlowe-sync-worker" worker) \MarloweSyncServerDependencies{..} -> do
   connector <- acceptSomeConnectorTraced syncSource

--- a/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/QueryServer.hs
+++ b/marlowe-runtime/sync/Language/Marlowe/Runtime/Sync/QueryServer.hs
@@ -4,6 +4,7 @@
 module Language.Marlowe.Runtime.Sync.QueryServer
   where
 
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Monad.Event.Class
 import Language.Marlowe.Protocol.Query.Server (MarloweQueryServer, marloweQueryServer)
@@ -17,7 +18,7 @@ data QueryServerDependencies r s m = QueryServerDependencies
   , querySource :: SomeConnectionSourceTraced MarloweQueryServer r s m
   }
 
-queryServer :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r) => Component m (QueryServerDependencies r s m) ()
+queryServer :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, WithLog env Message m) => Component m (QueryServerDependencies r s m) ()
 queryServer = serverComponent "sync-query-server" (component_ "sync-query-worker" worker) \QueryServerDependencies{..} -> do
   connector <- acceptSomeConnectorTraced querySource
   pure WorkerDependencies{..}

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction.hs
@@ -8,6 +8,7 @@ module Language.Marlowe.Runtime.Transaction
 
 import Cardano.Api (Tx)
 import Cardano.Api.Byron (BabbageEra)
+import Colog (Message, WithLog)
 import Control.Arrow (returnA)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes
@@ -40,7 +41,7 @@ data TransactionDependencies r s m = TransactionDependencies
   }
 
 transaction
-  :: (MonadUnliftIO m, MonadInjectEvent r TransactionServerSelector s m, HasSpanContext r)
+  :: (MonadUnliftIO m, MonadInjectEvent r TransactionServerSelector s m, HasSpanContext r, WithLog env Message m)
   => Component m (TransactionDependencies r s m) Probes
 transaction = proc TransactionDependencies{..} -> do
   (connected, getTip) <- transactionChainClient -< TransactionChainClientDependencies{..}

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Chain.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Chain.hs
@@ -4,6 +4,7 @@
 module Language.Marlowe.Runtime.Transaction.Chain
   where
 
+import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Concurrent.STM (STM, newTVar, readTVar, writeTVar)
 import Control.Monad.Event.Class (MonadEvent)
@@ -22,7 +23,7 @@ newtype TransactionChainClientDependencies r s m = TransactionChainClientDepende
   }
 
 transactionChainClient
-  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r)
+  :: (MonadUnliftIO m, MonadEvent r s m, HasSpanContext r, WithLog env Message m)
   => Component m (TransactionChainClientDependencies r s m) (STM Bool, STM Chain.ChainPoint)
 transactionChainClient = component "tx-chain-seek-client" \TransactionChainClientDependencies{..} -> do
   tipVar <- newTVar Chain.Genesis

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Server.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Server.hs
@@ -34,6 +34,7 @@ import Cardano.Api
   , makeShelleyAddress
   )
 import Cardano.Api.Shelley (ProtocolParameters)
+import Colog (Message, WithLog)
 import Control.Applicative ((<|>))
 import Control.Concurrent.Component
 import Control.Concurrent.STM (STM, modifyTVar, newEmptyTMVar, newTVar, putTMVar, readTMVar, readTVar, retry)
@@ -143,7 +144,7 @@ data TransactionServerDependencies r s m = TransactionServerDependencies
   }
 
 transactionServer
-  :: (MonadInjectEvent r TransactionServerSelector s m, MonadUnliftIO m, HasSpanContext r)
+  :: (MonadInjectEvent r TransactionServerSelector s m, MonadUnliftIO m, HasSpanContext r, WithLog env Message m)
   => Component m (TransactionServerDependencies r s m) ()
 transactionServer = serverComponentWithSetup "tx-job-server" worker \TransactionServerDependencies{..} -> do
   submitJobsVar <- newTVar mempty
@@ -168,8 +169,8 @@ data WorkerDependencies r s m = WorkerDependencies
   }
 
 worker
-  :: forall r s m
-   . (MonadInjectEvent r TransactionServerSelector s m, MonadUnliftIO m, HasSpanContext r)
+  :: forall r s env m
+   . (MonadInjectEvent r TransactionServerSelector s m, MonadUnliftIO m, HasSpanContext r, WithLog env Message m)
   => Component m (WorkerDependencies r s m) ()
 worker = component_ "tx-job-server-worker" \WorkerDependencies{..} -> do
   let

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Submit.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Submit.hs
@@ -67,7 +67,7 @@ doSubmit SubmitJobDependencies{..} tellStatus era tx= do
     txId = TxId $ C.serialiseToRawBytes $ C.getTxId $ C.getTxBody tx
 
     timeout :: m ()
-    timeout = threadDelay $ floor $ nominalDiffTimeToSeconds confirmationTimeout * 1_000_000 -- 10 minutes in microseconds
+    timeout = threadDelay $ floor $ nominalDiffTimeToSeconds confirmationTimeout * 1_000_000
 
     pollingMicroSeconds = floor $ nominalDiffTimeToSeconds pollingInterval * 1_000_000
 

--- a/nix/dev/compose.nix
+++ b/nix/dev/compose.nix
@@ -308,6 +308,11 @@ let
           max-file = "10";
         };
       };
+
+      command = [
+        "-c"
+        "max_connections=1000"
+      ];
     };
 
     services.jaeger = {


### PR DESCRIPTION
Fixes the interleaving of messages in console logs. It also fixes the following issues:

- [x] Introduces pervasive use of line buffering
- [x] Adds a polling delay to marlowe-apps when submitting a transaction
- [x] increases the max connections to postgres in the dev docker compose
- [x] Increases max submit timeout to 1 hr
- [x] Bumps polling interval for marlowe-tx submit to 1.5 seconds. 

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
    - [x] Reviewer requested
