### PR TITLE
Fix static cross-building with musl.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -781,6 +781,23 @@
         "type": "github"
       }
     },
+    "blst": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656163412,
+        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "type": "github"
+      }
+    },
     "byron-chain": {
       "flake": false,
       "locked": {
@@ -5527,11 +5544,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1686904565,
-        "narHash": "sha256-0S1bSFo4g5dcSjNesuqJmAqDqaJlIV9Ibf32OSyQ/1w=",
+        "lastModified": 1686926922,
+        "narHash": "sha256-ATZPmcRkNZsuHQIMC07J+fn5HwX8OOYmGhaFFZg0byQ=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "6ed22d6d308418042718f5a4ae2a2af643c0180a",
+        "rev": "a44697b024e9293448b793515dec1f10da49985c",
         "type": "github"
       },
       "original": {
@@ -5562,13 +5579,21 @@
       }
     },
     "iohk-nix_2": {
-      "flake": false,
+      "inputs": {
+        "blst": "blst",
+        "nixpkgs": [
+          "iogx",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
+      },
       "locked": {
-        "lastModified": 1684223806,
-        "narHash": "sha256-IyLoP+zhuyygLtr83XXsrvKyqqLQ8FHXTiySFf4FJOI=",
+        "lastModified": 1685727458,
+        "narHash": "sha256-c/pkFYCfzpRb6W2OOKE+EOzOlcw+96vwJGGg8Ir9Qfk=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "86421fdd89b3af43fa716ccd07638f96c6ecd1e4",
+        "rev": "02f42375ee5c2bab1640f14c6389b7e91bbfec8b",
         "type": "github"
       },
       "original": {
@@ -10463,6 +10488,40 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "sodium": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
         "type": "github"
       }
     },

--- a/nix/haskell-project.nix
+++ b/nix/haskell-project.nix
@@ -2,14 +2,14 @@
 
 {
   # Desystemized merged inputs.
-  # All the inputs from iogx (e.g. CHaP, haskell-nix, etc..) unioned with the 
+  # All the inputs from iogx (e.g. CHaP, haskell-nix, etc..) unioned with the
   # inputs defined in your flake. You will also find the `self` attribute here.
   # These inputs have been desystemized against the current system.
   inputs
 
 , systemized-inputs
 
-  # The very config passed as second argument to `inputs.iogx.mkFlake` in your 
+  # The very config passed as second argument to `inputs.iogx.mkFlake` in your
   # `flake.nix`.
 , flakeopts
 
@@ -25,7 +25,7 @@
   # when the build has to include haddock.
 , deferPluginErrors
 
-  # Whether to enable haskell profiling. 
+  # Whether to enable haskell profiling.
 , enableProfiling
 }:
 
@@ -88,10 +88,6 @@ let
     # Honestly not sure why we need this, it has a mysterious unused dependency on "m"
     # This will go away when we upgrade nixpkgs and things use ieee754 anyway.
     ieee.components.library.libs = lib.mkForce [ ];
-
-    # See https://github.com/input-output-hk/iohk-nix/pull/488
-    cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
-    cardano-crypto-class.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 ] ];
 
     # hpack fails due to modified cabal file, can remove when we bump to 3.12.0
     cardano-addresses.cabal-generator = lib.mkForce null;


### PR DESCRIPTION
This involved updating `iogx` to use the latest `iohk-nix` with its fixed crypto overlays, and removing the old ad hoc configuration to make libsodium available to needed builds (which selected the host package when cross-compiling).