### PR TITLE
PLT-6335 Added stake-address support for `marlowe-runtime-cli` and REST API

### DIFF
--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Common.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Common.hs
@@ -60,6 +60,7 @@ createCloseContract Wallet{..} = do
 
   Web.CreateTxEnvelope{txEnvelope, ..} <-
     postContract
+      Nothing
       webChangeAddress
       (Just webExtraAddresses)
       (Just webCollataralUtxos)

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Post.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Post.hs
@@ -35,6 +35,7 @@ spec = describe "Valid POST /contracts" do
       let (contract, _, _) = standardContract partyBAddress now $ secondsToNominalDiffTime 100
 
       postContract
+        Nothing
         partyAWebChangeAddress
         (Just partyAWebExtraAddresses)
         (Just partyAWebCollataralUtxos)

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Put.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Put.hs
@@ -38,6 +38,7 @@ spec = describe "POST /contracts/{contractId}/transactions" do
 
       Web.CreateTxEnvelope{contractId, txEnvelope} <-
         postContract
+          Nothing
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
           (Just partyAWebCollataralUtxos)

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Post.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Post.hs
@@ -40,6 +40,7 @@ spec = describe "POST /contracts/{contractId}/transactions" do
 
       contractCreated@Web.CreateTxEnvelope{contractId} <-
         postContract
+          Nothing
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
           (Just partyAWebCollataralUtxos)

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Put.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Put.hs
@@ -46,6 +46,7 @@ spec = describe "PUT /contracts/{contractId}/transactions/{transaction}" do
 
       contractCreated@Web.CreateTxEnvelope{contractId} <-
         postContract
+          Nothing
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
           (Just partyAWebCollataralUtxos)

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/StandardContract.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/StandardContract.hs
@@ -84,6 +84,7 @@ createStandardContractWithTags tags partyAWallet partyBWallet = do
 
   contractCreated@Web.CreateTxEnvelope{contractId} <-
     postContract
+      Nothing
       partyAWebChangeAddress
       (Just partyAWebExtraAddresses)
       (Just partyAWebCollataralUtxos)

--- a/marlowe-integration/app/Main.hs
+++ b/marlowe-integration/app/Main.hs
@@ -45,6 +45,7 @@ main = withLocalMarloweRuntime \MarloweRuntime{..} -> do
   either throw pure =<< runWebClient do
     Web.CreateTxEnvelope{txEnvelope = createTxBody, ..} <-
       postContract
+        Nothing
         webAddress
         Nothing
         Nothing

--- a/marlowe-runtime-web/changelog.d/20230630_110941_brian.bush_PLT_6335.md
+++ b/marlowe-runtime-web/changelog.d/20230630_110941_brian.bush_PLT_6335.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added header `X-Stake-Address` for creating contracts.

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/API.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/API.hs
@@ -188,8 +188,12 @@ instance HasNamedLink (CreateTxEnvelope tx) API "contract" where
 
 -- | POST /contracts sub-API
 type PostContractsAPI =
-  ReqBody '[JSON] PostContractsRequest :> PostTxAPI (PostCreated '[JSON] (PostContractsResponse CardanoTxBody))
-    :<|> ReqBody '[JSON] PostContractsRequest :> PostTxAPI (PostCreated '[TxJSON ContractTx] (PostContractsResponse CardanoTx))
+  ReqBody '[JSON] PostContractsRequest
+    :> Header "X-Stake-Address" StakeAddress
+    :> PostTxAPI (PostCreated '[JSON] (PostContractsResponse CardanoTxBody))
+    :<|> ReqBody '[JSON] PostContractsRequest
+      :> Header "X-Stake-Address" StakeAddress
+      :> PostTxAPI (PostCreated '[TxJSON ContractTx] (PostContractsResponse CardanoTx))
 
 -- | /contracts/:contractId sup-API
 type ContractAPI =

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Client.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Client.hs
@@ -131,16 +131,18 @@ getContracts
 getContracts = (fmap . fmap . fmap) snd . getContractsStatus
 
 postContractStatus
-  :: Address
+  :: Maybe StakeAddress
+  -> Address
   -> Maybe (Set Address)
   -> Maybe (Set TxOutRef)
   -> PostContractsRequest
   -> ClientM (RuntimeStatus, CreateTxEnvelope CardanoTxBody)
-postContractStatus changeAddress otherAddresses collateralUtxos request = do
+postContractStatus stakeAddress changeAddress otherAddresses collateralUtxos request = do
   let (_ :<|> (postContractCreateTxBody' :<|> _) :<|> _) :<|> _ = client
   response <-
     postContractCreateTxBody'
       request
+      stakeAddress
       changeAddress
       (setToCommaList <$> otherAddresses)
       (setToCommaList <$> collateralUtxos)
@@ -148,24 +150,27 @@ postContractStatus changeAddress otherAddresses collateralUtxos request = do
   pure (status, retractLink $ getResponse response)
 
 postContract
-  :: Address
+  :: Maybe StakeAddress
+  -> Address
   -> Maybe (Set Address)
   -> Maybe (Set TxOutRef)
   -> PostContractsRequest
   -> ClientM (CreateTxEnvelope CardanoTxBody)
-postContract = (fmap . fmap . fmap . fmap) snd . postContractStatus
+postContract = (fmap . fmap . fmap . fmap . fmap) snd . postContractStatus
 
 postContractCreateTxStatus
-  :: Address
+  :: Maybe StakeAddress
+  -> Address
   -> Maybe (Set Address)
   -> Maybe (Set TxOutRef)
   -> PostContractsRequest
   -> ClientM (RuntimeStatus, CreateTxEnvelope CardanoTx)
-postContractCreateTxStatus changeAddress otherAddresses collateralUtxos request = do
+postContractCreateTxStatus stakeAddress changeAddress otherAddresses collateralUtxos request = do
   let (_ :<|> (_ :<|> postContractCreateTx') :<|> _) :<|> _ = client
   response <-
     postContractCreateTx'
       request
+      stakeAddress
       changeAddress
       (setToCommaList <$> otherAddresses)
       (setToCommaList <$> collateralUtxos)
@@ -173,12 +178,13 @@ postContractCreateTxStatus changeAddress otherAddresses collateralUtxos request 
   pure (status, retractLink $ getResponse response)
 
 postContractCreateTx
-  :: Address
+  :: Maybe StakeAddress
+  -> Address
   -> Maybe (Set Address)
   -> Maybe (Set TxOutRef)
   -> PostContractsRequest
   -> ClientM (CreateTxEnvelope CardanoTx)
-postContractCreateTx = (fmap . fmap . fmap . fmap) snd . postContractCreateTxStatus
+postContractCreateTx = (fmap . fmap . fmap . fmap . fmap) snd . postContractCreateTxStatus
 
 getContractStatus :: TxOutRef -> ClientM (RuntimeStatus, ContractState)
 getContractStatus contractId = do

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
@@ -128,6 +128,20 @@ instance ToParamSchema Address where
       & OpenApi.description ?~ "A cardano address"
       & example ?~ "addr1w94f8ywk4fg672xasahtk4t9k6w3aql943uxz5rt62d4dvq8evxaf"
 
+newtype StakeAddress = StakeAddress {unStakeAddress :: T.Text}
+  deriving (Eq, Ord, Generic)
+  deriving newtype (Show, ToHttpApiData, FromHttpApiData, ToJSON, FromJSON)
+
+instance ToSchema StakeAddress where
+  declareNamedSchema = pure . NamedSchema (Just "StakeAddress") . toParamSchema
+
+instance ToParamSchema StakeAddress where
+  toParamSchema _ =
+    mempty
+      & type_ ?~ OpenApiString
+      & OpenApi.description ?~ "A cardano stake address"
+      & example ?~ "stake1ux7lyy9nhecm033qsmel9awnr22up6jadlzkrxufr78w82gsfsn0d"
+
 newtype CommaList a = CommaList {unCommaList :: [a]}
   deriving (Eq, Ord, Generic, Functor)
   deriving newtype (Show, ToJSON, FromJSON, IsList)

--- a/marlowe-runtime-web/test/Spec.hs
+++ b/marlowe-runtime-web/test/Spec.hs
@@ -209,6 +209,10 @@ instance Arbitrary Web.Address where
   arbitrary = Web.Address <$> arbitrary
   shrink = genericShrink
 
+instance Arbitrary Web.StakeAddress where
+  arbitrary = Web.StakeAddress <$> arbitrary
+  shrink = genericShrink
+
 instance (Arbitrary a) => Arbitrary (Web.ListObject a) where
   arbitrary = Web.ListObject <$> arbitrary
   shrink = genericShrink

--- a/marlowe-runtime/changelog.d/20230630_091216_brian.bush_PLT_6335.md
+++ b/marlowe-runtime/changelog.d/20230630_091216_brian.bush_PLT_6335.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added `--stake-address` to `marlowe-runtime-cli create` command, for attaching stake credentials to Marlowe's validator address.


### PR DESCRIPTION
Implemented including stake credentials in the Marlowe validator address in the following clients:
- `marlowe-runtime-cli create`
- Contract creation in REST API

Tested manually on the `preprod` network.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested