### PR TITLE
PLT-6344 Add contract source ID option to `POST /contracts`

### DIFF
--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Common.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Common.hs
@@ -35,6 +35,7 @@ import Language.Marlowe.Core.V1.Semantics.Types (
  )
 import Language.Marlowe.Runtime.Integration.Common hiding (choose, deposit, notify, withdraw)
 import Language.Marlowe.Runtime.Transaction.Api (WalletAddresses (..))
+import Language.Marlowe.Runtime.Web (ContractOrSourceId (..))
 import qualified Language.Marlowe.Runtime.Web as Web
 import Language.Marlowe.Runtime.Web.Client (
   getContract,
@@ -56,19 +57,19 @@ createCloseContract Wallet{..} = do
   let WalletAddresses{..} = addresses
   let webChangeAddress = toDTO changeAddress
   let webExtraAddresses = Set.map toDTO extraAddresses
-  let webCollataralUtxos = Set.map toDTO collateralUtxos
+  let webCollateralUtxos = Set.map toDTO collateralUtxos
 
   Web.CreateTxEnvelope{txEnvelope, ..} <-
     postContract
       Nothing
       webChangeAddress
       (Just webExtraAddresses)
-      (Just webCollataralUtxos)
+      (Just webCollateralUtxos)
       Web.PostContractsRequest
         { metadata = mempty
         , version = Web.V1
         , roles = Nothing
-        , contract = V1.Close
+        , contract = ContractOrSourceId $ Left V1.Close
         , minUTxODeposit = 2_000_000
         , tags = mempty
         }
@@ -83,12 +84,12 @@ applyCloseTransaction Wallet{..} contractId = do
   let WalletAddresses{..} = addresses
   let webChangeAddress = toDTO changeAddress
   let webExtraAddresses = Set.map toDTO extraAddresses
-  let webCollataralUtxos = Set.map toDTO collateralUtxos
+  let webCollateralUtxos = Set.map toDTO collateralUtxos
   Web.ApplyInputsTxEnvelope{transactionId, txEnvelope} <-
     postTransaction
       webChangeAddress
       (Just webExtraAddresses)
-      (Just webCollataralUtxos)
+      (Just webCollateralUtxos)
       contractId
       Web.PostTransactionsRequest
         { version = Web.V1
@@ -172,12 +173,12 @@ withdraw Wallet{..} contractId role = do
   let WalletAddresses{..} = addresses
   let webChangeAddress = toDTO changeAddress
   let webExtraAddresses = Set.map toDTO extraAddresses
-  let webCollataralUtxos = Set.map toDTO collateralUtxos
+  let webCollateralUtxos = Set.map toDTO collateralUtxos
 
   postWithdrawal
     webChangeAddress
     (Just webExtraAddresses)
-    (Just webCollataralUtxos)
+    (Just webCollateralUtxos)
     Web.PostWithdrawalsRequest
       { role
       , contractId
@@ -191,12 +192,12 @@ applyInputs Wallet{..} contractId inputs = do
   let WalletAddresses{..} = addresses
   let webChangeAddress = toDTO changeAddress
   let webExtraAddresses = Set.map toDTO extraAddresses
-  let webCollataralUtxos = Set.map toDTO collateralUtxos
+  let webCollateralUtxos = Set.map toDTO collateralUtxos
 
   postTransaction
     webChangeAddress
     (Just webExtraAddresses)
-    (Just webCollataralUtxos)
+    (Just webCollateralUtxos)
     contractId
     Web.PostTransactionsRequest
       { version = Web.V1

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Post.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Post.hs
@@ -10,6 +10,7 @@ import Language.Marlowe.Runtime.Integration.Common
 import Language.Marlowe.Runtime.Integration.StandardContract (standardContract)
 import Language.Marlowe.Runtime.Plutus.V2.Api (toPlutusAddress)
 import Language.Marlowe.Runtime.Transaction.Api (WalletAddresses (..))
+import Language.Marlowe.Runtime.Web (ContractOrSourceId (..))
 import qualified Language.Marlowe.Runtime.Web as Web
 import Language.Marlowe.Runtime.Web.Client (postContract)
 import Language.Marlowe.Runtime.Web.Server.DTO (ToDTO (toDTO))
@@ -26,7 +27,7 @@ spec = describe "Valid POST /contracts" do
       let partyAWalletAddresses = addresses partyAWallet
       let partyAWebChangeAddress = toDTO $ changeAddress partyAWalletAddresses
       let partyAWebExtraAddresses = Set.map toDTO $ extraAddresses partyAWalletAddresses
-      let partyAWebCollataralUtxos = Set.map toDTO $ collateralUtxos partyAWalletAddresses
+      let partyAWebCollateralUtxos = Set.map toDTO $ collateralUtxos partyAWalletAddresses
 
       let partyBWalletAddresses = addresses partyBWallet
 
@@ -40,12 +41,12 @@ spec = describe "Valid POST /contracts" do
           Nothing
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
-          (Just partyAWebCollataralUtxos)
+          (Just partyAWebCollateralUtxos)
           Web.PostContractsRequest
             { metadata = mempty
             , version = Web.V1
             , roles = Just $ Web.Mint $ Map.singleton "PartyA" $ Web.RoleTokenSimple partyAWebChangeAddress
-            , contract = contract
+            , contract = ContractOrSourceId $ Left contract
             , minUTxODeposit = 2_000_000
             , tags = mempty
             }

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Put.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Put.hs
@@ -8,7 +8,7 @@ import Language.Marlowe.Runtime.Integration.Common
 import Language.Marlowe.Runtime.Integration.StandardContract (standardContract)
 import Language.Marlowe.Runtime.Plutus.V2.Api (toPlutusAddress)
 import Language.Marlowe.Runtime.Transaction.Api (WalletAddresses (..))
-import Language.Marlowe.Runtime.Web (RoleTokenConfig (RoleTokenSimple))
+import Language.Marlowe.Runtime.Web (ContractOrSourceId (..), RoleTokenConfig (RoleTokenSimple))
 import qualified Language.Marlowe.Runtime.Web as Web
 import Language.Marlowe.Runtime.Web.Client (postContract, putContract)
 import Language.Marlowe.Runtime.Web.Common (signShelleyTransaction')
@@ -26,7 +26,7 @@ spec = describe "POST /contracts/{contractId}/transactions" do
       let partyAWalletAddresses = addresses partyAWallet
       let partyAWebChangeAddress = toDTO $ changeAddress partyAWalletAddresses
       let partyAWebExtraAddresses = Set.map toDTO $ extraAddresses partyAWalletAddresses
-      let partyAWebCollataralUtxos = Set.map toDTO $ collateralUtxos partyAWalletAddresses
+      let partyAWebCollateralUtxos = Set.map toDTO $ collateralUtxos partyAWalletAddresses
 
       let partyBWalletAddresses = addresses partyBWallet
 
@@ -41,12 +41,12 @@ spec = describe "POST /contracts/{contractId}/transactions" do
           Nothing
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
-          (Just partyAWebCollataralUtxos)
+          (Just partyAWebCollateralUtxos)
           Web.PostContractsRequest
             { metadata = mempty
             , version = Web.V1
             , roles = Just $ Web.Mint $ Map.singleton "PartyA" $ RoleTokenSimple partyAWebChangeAddress
-            , contract = contract
+            , contract = ContractOrSourceId $ Left contract
             , minUTxODeposit = 2_000_000
             , tags = mempty
             }

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Post.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Post.hs
@@ -11,7 +11,7 @@ import Language.Marlowe.Runtime.Integration.Common
 import Language.Marlowe.Runtime.Integration.StandardContract (standardContract)
 import Language.Marlowe.Runtime.Plutus.V2.Api (toPlutusAddress)
 import Language.Marlowe.Runtime.Transaction.Api (WalletAddresses (..))
-import Language.Marlowe.Runtime.Web (RoleTokenConfig (RoleTokenSimple))
+import Language.Marlowe.Runtime.Web (ContractOrSourceId (..), RoleTokenConfig (RoleTokenSimple))
 import qualified Language.Marlowe.Runtime.Web as Web
 import Language.Marlowe.Runtime.Web.Client (postContract, postTransaction)
 import Language.Marlowe.Runtime.Web.Common (submitContract)
@@ -29,7 +29,7 @@ spec = describe "POST /contracts/{contractId}/transactions" do
       let partyAWalletAddresses = addresses partyAWallet
       let partyAWebChangeAddress = toDTO $ changeAddress partyAWalletAddresses
       let partyAWebExtraAddresses = Set.map toDTO $ extraAddresses partyAWalletAddresses
-      let partyAWebCollataralUtxos = Set.map toDTO $ collateralUtxos partyAWalletAddresses
+      let partyAWebCollateralUtxos = Set.map toDTO $ collateralUtxos partyAWalletAddresses
 
       let partyBWalletAddresses = addresses partyBWallet
 
@@ -44,12 +44,12 @@ spec = describe "POST /contracts/{contractId}/transactions" do
           Nothing
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
-          (Just partyAWebCollataralUtxos)
+          (Just partyAWebCollateralUtxos)
           Web.PostContractsRequest
             { metadata = mempty
             , version = Web.V1
             , roles = Just $ Web.Mint $ Map.singleton "Party A" $ RoleTokenSimple partyAWebChangeAddress
-            , contract = contract
+            , contract = ContractOrSourceId $ Left contract
             , minUTxODeposit = 2_000_000
             , tags = mempty
             }
@@ -62,7 +62,7 @@ spec = describe "POST /contracts/{contractId}/transactions" do
         postTransaction
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
-          (Just partyAWebCollataralUtxos)
+          (Just partyAWebCollateralUtxos)
           contractId
           Web.PostTransactionsRequest
             { version = Web.V1

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Put.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Put.hs
@@ -16,7 +16,7 @@ import Language.Marlowe.Runtime.Integration.Common (
 import Language.Marlowe.Runtime.Integration.StandardContract (standardContract)
 import Language.Marlowe.Runtime.Plutus.V2.Api (toPlutusAddress)
 import Language.Marlowe.Runtime.Transaction.Api (WalletAddresses (..))
-import Language.Marlowe.Runtime.Web (RoleTokenConfig (RoleTokenSimple))
+import Language.Marlowe.Runtime.Web (ContractOrSourceId (..), RoleTokenConfig (RoleTokenSimple))
 import qualified Language.Marlowe.Runtime.Web as Web
 import Language.Marlowe.Runtime.Web.Client (postContract, postTransaction, putTransaction)
 import Language.Marlowe.Runtime.Web.Common (signShelleyTransaction', submitContract)
@@ -34,7 +34,7 @@ spec = describe "PUT /contracts/{contractId}/transactions/{transaction}" do
       let partyAWalletAddresses = addresses partyAWallet
       let partyAWebChangeAddress = toDTO $ changeAddress partyAWalletAddresses
       let partyAWebExtraAddresses = Set.map toDTO $ extraAddresses partyAWalletAddresses
-      let partyAWebCollataralUtxos = Set.map toDTO $ collateralUtxos partyAWalletAddresses
+      let partyAWebCollateralUtxos = Set.map toDTO $ collateralUtxos partyAWalletAddresses
 
       let partyBWalletAddresses = addresses partyBWallet
 
@@ -49,12 +49,12 @@ spec = describe "PUT /contracts/{contractId}/transactions/{transaction}" do
           Nothing
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
-          (Just partyAWebCollataralUtxos)
+          (Just partyAWebCollateralUtxos)
           Web.PostContractsRequest
             { metadata = mempty
             , version = Web.V1
             , roles = Just $ Web.Mint $ Map.singleton "Party A" $ RoleTokenSimple partyAWebChangeAddress
-            , contract = contract
+            , contract = ContractOrSourceId $ Left contract
             , minUTxODeposit = 2_000_000
             , tags = mempty
             }
@@ -67,7 +67,7 @@ spec = describe "PUT /contracts/{contractId}/transactions/{transaction}" do
         postTransaction
           partyAWebChangeAddress
           (Just partyAWebExtraAddresses)
-          (Just partyAWebCollataralUtxos)
+          (Just partyAWebCollateralUtxos)
           contractId
           Web.PostTransactionsRequest
             { version = Web.V1

--- a/marlowe-integration/app/Main.hs
+++ b/marlowe-integration/app/Main.hs
@@ -19,7 +19,11 @@ import Data.Maybe (fromJust)
 import qualified Data.Text as T
 import qualified Language.Marlowe.Core.V1.Semantics.Types as V1
 import Language.Marlowe.Runtime.ChainSync.Api (Address (..), fromBech32, toBech32)
-import Language.Marlowe.Runtime.Web (CreateTxEnvelope (CreateTxEnvelope), PostContractsRequest (..))
+import Language.Marlowe.Runtime.Web (
+  ContractOrSourceId (..),
+  CreateTxEnvelope (CreateTxEnvelope),
+  PostContractsRequest (..),
+ )
 import qualified Language.Marlowe.Runtime.Web as Web
 import Language.Marlowe.Runtime.Web.Client (
   getContract,
@@ -54,7 +58,7 @@ main = withLocalMarloweRuntime \MarloweRuntime{..} -> do
           , tags = mempty
           , version = Web.V1
           , roles = Nothing
-          , contract = V1.Close
+          , contract = ContractOrSourceId $ Left V1.Close
           , minUTxODeposit = 2_000_000
           }
 

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/ContractSources.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/ContractSources.hs
@@ -27,10 +27,10 @@ import Servant
 server :: ServerT ContractSourcesAPI ServerM
 server =
   post
-    :<|> contractServer
+    :<|> contractSourceServer
 
-contractServer :: ContractSourceId -> ServerT ContractSourceAPI ServerM
-contractServer sourceId =
+contractSourceServer :: ContractSourceId -> ServerT ContractSourceAPI ServerM
+contractSourceServer sourceId =
   getOne sourceId
     :<|> getAdjacency sourceId
     :<|> getClosure sourceId

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Contracts.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Contracts.hs
@@ -14,7 +14,7 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import Language.Marlowe.Analysis.Safety.Types (SafetyError)
 import Language.Marlowe.Protocol.Query.Types (ContractFilter (..), Page (..))
-import Language.Marlowe.Runtime.ChainSync.Api (Lovelace (..))
+import Language.Marlowe.Runtime.ChainSync.Api (DatumHash (..), Lovelace (..))
 import Language.Marlowe.Runtime.Core.Api (
   ContractId,
   MarloweMetadataTag (..),
@@ -78,6 +78,7 @@ postCreateTxBody PostContractsRequest{..} stakeAddressDTO changeAddressDTO mAddr
     fromDTOThrow
       (badRequest' "Invalid tags value")
       if Map.null tags then Nothing else Just (tags, Nothing)
+  let ContractOrSourceId contract' = contract
   createContract
     stakeAddress
     v
@@ -85,7 +86,7 @@ postCreateTxBody PostContractsRequest{..} stakeAddressDTO changeAddressDTO mAddr
     roles'
     MarloweTransactionMetadata{..}
     (Lovelace minUTxODeposit)
-    contract
+    (DatumHash . unContractSourceId <$> contract')
     >>= \case
       Left err -> throwDTOError err
       Right ContractCreated{contractId, txBody, safetyErrors} -> pure (contractId, txBody, safetyErrors)

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
@@ -36,7 +36,7 @@ import qualified Data.Map as Map
 import Data.Time (UTCTime)
 import Language.Marlowe.Protocol.Client (MarloweRuntimeClient (..))
 import Language.Marlowe.Runtime.Cardano.Api (fromCardanoTxId)
-import Language.Marlowe.Runtime.ChainSync.Api (Lovelace, StakeCredential, TokenName, TxId)
+import Language.Marlowe.Runtime.ChainSync.Api (DatumHash, Lovelace, StakeCredential, TokenName, TxId)
 import Language.Marlowe.Runtime.Core.Api (
   Contract,
   ContractId,
@@ -74,7 +74,7 @@ type CreateContract m =
   -> RoleTokensConfig
   -> MarloweTransactionMetadata
   -> Lovelace
-  -> Contract v
+  -> Either (Contract v) DatumHash
   -> m (Either (CreateError v) (ContractCreated BabbageEra v))
 
 type ApplyInputs m =
@@ -204,8 +204,7 @@ txClient = component "web-tx-client" \TxClientDependencies{..} -> do
               runConnector connector $
                 RunTxClient $
                   liftCommand $
-                    Create stakeCredential version addresses roles metadata minUTxODeposit $
-                      Left contract
+                    Create stakeCredential version addresses roles metadata minUTxODeposit contract
             liftIO $ for_ response \creation@ContractCreated{contractId} ->
               atomically $
                 modifyTVar tempContracts $

--- a/marlowe-runtime-web/test/Spec.hs
+++ b/marlowe-runtime-web/test/Spec.hs
@@ -18,6 +18,7 @@ import Servant.OpenApi
 import Spec.Marlowe.Semantics.Arbitrary ()
 import Spec.Marlowe.Semantics.Next.Arbitrary ()
 
+import Language.Marlowe.Runtime.Web (ContractOrSourceId (..))
 import Test.Hspec (Spec, describe, hspec)
 import Test.QuickCheck (Arbitrary (..), Gen, elements, genericShrink, listOf, oneof, resize, suchThat)
 import Test.QuickCheck.Instances ()
@@ -145,8 +146,12 @@ instance Arbitrary Web.PostContractsRequest where
       <*> arbitrary
       -- size of 6 will result in a 1-layer deep contract being generated (this is
       -- all we care about for the purposes of schema checking).
-      <*> resize 6 arbitrary
       <*> arbitrary
+      <*> arbitrary
+  shrink = genericShrink
+
+instance Arbitrary Web.ContractOrSourceId where
+  arbitrary = ContractOrSourceId <$> oneof [Right <$> arbitrary, Left <$> resize 6 arbitrary]
   shrink = genericShrink
 
 instance Arbitrary Web.PostTransactionsRequest where
@@ -223,6 +228,9 @@ instance Arbitrary Web.TextEnvelope where
 
 instance Arbitrary Web.TxOutRef where
   arbitrary = Web.TxOutRef <$> arbitrary <*> arbitrary
+
+instance Arbitrary Web.ContractSourceId where
+  arbitrary = Web.ContractSourceId . BS.pack <$> replicateM 32 arbitrary
 
 instance Arbitrary Web.TxId where
   arbitrary = Web.TxId . BS.pack <$> replicateM 32 arbitrary

--- a/marlowe-runtime/changelog.d/20230714_084746_jhbertra_plt_6344_get_contract_source_tx.md
+++ b/marlowe-runtime/changelog.d/20230714_084746_jhbertra_plt_6344_get_contract_source_tx.md
@@ -1,0 +1,3 @@
+### Added
+
+- Request body for `POST /contracts` now accepts a contract source ID as well as contract JSON.


### PR DESCRIPTION
Added ability to specify a `contractSourceId` when creating a contract.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
    - [x] Reviewer requested
