### PR TITLE
PLT-6201 Allow tracing to become a true noop

### DIFF
--- a/async-components/async-components.cabal
+++ b/async-components/async-components.cabal
@@ -49,11 +49,21 @@ library
   exposed-modules:
     Control.Concurrent.Component
     Control.Concurrent.Component.Probes
+    Control.Concurrent.Component.Run
   build-depends:
     , base >= 4.9 && < 5
+    , co-log >= 0.5.0.0 && < 0.6.0.0
+    , eventuo11y ^>= { 0.9, 0.10 }
+    , eventuo11y-extras ==0.1.0.0
+    , eventuo11y-otel ^>=  0.1
+    , exceptions >= 0.10 && < 0.11
+    , general-allocate ^>= { 0.2 }
+    , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
+    , hs-opentelemetry-sdk >= 0.0.3 && < 0.0.4
+    , mtl >= 2.2 && < 3
     , servant >= 0.19 && < 0.20
     , servant-client >= 0.19 && < 0.20
     , servant-server >= 0.19 && < 0.20
+    , transformers >= 0.5.6 && < 0.6
     , unliftio >= 0.2.1 && < 0.3
     , warp >= 3.3 && < 4
-    , co-log >= 0.5.0.0 && < 0.6.0.0

--- a/async-components/src/Control/Concurrent/Component/Run.hs
+++ b/async-components/src/Control/Concurrent/Component/Run.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Control.Concurrent.Component.Run
+  where
+
+import Colog
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Control.Monad.Event.Class
+import Control.Monad.Reader
+import Control.Monad.With
+import Data.Bifunctor (first)
+import Data.GeneralAllocate
+import Data.Maybe (isJust)
+import Observe.Event (EventBackend)
+import Observe.Event.Backend (hoistEventBackend, noopEventBackend)
+import Observe.Event.Render.OpenTelemetry (RenderSelectorOTel, tracerEventBackend)
+import OpenTelemetry.Trace
+import OpenTelemetry.Trace.Core (getSpanContext, wrapSpanContext)
+import System.Environment (lookupEnv)
+import UnliftIO (BufferMode(..), MonadUnliftIO, bracket, hSetBuffering, newMVar, stderr, stdout, withMVar, withRunInIO)
+
+newtype AppM r s a = AppM
+  { unAppM :: ReaderT (EventBackend (AppM r s) r s, LogAction IO Message) IO a
+  } deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadThrow, MonadCatch, MonadMask, MonadFail)
+
+runAppMTraced :: forall s a. InstrumentationLibrary -> RenderSelectorOTel s -> AppM Span s a -> IO a
+runAppMTraced library render app = bracket
+  initializeTracerProvider'
+  snd
+  \(backend, _) -> runAppM backend app
+  where
+    initializeTracerProvider' :: IO (EventBackend IO Span s, IO ())
+    initializeTracerProvider' = do
+      endpointConfigured <- isJust <$> lookupEnv "OTEL_EXPORTER_OTLP_ENDPOINT"
+      if endpointConfigured
+        then do
+          provider <- initializeTracerProvider
+          let tracer = makeTracer provider library tracerOptions
+          pure
+            ( tracerEventBackend tracer render
+            , shutdownTracerProvider provider
+            )
+        else do
+          provider <- createTracerProvider [] emptyTracerProviderOptions
+          let tracer = makeTracer provider library tracerOptions
+          dummyContext <- inSpan' tracer "dummy" defaultSpanArguments getSpanContext
+          pure
+            ( noopEventBackend $ wrapSpanContext dummyContext
+            , shutdownTracerProvider provider
+            )
+
+runAppM :: EventBackend IO r s -> AppM r s a -> IO a
+runAppM eventBackend (AppM action) = do
+  hSetBuffering stderr LineBuffering
+  hSetBuffering stdout LineBuffering
+  logAction <- concurrentLogger
+  runReaderT action (hoistEventBackend liftIO eventBackend, logAction)
+
+concurrentLogger :: MonadUnliftIO m => IO (LogAction m Message)
+concurrentLogger = do
+  lock <- newMVar ()
+  let LogAction baseAction = cmap fmtMessage logTextStdout
+  pure $ LogAction $ withMVar lock . const . baseAction
+
+instance MonadReader (LogAction (AppM r s) Message) (AppM r s) where
+  ask = AppM $ asks $ hoistLogAction liftIO . snd
+  local f (AppM m) = withRunInIO \runInIO -> runInIO $ AppM $ withReaderT (fmap $ hoistLogAction runInIO . f . hoistLogAction liftIO) m
+
+instance MonadWith (AppM r s) where
+  type WithException (AppM r s) = WithException IO
+  stateThreadingGeneralWith
+    :: forall a b releaseReturn
+     . GeneralAllocate (AppM r s) (WithException IO) releaseReturn b a
+    -> (a -> AppM r s b)
+    -> AppM r s (b, releaseReturn)
+  stateThreadingGeneralWith (GeneralAllocate allocA) go = AppM . ReaderT $ \r -> do
+    let
+      allocA' :: (forall x. IO x -> IO x) -> IO (GeneralAllocated IO (WithException IO) releaseReturn b a)
+      allocA' restore = do
+        let
+          restore' :: forall x. AppM r s x -> AppM r s x
+          restore' mx = AppM . ReaderT $ restore . (runReaderT . unAppM) mx
+        GeneralAllocated a releaseA <- (runReaderT . unAppM) (allocA restore') r
+        let
+          releaseA' relTy = (runReaderT . unAppM) (releaseA relTy) r
+        pure $ GeneralAllocated a releaseA'
+    stateThreadingGeneralWith (GeneralAllocate allocA') (flip (runReaderT . unAppM) r . go)
+
+instance MonadEvent r s (AppM r s) where
+  askBackend = askBackendReaderT AppM fst
+  localBackend = localBackendReaderT AppM unAppM first

--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -238,11 +238,9 @@ executable marlowe-chain-indexer
     , cardano-api ==1.35.4
     , cardano-crypto-wrapper ==1.3.0
     , cardano-ledger-byron ==0.1.0.0
-    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1
-    , general-allocate ^>= { 0.2 }
     , hasql >= 1.6 && < 2
     , hasql-pool ^>= 0.8
     , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
@@ -274,11 +272,9 @@ executable marlowe-chain-sync
     , bytestring >= 0.10.12 && < 0.12
     , cardano-api ==1.35.4
     , cardano-ledger-byron ==0.1.0.0
-    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1
-    , general-allocate ^>= { 0.2 }
     , hasql >= 1.6 && < 2
     , hasql-pool ^>= 0.8
     , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
@@ -292,5 +288,4 @@ executable marlowe-chain-sync
     , ouroboros-network ==0.1.0.1
     , postgresql-libpq >= 0.9 && < 0.10
     , text >= 1.2.4 && < 2
-    , transformers >= 0.5.6 && < 0.6
     , unliftio >= 0.2.1 && < 0.3

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server.hs
@@ -26,6 +26,7 @@ module Language.Marlowe.Runtime.Web.Server
   ) where
 
 import Control.Concurrent.Component
+import Control.Concurrent.Component.Run (AppM(..))
 import Control.Monad.Event.Class
 import Control.Monad.IO.Unlift (liftIO, withRunInIO)
 import Control.Monad.Reader (ReaderT(ReaderT), runReaderT)
@@ -34,7 +35,7 @@ import Language.Marlowe.Protocol.Types (MarloweRuntime)
 import Language.Marlowe.Runtime.ChainSync.Api (TxId)
 import Language.Marlowe.Runtime.Core.Api (ContractId)
 import qualified Language.Marlowe.Runtime.Web as Web
-import Language.Marlowe.Runtime.Web.Server.Monad (AppEnv(..), AppM(..), BackendM(BackendM))
+import Language.Marlowe.Runtime.Web.Server.Monad (AppEnv(..), ServerM(..))
 import qualified Language.Marlowe.Runtime.Web.Server.OpenAPI as OpenAPI
 import qualified Language.Marlowe.Runtime.Web.Server.REST as REST
 import Language.Marlowe.Runtime.Web.Server.SyncClient
@@ -82,16 +83,16 @@ type APIWithOpenAPI = OpenAPI.API :<|>  Web.API
 apiWithOpenApi :: Proxy APIWithOpenAPI
 apiWithOpenApi = Proxy
 
-serverWithOpenAPI :: ServerT APIWithOpenAPI AppM
+serverWithOpenAPI :: ServerT APIWithOpenAPI ServerM
 serverWithOpenAPI = OpenAPI.server :<|> REST.server
 
-serveAppM
+serveServerM
   :: HasServer api '[]
   => Proxy api
   -> AppEnv
-  -> ServerT api AppM
+  -> ServerT api ServerM
   -> Application
-serveAppM api env = serve api . hoistServer api (flip runReaderT env . runAppM)
+serveServerM api env = serve api . hoistServer api (flip runReaderT env . runServerM)
 
 corsMiddleware :: Bool -> WAI.Middleware
 corsMiddleware accessControlAllowOriginAll =
@@ -117,7 +118,7 @@ data ServerDependencies transport r s = ServerDependencies
   { openAPIEnabled :: Bool
   , accessControlAllowOriginAll :: Bool
   , runApplication :: Application -> IO ()
-  , marloweTracedContext :: MarloweTracedContext r s (ServerSelector transport) (BackendM r (ServerSelector transport))
+  , marloweTracedContext :: MarloweTracedContext r s (ServerSelector transport) (AppM r (ServerSelector transport))
   }
 
 {- Architecture notes:
@@ -131,7 +132,7 @@ data ServerDependencies transport r s = ServerDependencies
     process having its own event backend injected via its parameters.
 -}
 
-server :: HasSpanContext r => Component (BackendM r (ServerSelector transport)) (ServerDependencies transport r s) ()
+server :: HasSpanContext r => Component (AppM r (ServerSelector transport)) (ServerDependencies transport r s) ()
 server = proc deps@ServerDependencies{marloweTracedContext = MarloweTracedContext{..}} -> do
   TxClient{..} <- txClient -< TxClientDependencies
     { connector = SomeConnectorTraced injector connector
@@ -163,38 +164,38 @@ server = proc deps@ServerDependencies{marloweTracedContext = MarloweTracedContex
         }
 
 data WebServerDependencies r s = WebServerDependencies
-  { _loadContractHeaders :: LoadContractHeaders (BackendM r s)
-  , _loadContract :: LoadContract (BackendM r s)
-  , _loadWithdrawals :: LoadWithdrawals (BackendM r s)
-  , _loadWithdrawal :: LoadWithdrawal (BackendM r s)
-  , _loadTransactions :: LoadTransactions (BackendM r s)
-  , _loadTransaction :: LoadTransaction (BackendM r s)
-  , _createContract :: CreateContract (BackendM r s)
-  , _withdraw :: Withdraw (BackendM r s)
-  , _applyInputs :: ApplyInputs (BackendM r s)
-  , _submitContract :: ContractId -> Submit r (BackendM r s)
-  , _submitTransaction :: ContractId -> TxId -> Submit r (BackendM r s)
-  , _submitWithdrawal :: TxId -> Submit r (BackendM r s)
+  { _loadContractHeaders :: LoadContractHeaders (AppM r s)
+  , _loadContract :: LoadContract (AppM r s)
+  , _loadWithdrawals :: LoadWithdrawals (AppM r s)
+  , _loadWithdrawal :: LoadWithdrawal (AppM r s)
+  , _loadTransactions :: LoadTransactions (AppM r s)
+  , _loadTransaction :: LoadTransaction (AppM r s)
+  , _createContract :: CreateContract (AppM r s)
+  , _withdraw :: Withdraw (AppM r s)
+  , _applyInputs :: ApplyInputs (AppM r s)
+  , _submitContract :: ContractId -> Submit r (AppM r s)
+  , _submitTransaction :: ContractId -> TxId -> Submit r (AppM r s)
+  , _submitWithdrawal :: TxId -> Submit r (AppM r s)
   , openAPIEnabled :: Bool
   , accessControlAllowOriginAll :: Bool
   , runApplication :: Application -> IO ()
   }
 
-webServer :: Component (BackendM r (ServerSelector transport)) (WebServerDependencies r (ServerSelector transport)) ()
+webServer :: Component (AppM r (ServerSelector transport)) (WebServerDependencies r (ServerSelector transport)) ()
 webServer = component_ "web-server" \WebServerDependencies{..} -> withRunInIO \runInIO ->
   -- Observe.Event.Wai does not expose a reference to the ServeRequest field, which we
   -- need because of the asynchronous processing of submit jobs. So, we have to
   -- roll our own version of Observe.Event.Wai.application here. A bonus is
-  -- that we do not have to translate to and from EventT and BackendM.
+  -- that we do not have to translate to and from EventT and AppM.
   runApplication \req handleRes ->
     runInIO $ withEventFields (ServeRequest req) [ReqField req] \ev -> do
       _eventBackend <- askBackend
-      _logAction <- BackendM $ ReaderT \(_, logAction) -> pure logAction
+      _logAction <- AppM $ ReaderT \(_, logAction) -> pure logAction
       let _requestParent = reference ev
       let
         mkApp
-          | openAPIEnabled = corsMiddleware accessControlAllowOriginAll $ serveAppM apiWithOpenApi AppEnv{..} serverWithOpenAPI
-          | otherwise = corsMiddleware accessControlAllowOriginAll $ serveAppM Web.api AppEnv{..} REST.server
+          | openAPIEnabled = corsMiddleware accessControlAllowOriginAll $ serveServerM apiWithOpenApi AppEnv{..} serverWithOpenAPI
+          | otherwise = corsMiddleware accessControlAllowOriginAll $ serveServerM Web.api AppEnv{..} REST.server
       liftIO $ mkApp req \res -> runInIO do
         addField ev $ ResField res
         liftIO $ handleRes res

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/Monad.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/Monad.hs
@@ -13,20 +13,14 @@ module Language.Marlowe.Runtime.Web.Server.Monad
   where
 
 import Colog (LogAction, Message, hoistLogAction)
+import Control.Concurrent.Component.Run (AppM, unAppM)
 import Control.Monad.Base (MonadBase)
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.Catch.Pure (MonadMask)
-import Control.Monad.Event.Class
-import Control.Monad.Except (ExceptT, MonadError)
+import Control.Monad.Except (MonadError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.IO.Unlift (MonadUnliftIO, withRunInIO)
 import Control.Monad.Reader (MonadReader(..), ReaderT(..), asks)
 import Control.Monad.Trans.Control (MonadBaseControl)
-import Control.Monad.Trans.Reader (withReaderT)
-import Control.Monad.With (MonadWith(..))
-import Data.Bifunctor (first)
-import Data.Coerce (coerce)
-import Data.GeneralAllocate (GeneralAllocate(..), GeneralAllocated(..))
 import Language.Marlowe.Runtime.ChainSync.Api (TxId)
 import Language.Marlowe.Runtime.Core.Api (ContractId)
 import Language.Marlowe.Runtime.Web.Server.SyncClient
@@ -35,7 +29,7 @@ import Language.Marlowe.Runtime.Web.Server.TxClient (ApplyInputs, CreateContract
 import Observe.Event (EventBackend)
 import Servant
 
-newtype AppM a = AppM { runAppM :: ReaderT AppEnv Handler a }
+newtype ServerM a = ServerM { runServerM :: ReaderT AppEnv Handler a }
   deriving newtype
     ( Functor
     , Applicative
@@ -51,161 +45,97 @@ newtype AppM a = AppM { runAppM :: ReaderT AppEnv Handler a }
     , MonadBase IO
     )
 
-newtype BackendM r s a = BackendM { runBackendM :: ReaderT (EventBackend (BackendM r s) r s, LogAction IO Message) IO a }
-  deriving newtype
-    ( Functor
-    , Applicative
-    , Monad
-    , MonadIO
-    , MonadFail
-    , MonadCatch
-    , MonadMask
-    , MonadThrow
-    , MonadBaseControl IO
-    , MonadBase IO
-    , MonadUnliftIO
-    )
-
-instance MonadWith AppM where
-  type WithException AppM = WithException (ExceptT ServerError IO)
-  stateThreadingGeneralWith
-    :: forall a b releaseReturn
-     . GeneralAllocate AppM (WithException (ExceptT ServerError IO)) releaseReturn b a
-    -> (a -> AppM b)
-    -> AppM (b, releaseReturn)
-  stateThreadingGeneralWith (GeneralAllocate allocA) go = AppM . ReaderT $ \r -> do
-    let
-      allocA' :: (forall x. ExceptT ServerError IO x -> ExceptT ServerError IO x) -> (ExceptT ServerError IO) (GeneralAllocated (ExceptT ServerError IO) (WithException (ExceptT ServerError IO)) releaseReturn b a)
-      allocA' restore = do
-        let
-          restore' :: forall x. AppM x -> AppM x
-          restore' mx = AppM . ReaderT $ coerce . restore . coerce . (runReaderT . runAppM) mx
-        GeneralAllocated a releaseA <- (coerce . runReaderT . runAppM) (allocA restore') r
-        let
-          releaseA' relTy = (coerce . runReaderT . runAppM) (releaseA relTy) r
-        pure $ GeneralAllocated a releaseA'
-    coerce $ stateThreadingGeneralWith (GeneralAllocate allocA') (flip (coerce . runReaderT . runAppM) r . go)
-
-instance MonadWith (BackendM r s) where
-  type WithException (BackendM r s) = WithException IO
-  stateThreadingGeneralWith
-    :: forall a b releaseReturn
-     . GeneralAllocate (BackendM r s) (WithException IO) releaseReturn b a
-    -> (a -> BackendM r s b)
-    -> BackendM r s (b, releaseReturn)
-  stateThreadingGeneralWith (GeneralAllocate allocA) go = BackendM . ReaderT $ \r -> do
-    let
-      allocA' :: (forall x. IO x -> IO x) -> IO (GeneralAllocated IO (WithException IO) releaseReturn b a)
-      allocA' restore = do
-        let
-          restore' :: forall x. BackendM r s x -> BackendM r s x
-          restore' mx = BackendM . ReaderT $ restore . (runReaderT . runBackendM) mx
-        GeneralAllocated a releaseA <- (runReaderT . runBackendM) (allocA restore') r
-        let
-          releaseA' relTy = (runReaderT . runBackendM) (releaseA relTy) r
-        pure $ GeneralAllocated a releaseA'
-    stateThreadingGeneralWith (GeneralAllocate allocA') (flip (runReaderT . runBackendM) r . go)
-
-instance MonadEvent r s (BackendM r s) where
-  askBackend = askBackendReaderT BackendM fst
-  localBackend = localBackendReaderT BackendM runBackendM first
-
-instance MonadReader (LogAction (BackendM r s) Message) (BackendM r s) where
-  ask = BackendM $ asks $ hoistLogAction liftIO . snd
-  local f (BackendM m) = withRunInIO \runInIO -> runInIO $ BackendM
-    $ withReaderT (fmap $ hoistLogAction runInIO . f . hoistLogAction liftIO) m
-
 data AppEnv = forall r s. AppEnv
-  { _loadContractHeaders :: LoadContractHeaders (BackendM r s)
-  , _loadContract :: LoadContract (BackendM r s)
-  , _loadWithdrawals :: LoadWithdrawals (BackendM r s)
-  , _loadWithdrawal :: LoadWithdrawal (BackendM r s)
-  , _loadTransactions :: LoadTransactions (BackendM r s)
-  , _loadTransaction :: LoadTransaction (BackendM r s)
-  , _createContract :: CreateContract (BackendM r s)
-  , _withdraw :: Withdraw (BackendM r s)
-  , _applyInputs :: ApplyInputs (BackendM r s)
-  , _submitContract :: ContractId -> Submit r (BackendM r s)
-  , _submitTransaction :: ContractId -> TxId -> Submit r (BackendM r s)
-  , _submitWithdrawal :: TxId -> Submit r (BackendM r s)
-  , _eventBackend :: EventBackend (BackendM r s) r s
+  { _loadContractHeaders :: LoadContractHeaders (AppM r s)
+  , _loadContract :: LoadContract (AppM r s)
+  , _loadWithdrawals :: LoadWithdrawals (AppM r s)
+  , _loadWithdrawal :: LoadWithdrawal (AppM r s)
+  , _loadTransactions :: LoadTransactions (AppM r s)
+  , _loadTransaction :: LoadTransaction (AppM r s)
+  , _createContract :: CreateContract (AppM r s)
+  , _withdraw :: Withdraw (AppM r s)
+  , _applyInputs :: ApplyInputs (AppM r s)
+  , _submitContract :: ContractId -> Submit r (AppM r s)
+  , _submitTransaction :: ContractId -> TxId -> Submit r (AppM r s)
+  , _submitWithdrawal :: TxId -> Submit r (AppM r s)
+  , _eventBackend :: EventBackend (AppM r s) r s
   , _requestParent :: r
   , _logAction :: LogAction IO Message
   }
 
 -- | Load a list of contract headers.
-loadContractHeaders :: LoadContractHeaders AppM
+loadContractHeaders :: LoadContractHeaders ServerM
 loadContractHeaders cFilter range = do
   AppEnv { _eventBackend = backend, _loadContractHeaders = load } <- ask
   liftBackendM backend $ load cFilter range
 
 -- | Load a contract.
-loadContract :: LoadContract AppM
+loadContract :: LoadContract ServerM
 loadContract contractId = do
   AppEnv { _eventBackend = backend, _loadContract = load } <- ask
   liftBackendM backend $ load contractId
 
 -- | Load a list of withdrawal headers.
-loadWithdrawals :: LoadWithdrawals AppM
+loadWithdrawals :: LoadWithdrawals ServerM
 loadWithdrawals wFilter range = do
   AppEnv { _eventBackend = backend, _loadWithdrawals = load } <- ask
   liftBackendM backend $ load wFilter range
 
 -- | Load a list of withdrawal headers.
-loadWithdrawal :: LoadWithdrawal AppM
+loadWithdrawal :: LoadWithdrawal ServerM
 loadWithdrawal withdrawalId = do
   AppEnv { _eventBackend = backend, _loadWithdrawal = load } <- ask
   liftBackendM backend $ load withdrawalId
 
 -- | Load a list of transactions for a contract.
-loadTransactions :: LoadTransactions AppM
+loadTransactions :: LoadTransactions ServerM
 loadTransactions contractId range = do
   AppEnv { _eventBackend = backend, _loadTransactions = load } <- ask
   liftBackendM backend $ load contractId range
 
 -- | Load a transaction for a contract.
-loadTransaction :: LoadTransaction AppM
+loadTransaction :: LoadTransaction ServerM
 loadTransaction contractId txId = do
   AppEnv { _eventBackend = backend, _loadTransaction = load } <- ask
   liftBackendM backend $ load contractId txId
 
 -- | Create a contract.
-createContract :: CreateContract AppM
+createContract :: CreateContract ServerM
 createContract stakeCredential version addresses roles metadata minUTxODeposit contract = do
   AppEnv { _eventBackend = backend, _createContract = create } <- ask
   liftBackendM backend $ create stakeCredential version addresses roles metadata minUTxODeposit contract
 
 -- | Apply inputs to a contract.
-applyInputs :: ApplyInputs AppM
+applyInputs :: ApplyInputs ServerM
 applyInputs version addresses contractId metadata invalidBefore invalidHereafter inputs = do
   AppEnv { _eventBackend = backend, _applyInputs = apply } <- ask
   liftBackendM backend $ apply version addresses contractId metadata invalidBefore invalidHereafter inputs
 
 -- | Withdraw funds from a role.
-withdraw :: Withdraw AppM
+withdraw :: Withdraw ServerM
 withdraw version addresses contractId role = do
   AppEnv { _eventBackend = backend, _withdraw = _withdraw } <- ask
   liftBackendM backend $ _withdraw version addresses contractId role
 
 -- | Submit a contract creation transaction to the node
-submitContract :: ContractId -> Submit' AppM
+submitContract :: ContractId -> Submit' ServerM
 submitContract contractId tx = do
   AppEnv { _eventBackend = backend, _requestParent, _submitContract = submit } <- ask
   liftBackendM backend $ submit contractId _requestParent tx
 
 -- | Submit a withdrawal transaction to the node
-submitWithdrawal :: TxId -> Submit' AppM
+submitWithdrawal :: TxId -> Submit' ServerM
 submitWithdrawal txId tx = do
   AppEnv { _eventBackend = backend, _requestParent, _submitWithdrawal = submit } <- ask
   liftBackendM backend $ submit txId _requestParent tx
 
 -- | Submit an apply inputs transaction to the node
-submitTransaction :: ContractId -> TxId -> Submit' AppM
+submitTransaction :: ContractId -> TxId -> Submit' ServerM
 submitTransaction contractId txId tx = do
   AppEnv { _eventBackend = backend, _requestParent, _submitTransaction = submit } <- ask
   liftBackendM backend $ submit contractId txId _requestParent tx
 
-liftBackendM :: EventBackend (BackendM r s) r s ->  BackendM r s a -> AppM a
-liftBackendM backend m = AppM do
+liftBackendM :: EventBackend (AppM r s) r s ->  AppM r s a -> ServerM a
+liftBackendM backend m = ServerM do
   logAction <- asks _logAction
-  liftIO $ runReaderT (runBackendM m) (backend, hoistLogAction liftIO logAction)
+  liftIO $ runReaderT (unAppM m) (backend, hoistLogAction liftIO logAction)

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST.hs
@@ -11,13 +11,13 @@ module Language.Marlowe.Runtime.Web.Server.REST
   where
 
 import Language.Marlowe.Runtime.Web
-import Language.Marlowe.Runtime.Web.Server.Monad (AppM)
+import Language.Marlowe.Runtime.Web.Server.Monad (ServerM)
 import qualified Language.Marlowe.Runtime.Web.Server.REST.Contracts as Contracts
 import qualified Language.Marlowe.Runtime.Web.Server.REST.Withdrawals as Withdrawals
 import Servant
 
-server :: ServerT API AppM
+server :: ServerT API ServerM
 server = Contracts.server :<|> Withdrawals.server :<|> healthcheckServer
 
-healthcheckServer :: AppM NoContent
+healthcheckServer :: ServerM NoContent
 healthcheckServer = pure NoContent

--- a/marlowe-runtime/marlowe-contract/Main.hs
+++ b/marlowe-runtime/marlowe-contract/Main.hs
@@ -9,19 +9,11 @@
 module Main
   where
 
-import Colog (LogAction(LogAction), Message, cmap, fmtMessage, logTextStdout)
 import Control.Concurrent.Component
 import Control.Concurrent.Component.Probes (ProbeServerDependencies(..), probeServer)
-import Control.Exception (bracket)
+import Control.Concurrent.Component.Run (AppM, runAppMTraced)
 import Control.Monad (when)
-import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Event.Class
-import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Reader (MonadReader(..), asks, withReaderT)
-import Control.Monad.Trans.Reader (ReaderT(..))
-import Control.Monad.With
-import Data.Bifunctor (first)
-import Data.GeneralAllocate
 import qualified Data.Text as T
 import Data.Version (showVersion)
 import Data.Word (Word64)
@@ -38,8 +30,6 @@ import Network.Protocol.Handshake.Server (handshakeConnectionSourceTraced)
 import Network.Protocol.Query.Server (queryServerPeer)
 import Network.Socket (HostName, PortNumber)
 import Network.TypedProtocol (unsafeIntToNat)
-import Observe.Event.Backend (EventBackend, hoistEventBackend)
-import Observe.Event.Render.OpenTelemetry (tracerEventBackend)
 import OpenTelemetry.Trace
 import Options.Applicative
   ( auto
@@ -59,27 +49,18 @@ import Options.Applicative
   , value
   )
 import Paths_marlowe_runtime
-import UnliftIO (BufferMode(LineBuffering), MonadUnliftIO, hSetBuffering, newMVar, stderr, stdout, withMVar)
 
 main :: IO ()
 main = do
-  hSetBuffering stdout LineBuffering
-  hSetBuffering stderr LineBuffering
   options <- getOptions
-  withTracer \tracer ->
-    runAppM (tracerEventBackend tracer renderRootSelectorOTel) $ run options
+  runAppMTraced instrumentationLibrary renderRootSelectorOTel $ run options
   where
-    withTracer f = bracket
-      initializeGlobalTracerProvider
-      shutdownTracerProvider
-      \provider -> f $ makeTracer provider instrumentationLibrary tracerOptions
-
     instrumentationLibrary = InstrumentationLibrary
       { libraryName = "marlowe-proxy"
       , libraryVersion = T.pack $ showVersion version
       }
 
-run :: Options -> AppM Span ()
+run :: Options -> AppM Span RootSelector ()
 run Options{..} = do
   contractStore <- traceContractStore inject
     <$> createContractStore ContractStoreOptions{..}
@@ -105,49 +86,6 @@ run Options{..} = do
       }
 
     probeServer -< ProbeServerDependencies { port = fromIntegral httpPort, .. }
-
-runAppM :: EventBackend IO r RootSelector -> AppM r a -> IO a
-runAppM eventBackend (AppM action) = do
-  logAction <- concurrentLogger
-  runReaderT action (hoistEventBackend liftIO eventBackend, logAction)
-
-concurrentLogger :: MonadUnliftIO m => IO (LogAction m Message)
-concurrentLogger = do
-  lock <- newMVar ()
-  let LogAction baseAction = cmap fmtMessage logTextStdout
-  pure $ LogAction $ withMVar lock . const . baseAction
-
-newtype AppM r a = AppM
-  { unAppM :: ReaderT (EventBackend (AppM r) r RootSelector, LogAction (AppM r) Message) IO a
-  } deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadFail, MonadThrow, MonadCatch, MonadMask)
-
-instance MonadReader (LogAction (AppM r) Message) (AppM r) where
-  ask = AppM $ asks snd
-  local f (AppM m) = AppM $ withReaderT (fmap f) m
-
-instance MonadWith (AppM r) where
-  type WithException (AppM r) = WithException IO
-  stateThreadingGeneralWith
-    :: forall a b releaseReturn
-     . GeneralAllocate (AppM r) (WithException IO) releaseReturn b a
-    -> (a -> AppM r b)
-    -> AppM r (b, releaseReturn)
-  stateThreadingGeneralWith (GeneralAllocate allocA) go = AppM . ReaderT $ \r -> do
-    let
-      allocA' :: (forall x. IO x -> IO x) -> IO (GeneralAllocated IO (WithException IO) releaseReturn b a)
-      allocA' restore = do
-        let
-          restore' :: forall x. AppM r x -> AppM r x
-          restore' mx = AppM . ReaderT $ restore . (runReaderT . unAppM) mx
-        GeneralAllocated a releaseA <- (runReaderT . unAppM) (allocA restore') r
-        let
-          releaseA' relTy = (runReaderT . unAppM) (releaseA relTy) r
-        pure $ GeneralAllocated a releaseA'
-    stateThreadingGeneralWith (GeneralAllocate allocA') (flip (runReaderT . unAppM) r . go)
-
-instance MonadEvent r RootSelector (AppM r) where
-  askBackend = askBackendReaderT AppM fst
-  localBackend = localBackendReaderT AppM unAppM first
 
 data Options = Options
   { host :: HostName

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -493,11 +493,9 @@ executable marlowe-indexer
     , base >= 4.9 && < 5
     , bytestring >= 0.10.12 && < 0.12
     , containers >= 0.6.5 && < 0.7
-    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1
-    , general-allocate ^>= { 0.2 }
     , hasql >= 1.6 && < 2
     , hasql-pool ^>= 0.8
     , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
@@ -512,7 +510,6 @@ executable marlowe-indexer
     , optparse-applicative >= 0.17 && < 0.18
     , postgresql-libpq >= 0.9 && < 0.10
     , text >= 1.2.4 && < 2
-    , transformers >= 0.5.6 && < 0.6
     , unliftio >= 0.2.1 && < 0.3
   ghc-options: -threaded
 
@@ -529,11 +526,9 @@ executable marlowe-sync
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
     , bytestring >= 0.10.12 && < 0.12
-    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1
-    , general-allocate ^>= { 0.2 }
     , hasql >= 1.6 && < 2
     , hasql-pool ^>= 0.8
     , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
@@ -549,7 +544,6 @@ executable marlowe-sync
     , optparse-applicative >= 0.17 && < 0.18
     , postgresql-libpq >= 0.9 && < 0.10
     , text >= 1.2.4 && < 2
-    , transformers >= 0.5.6 && < 0.6
     , unliftio >= 0.2.1 && < 0.3
   ghc-options: -threaded
 
@@ -566,12 +560,10 @@ executable marlowe-tx
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
     , cardano-api ==1.35.4
-    , co-log >= 0.5.0.0 && < 0.6.0.0
     , containers >= 0.6.5 && < 0.7
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>= 0.1
-    , general-allocate ^>= { 0.2 }
     , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
     , hs-opentelemetry-sdk >= 0.0.3 && < 0.0.4
     , marlowe-chain-sync ==0.0.1
@@ -580,12 +572,9 @@ executable marlowe-tx
     , marlowe-runtime:contract-api ==0.0.1
     , marlowe-runtime:tx ==0.0.1
     , marlowe-runtime:tx-api ==0.0.1
-    , mtl >= 2.2 && < 3
     , network >= 3.1 && < 4
     , optparse-applicative >= 0.17 && < 0.18
     , text >= 1.2.4 && < 2
-    , transformers >= 0.5.6 && < 0.6
-    , unliftio >= 0.2.1 && < 0.3
   ghc-options: -threaded
 
 executable marlowe-contract
@@ -601,25 +590,19 @@ executable marlowe-contract
     , aeson >= 2 && < 3
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
-    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>=  0.1
-    , exceptions >= 0.10 && < 0.11
-    , general-allocate ^>= { 0.2 }
     , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
     , hs-opentelemetry-sdk >= 0.0.3 && < 0.0.4
     , marlowe-cardano ==0.1.0.3
     , marlowe-protocols ==0.1.0.0
     , marlowe-runtime:contract ==0.0.1
     , marlowe-runtime:contract-api ==0.0.1
-    , mtl >= 2.2 && < 3
     , network >= 3.1 && < 4
     , optparse-applicative >= 0.17 && < 0.18
     , text >= 1.2.4 && < 2
-    , transformers >= 0.5.6 && < 0.6
     , typed-protocols ==0.1.0.0
-    , unliftio >= 0.2.1 && < 0.3
   ghc-options: -threaded
 
 executable marlowe-proxy
@@ -634,11 +617,9 @@ executable marlowe-proxy
   build-depends:
     , async-components ==0.1.0.0
     , base >= 4.9 && < 5
-    , co-log >= 0.5.0.0 && < 0.6.0.0
     , eventuo11y ^>= { 0.9, 0.10 }
     , eventuo11y-extras ==0.1.0.0
     , eventuo11y-otel ^>=  0.1
-    , general-allocate ^>= { 0.2 }
     , hs-opentelemetry-api >= 0.0.3 && < 0.0.4
     , hs-opentelemetry-sdk >= 0.0.3 && < 0.0.4
     , marlowe-protocols ==0.1.0.0
@@ -650,12 +631,9 @@ executable marlowe-proxy
     , marlowe-runtime:proxy-api ==0.0.1
     , marlowe-runtime:sync-api ==0.0.1
     , marlowe-runtime:tx-api ==0.0.1
-    , mtl >= 2.2 && < 3
     , network >= 3.1 && < 4
     , optparse-applicative >= 0.17 && < 0.18
     , text >= 1.2.4 && < 2
-    , transformers >= 0.5.6 && < 0.6
-    , unliftio >= 0.2.1 && < 0.3
   ghc-options: -threaded
 
 test-suite marlowe-runtime-test


### PR DESCRIPTION
- [x] Make tracing a no-op if the `OTEL_EXPORTER_OTLP_ENDPOINT` env var is not set (this is not standard, but is convenient in our case).
  - No-op means that the global tracer provider is not initialized and that a `noopEventBackend` is used, so selectors and fields are never held in memory past creation and are not processed into spans and attributes.
- [x] Refactor: consolidate duplicated monad stack into a single module (used in all runtime components, web server, and integration tests).
- [x] Refactor: consolidate tracer initialization to the same place. 

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
    - [x] Reviewer requested
