### PR TITLE
Add custom headers to exposed list on the server side

### DIFF
--- a/marlowe-runtime-web/changelog.d/20230717_085425_tomasz.rybarczyk_PLT_6724_cors_failure.md
+++ b/marlowe-runtime-web/changelog.d/20230717_085425_tomasz.rybarczyk_PLT_6724_cors_failure.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- CORS behaviour by adding list of new server custom headers to the `Access-Control-Expose-Headers`
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server.hs
@@ -119,14 +119,21 @@ corsMiddleware accessControlAllowOriginAll =
       let policy =
             simpleCorsResourcePolicy
               { corsRequestHeaders =
-                  [ "Content-Type"
+                  [ "Accept"
+                  , "Content-Type"
                   , "Range"
-                  , "Accept"
-                  , "X-Change-Address"
                   , "X-Address"
+                  , "X-Change-Address"
                   , "X-Collateral-UTxO"
                   ]
-              , corsExposedHeaders = Just ["*"]
+              , corsExposedHeaders =
+                  Just
+                    [ "X-Network-Id"
+                    , "X-Node-Tip"
+                    , "X-Runtime-Chain-Tip"
+                    , "X-Runtime-Tip"
+                    , "X-Runtime-Version"
+                    ]
               , corsMethods = ["GET", "POST", "PUT", "OPTIONS", "DELETE"]
               }
       cors (const $ Just policy)


### PR DESCRIPTION
Quick fix which adds headers to `Access-Control-Expose-Headers` list. It probably requires a fix release. Currently POST endpoints for instances on demeter.run are unusable from any web browser client. 

We don't catch CORS errors in the test suite unfortunately.