### PR TITLE
PLT-6838 Optimise ChainSeek

### DIFF
--- a/marlowe-chain-sync/.golden/ChainSeek/golden
+++ b/marlowe-chain-sync/.golden/ChainSeek/golden
@@ -1,23 +1,43 @@
 Show: MsgQueryNext (AdvanceBlocks 1)
 Binary: 0101000000000000000001
+Show: MsgScan (AdvanceBlocks 1)
+Binary: 0901000000000000000001
 Show: MsgQueryNext (Intersect [])
 Binary: 01020000000000000000
 Show: MsgQueryNext (Intersect [BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}])
 Binary: 01020000000000000001000000000000000100000000000000000000000000000001
 Show: MsgQueryNext (Intersect [BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}])
 Binary: 0102000000000000000100000000000000010000000000000001610000000000000001
+Show: MsgScan (Intersect [])
+Binary: 09020000000000000000
+Show: MsgScan (Intersect [BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}])
+Binary: 09020000000000000001000000000000000100000000000000000000000000000001
+Show: MsgScan (Intersect [BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}])
+Binary: 0902000000000000000100000000000000010000000000000001610000000000000001
 Show: MsgQueryNext (FindConsumingTxs (fromList []))
 Binary: 01040000000000000000
 Show: MsgQueryNext (FindConsumingTxs (fromList [TxOutRef {txId = "", txIx = TxIx {unTxIx = 1}}]))
 Binary: 0104000000000000000100000000000000000001
 Show: MsgQueryNext (FindConsumingTxs (fromList [TxOutRef {txId = "61", txIx = TxIx {unTxIx = 1}}]))
 Binary: 010400000000000000010000000000000001610001
+Show: MsgScan (FindConsumingTxs (fromList []))
+Binary: 09040000000000000000
+Show: MsgScan (FindConsumingTxs (fromList [TxOutRef {txId = "", txIx = TxIx {unTxIx = 1}}]))
+Binary: 0904000000000000000100000000000000000001
+Show: MsgScan (FindConsumingTxs (fromList [TxOutRef {txId = "61", txIx = TxIx {unTxIx = 1}}]))
+Binary: 090400000000000000010000000000000001610001
 Show: MsgQueryNext (FindTx "" False)
 Binary: 0103000000000000000000
 Show: MsgQueryNext (FindTx "" True)
 Binary: 0103000000000000000001
 Show: MsgQueryNext (FindTx "61" False)
 Binary: 010300000000000000016100
+Show: MsgScan (FindTx "" False)
+Binary: 0903000000000000000000
+Show: MsgScan (FindTx "" True)
+Binary: 0903000000000000000001
+Show: MsgScan (FindTx "61" False)
+Binary: 090300000000000000016100
 Show: MsgQueryNext (FindTxsFor (fromList (PaymentKeyCredential "" :| [])))
 Binary: 01060000000000000001000000000000000000
 Show: MsgQueryNext (FindTxsFor (fromList (PaymentKeyCredential "" :| [PaymentKeyCredential "61"])))
@@ -32,14 +52,34 @@ Show: MsgQueryNext (FindTxsFor (fromList (ScriptCredential "" :| [])))
 Binary: 01060000000000000001010000000000000000
 Show: MsgQueryNext (FindTxsFor (fromList (ScriptCredential "61" :| [])))
 Binary: 0106000000000000000101000000000000000161
+Show: MsgScan (FindTxsFor (fromList (PaymentKeyCredential "" :| [])))
+Binary: 09060000000000000001000000000000000000
+Show: MsgScan (FindTxsFor (fromList (PaymentKeyCredential "" :| [PaymentKeyCredential "61"])))
+Binary: 0906000000000000000200000000000000000000000000000000000161
+Show: MsgScan (FindTxsFor (fromList (PaymentKeyCredential "" :| [ScriptCredential ""])))
+Binary: 09060000000000000002000000000000000000010000000000000000
+Show: MsgScan (FindTxsFor (fromList (PaymentKeyCredential "" :| [ScriptCredential "61"])))
+Binary: 0906000000000000000200000000000000000001000000000000000161
+Show: MsgScan (FindTxsFor (fromList (PaymentKeyCredential "61" :| [])))
+Binary: 0906000000000000000100000000000000000161
+Show: MsgScan (FindTxsFor (fromList (ScriptCredential "" :| [])))
+Binary: 09060000000000000001010000000000000000
+Show: MsgScan (FindTxsFor (fromList (ScriptCredential "61" :| [])))
+Binary: 0906000000000000000101000000000000000161
 Show: MsgQueryNext AdvanceToTip
 Binary: 0105
+Show: MsgScan AdvanceToTip
+Binary: 0905
 Show: MsgDone
 Binary: 02
 Show: MsgPoll
 Binary: 07
 Show: MsgCancel
 Binary: 08
+Show: MsgCollect
+Binary: 0a
+Show: MsgCancelScan
+Binary: 0b
 Show: MsgRollForward () Genesis Genesis
 Binary: 04010000
 Show: MsgRollForward () (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
@@ -60,6 +100,24 @@ Show: MsgRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, 
 Binary: 050001000000000000000100000000000000000000000000000001
 Show: MsgRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
 Binary: 05000100000000000000010000000000000001610000000000000001
+Show: MsgCollected [(Genesis())] Genesis
+Binary: 0d0100000000000000010000
+Show: MsgCollected [] Genesis
+Binary: 0d01000000000000000000
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d01000000000000000001000000000000000100000000000000000000000000000001
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d0100000000000000000100000000000000010000000000000001610000000000000001
+Show: MsgCollectRollBackward Genesis Genesis
+Binary: 0e0000
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e0100000000000000010000000000000000000000000000000100
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e010000000000000001000000000000000161000000000000000100
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e0001000000000000000100000000000000000000000000000001
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e000100000000000000010000000000000001610000000000000001
 Show: MsgRollForward () Genesis Genesis
 Binary: 04020000
 Show: MsgRollForward () (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
@@ -86,6 +144,30 @@ Show: MsgRejectQuery IntersectionNotFound (At (BlockHeader {slotNo = SlotNo {unS
 Binary: 030201000000000000000100000000000000000000000000000001
 Show: MsgRejectQuery IntersectionNotFound (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
 Binary: 03020100000000000000010000000000000001610000000000000001
+Show: MsgCollected [(Genesis())] Genesis
+Binary: 0d0200000000000000010000
+Show: MsgCollected [] Genesis
+Binary: 0d02000000000000000000
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d02000000000000000001000000000000000100000000000000000000000000000001
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d0200000000000000000100000000000000010000000000000001610000000000000001
+Show: MsgCollectRollBackward Genesis Genesis
+Binary: 0e0000
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e0100000000000000010000000000000000000000000000000100
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e010000000000000001000000000000000161000000000000000100
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e0001000000000000000100000000000000000000000000000001
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e000100000000000000010000000000000001610000000000000001
+Show: MsgCollectFailed IntersectionNotFound Genesis
+Binary: 0c0200
+Show: MsgCollectFailed IntersectionNotFound (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0c0201000000000000000100000000000000000000000000000001
+Show: MsgCollectFailed IntersectionNotFound (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0c020100000000000000010000000000000001610000000000000001
 Show: MsgRollForward (fromList []) Genesis Genesis
 Binary: 040400000000000000000000
 Show: MsgRollForward (fromList [(TxOutRef {txId = "", txIx = TxIx {unTxIx = 1}},Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList []}})]) Genesis Genesis
@@ -230,6 +312,38 @@ Show: MsgRejectQuery (fromList []) (At (BlockHeader {slotNo = SlotNo {unSlotNo =
 Binary: 0304000000000000000001000000000000000100000000000000000000000000000001
 Show: MsgRejectQuery (fromList []) (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
 Binary: 030400000000000000000100000000000000010000000000000001610000000000000001
+Show: MsgCollected [(GenesisfromList [])] Genesis
+Binary: 0d04000000000000000100000000000000000000
+Show: MsgCollected [(At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})fromList [(TxOutRef {txId = "", txIx = TxIx {unTxIx = 1}},Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList []}})]),(At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})fromList [(TxOutRef {txId = "", txIx = TxIx {unTxIx = 1}},Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList [(AssetId {policyId = "", tokenName = ""},Quantity {unQuantity = 1})]}})])] Genesis
+Binary: 0d0400000000000000020100000000000000010000000000000000000000000000000100000000000000010000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000010000000000000001610000000000000001000000000000000100000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000100
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d04000000000000000001000000000000000100000000000000000000000000000001
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d0400000000000000000100000000000000010000000000000001610000000000000001
+Show: MsgCollectRollBackward Genesis Genesis
+Binary: 0e0000
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e0100000000000000010000000000000000000000000000000100
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e010000000000000001000000000000000161000000000000000100
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e0001000000000000000100000000000000000000000000000001
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e000100000000000000010000000000000001610000000000000001
+Show: MsgCollectFailed (fromList []) Genesis
+Binary: 0c04000000000000000000
+Show: MsgCollectFailed (fromList [(TxOutRef {txId = "", txIx = TxIx {unTxIx = 1}},UTxONotFound)]) Genesis
+Binary: 0c040000000000000001000000000000000000010000
+Show: MsgCollectFailed (fromList [(TxOutRef {txId = "", txIx = TxIx {unTxIx = 1}},UTxOSpent "")]) Genesis
+Binary: 0c0400000000000000010000000000000000000101000000000000000000
+Show: MsgCollectFailed (fromList [(TxOutRef {txId = "", txIx = TxIx {unTxIx = 1}},UTxOSpent "61")]) Genesis
+Binary: 0c040000000000000001000000000000000000010100000000000000016100
+Show: MsgCollectFailed (fromList [(TxOutRef {txId = "61", txIx = TxIx {unTxIx = 1}},UTxONotFound)]) Genesis
+Binary: 0c04000000000000000100000000000000016100010000
+Show: MsgCollectFailed (fromList []) (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0c04000000000000000001000000000000000100000000000000000000000000000001
+Show: MsgCollectFailed (fromList []) (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0c0400000000000000000100000000000000010000000000000001610000000000000001
 Show: MsgRollForward (Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList []}}) Genesis Genesis
 Binary: 040300000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 Show: MsgRollForward (Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList [(AssetId {policyId = "", tokenName = ""},Quantity {unQuantity = 1})]}}) Genesis Genesis
@@ -366,6 +480,34 @@ Show: MsgRejectQuery TxNotFound (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}
 Binary: 03030001000000000000000100000000000000000000000000000001
 Show: MsgRejectQuery TxNotFound (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
 Binary: 0303000100000000000000010000000000000001610000000000000001
+Show: MsgCollected [(GenesisTransaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList []}})] Genesis
+Binary: 0d03000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+Show: MsgCollected [(At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList [(AssetId {policyId = "", tokenName = ""},Quantity {unQuantity = 1})]}}),(At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList [(AssetId {policyId = "", tokenName = "a"},Quantity {unQuantity = 1})]}})] Genesis
+Binary: 0d030000000000000002010000000000000001000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000001010000000000000001000000000000000161000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000161000000000000000100
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d03000000000000000001000000000000000100000000000000000000000000000001
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d0300000000000000000100000000000000010000000000000001610000000000000001
+Show: MsgCollectRollBackward Genesis Genesis
+Binary: 0e0000
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e0100000000000000010000000000000000000000000000000100
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e010000000000000001000000000000000161000000000000000100
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e0001000000000000000100000000000000000000000000000001
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e000100000000000000010000000000000001610000000000000001
+Show: MsgCollectFailed TxNotFound Genesis
+Binary: 0c030000
+Show: MsgCollectFailed (TxInPast (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0c030100000000000000010000000000000000000000000000000100
+Show: MsgCollectFailed (TxInPast (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0c03010000000000000001000000000000000161000000000000000100
+Show: MsgCollectFailed TxNotFound (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0c030001000000000000000100000000000000000000000000000001
+Show: MsgCollectFailed TxNotFound (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0c03000100000000000000010000000000000001610000000000000001
 Show: MsgRollForward (fromList []) Genesis Genesis
 Binary: 040600000000000000000000
 Show: MsgRollForward (fromList [Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList []}}]) Genesis Genesis
@@ -494,6 +636,24 @@ Show: MsgRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, 
 Binary: 050001000000000000000100000000000000000000000000000001
 Show: MsgRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
 Binary: 05000100000000000000010000000000000001610000000000000001
+Show: MsgCollected [(GenesisfromList [])] Genesis
+Binary: 0d06000000000000000100000000000000000000
+Show: MsgCollected [(At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})fromList [Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList []}}]),(At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})fromList [Transaction {txId = "", validityRange = Unbounded, metadata = TransactionMetadata {unTransactionMetadata = fromList []}, inputs = fromList [], outputs = [], mintedTokens = Tokens {unTokens = fromList [(AssetId {policyId = "", tokenName = ""},Quantity {unQuantity = 1})]}}])] Genesis
+Binary: 0d060000000000000002010000000000000001000000000000000000000000000000010000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000100000000000000016100000000000000010000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000100
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d06000000000000000001000000000000000100000000000000000000000000000001
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d0600000000000000000100000000000000010000000000000001610000000000000001
+Show: MsgCollectRollBackward Genesis Genesis
+Binary: 0e0000
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e0100000000000000010000000000000000000000000000000100
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e010000000000000001000000000000000161000000000000000100
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e0001000000000000000100000000000000000000000000000001
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e000100000000000000010000000000000001610000000000000001
 Show: MsgRollForward () Genesis Genesis
 Binary: 04050000
 Show: MsgRollForward () (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
@@ -514,3 +674,21 @@ Show: MsgRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, 
 Binary: 050001000000000000000100000000000000000000000000000001
 Show: MsgRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
 Binary: 05000100000000000000010000000000000001610000000000000001
+Show: MsgCollected [(Genesis())] Genesis
+Binary: 0d0500000000000000010000
+Show: MsgCollected [] Genesis
+Binary: 0d05000000000000000000
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d05000000000000000001000000000000000100000000000000000000000000000001
+Show: MsgCollected [] (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0d0500000000000000000100000000000000010000000000000001610000000000000001
+Show: MsgCollectRollBackward Genesis Genesis
+Binary: 0e0000
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e0100000000000000010000000000000000000000000000000100
+Show: MsgCollectRollBackward (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}})) Genesis
+Binary: 0e010000000000000001000000000000000161000000000000000100
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e0001000000000000000100000000000000000000000000000001
+Show: MsgCollectRollBackward Genesis (At (BlockHeader {slotNo = SlotNo {unSlotNo = 1}, headerHash = "61", blockNo = BlockNo {unBlockNo = 1}}))
+Binary: 0e000100000000000000010000000000000001610000000000000001

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync.hs
@@ -32,6 +32,7 @@ import Language.Marlowe.Runtime.ChainSync.Server (ChainSyncServerDependencies (.
 import Network.Protocol.Connection (ServerSource (..))
 import Network.Protocol.Job.Server (JobServer)
 import Network.Protocol.Query.Server (QueryServer)
+import Numeric.Natural (Natural)
 import Observe.Event.Render.OpenTelemetry (OTelRendered (..), RenderSelectorOTel)
 import OpenTelemetry.Trace.Core (SpanKind (..), toAttribute)
 import Ouroboros.Network.Protocol.LocalStateQuery.Client (Some (..))
@@ -51,6 +52,7 @@ data ChainSyncDependencies m = ChainSyncDependencies
       -> Tx era
       -> m (SubmitResult (TxValidationErrorInMode CardanoMode))
   , nodeTip :: STM ChainPoint
+  , scanBatchSize :: Natural
   }
 
 data ChainSync m = ChainSync

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/Database.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/Database.hs
@@ -3,7 +3,9 @@
 
 module Language.Marlowe.Runtime.ChainSync.Database where
 
+import Data.List.NonEmpty (NonEmpty)
 import Language.Marlowe.Runtime.ChainSync.Api (BlockHeader, ChainPoint, GetUTxOsQuery, Move, UTxOs)
+import Numeric.Natural (Natural)
 
 -- Queries
 
@@ -22,6 +24,18 @@ data MoveResult err result
 newtype MoveClient m = MoveClient
   {runMoveClient :: forall err result. ChainPoint -> Move err result -> m (MoveResult err result)}
 
+newtype Scan m = Scan
+  {runScan :: forall err result. ChainPoint -> Move err result -> m (Collect err result m)}
+
+data CollectResult err result m
+  = NextBlocks (NonEmpty (BlockHeader, result)) ChainPoint (Collect err result m)
+  | CollectRollBack ChainPoint ChainPoint
+  | CollectReject err ChainPoint
+  | CollectWait ChainPoint
+
+newtype Collect err result m = Collect
+  {runCollect :: Natural -> m (CollectResult err result m)}
+
 hoistGetUTxOs :: (forall a. m a -> n a) -> GetUTxOs m -> GetUTxOs n
 hoistGetUTxOs transformation = GetUTxOs . fmap transformation . runGetUTxOs
 
@@ -32,18 +46,35 @@ hoistMoveClient :: (forall a. m a -> n a) -> MoveClient m -> MoveClient n
 hoistMoveClient transformation (MoveClient runMoveClient) =
   MoveClient $ fmap transformation . runMoveClient
 
+hoistScan :: (Functor m) => (forall a. m a -> n a) -> Scan m -> Scan n
+hoistScan transformation (Scan runScan) =
+  Scan $ fmap (transformation . fmap (hoistCollect transformation)) . runScan
+
+hoistCollect :: (Functor m) => (forall a. m a -> n a) -> Collect err result m -> Collect err result n
+hoistCollect transformation (Collect runCollect) =
+  Collect $ transformation . fmap (hoistCollectResult transformation) . runCollect
+
+hoistCollectResult :: (Functor m) => (forall a. m a -> n a) -> CollectResult err result m -> CollectResult err result n
+hoistCollectResult transformation = \case
+  NextBlocks results tip collect -> NextBlocks results tip $ hoistCollect transformation collect
+  CollectRollBack point tip -> CollectRollBack point tip
+  CollectReject err tip -> CollectReject err tip
+  CollectWait tip -> CollectWait tip
+
 -- Bundles
 
 data DatabaseQueries m = DatabaseQueries
   { getUTxOs :: GetUTxOs m
   , getTip :: GetTip m
   , moveClient :: MoveClient m
+  , scan :: Scan m
   }
 
-hoistDatabaseQueries :: (forall a. m a -> n a) -> DatabaseQueries m -> DatabaseQueries n
+hoistDatabaseQueries :: (Functor m) => (forall a. m a -> n a) -> DatabaseQueries m -> DatabaseQueries n
 hoistDatabaseQueries transformation DatabaseQueries{..} =
   DatabaseQueries
     { getUTxOs = hoistGetUTxOs transformation getUTxOs
     , getTip = hoistGetTip transformation getTip
     , moveClient = hoistMoveClient transformation moveClient
+    , scan = hoistScan transformation scan
     }

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL.hs
@@ -777,7 +777,6 @@ queryTxInsBulk txInIds =
           , txIn.redeemerDatumBytes :: bytea?
         FROM chain.txIn  as txIn
         JOIN chain.txOut as txOut ON txOut.txId = txIn.txOutId AND txOut.txIx = txIn.txOutIx
-        JOIN ids USING (txInId)
       WHERE txIn.txInId = ANY($1 :: bytea[])
   |]
       foldTxIns

--- a/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL.hs
+++ b/marlowe-chain-sync/libchainsync/Language/Marlowe/Runtime/ChainSync/Database/PostgreSQL.hs
@@ -45,12 +45,10 @@ import Control.Monad.Trans.Maybe (MaybeT (..))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Foldable (fold)
-import Data.Function (on)
 import Data.Functor ((<&>))
 import Data.Int (Int16, Int64)
 import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
-import Data.List (groupBy, sortOn)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
@@ -201,44 +199,46 @@ collectTxsFor networkId batchSize credentials fromPoint =
   where
     loadTxIds :: HT.Transaction (Map BlockHeader (Set TxId))
     loadTxIds =
-      Map.fromDistinctAscList
-        . fmap ((fst . head) &&& foldMap snd)
-        . groupBy (on (==) fst)
-        . fmap mapRow
-        . sortOn (\(slot, _, _, _) -> slot)
-        . V.toList
+      Map.fromDistinctAscList . fmap mapRow . V.toList
         <$> HT.statement
           params
           [vectorStatement|
             WITH credentials (addressHeader,  addressPaymentCredential) as
               ( SELECT * FROM UNNEST ($1 :: bytea[], $2 :: bytea[])
               )
+            , blocks (slotNo, blockId, blockNo, txId) as
+              ( SELECT
+                  block.slotNo,
+                  block.id,
+                  block.blockNo,
+                  tx.id
+                FROM chain.block
+                JOIN chain.tx                          ON block.id = tx.blockId AND  block.slotNo = tx.slotNo
+                JOIN chain.txOut                       ON tx.id = txOut.txId AND tx.slotNo = txOut.slotNo
+                JOIN credentials USING (addressHeader, addressPaymentCredential)
+                WHERE block.rollbackToSlot IS NULL
+                  AND block.slotNo > $3 :: bigint
+                UNION
+                SELECT
+                  block.slotNo,
+                  block.id,
+                  block.blockNo,
+                  tx.id
+                FROM chain.block
+                JOIN chain.tx                          ON block.id = tx.blockId AND  block.slotNo = tx.slotNo
+                JOIN chain.txIn                        ON tx.id = txIn.txInId AND tx.slotNo = txIn.slotNo
+                JOIN chain.txOut                       ON txIn.txOutId = txOut.txId AND txIn.txOutIx = txOut.txIx
+                JOIN credentials USING (addressHeader, addressPaymentCredential)
+                WHERE block.rollbackToSlot IS NULL
+                  AND block.slotNo > $3 :: bigint
+              )
             SELECT
-              block.slotNo :: bigint,
-              (ARRAY_AGG(block.id))[1] :: bytea,
-              (ARRAY_AGG(block.blockNo))[1] :: bigint,
-              ARRAY_AGG(tx.id) :: bytea[]
-            FROM chain.block
-            JOIN chain.tx                          ON block.id = tx.blockId AND  block.slotNo = tx.slotNo
-            JOIN chain.txOut                       ON tx.id = txOut.txId AND tx.slotNo = txOut.slotNo
-            JOIN credentials USING (addressHeader, addressPaymentCredential)
-            WHERE block.rollbackToSlot IS NULL
-              AND block.slotNo > $3 :: bigint
-            GROUP BY block.slotNo
-            UNION
-            SELECT
-              block.slotNo :: bigint,
-              (ARRAY_AGG(block.id))[1] :: bytea,
-              (ARRAY_AGG(block.blockNo))[1] :: bigint,
-              ARRAY_AGG(tx.id) :: bytea[]
-            FROM chain.block
-            JOIN chain.tx                          ON block.id = tx.blockId AND  block.slotNo = tx.slotNo
-            JOIN chain.txIn                        ON tx.id = txIn.txInId AND tx.slotNo = txIn.slotNo
-            JOIN chain.txOut                       ON txIn.txOutId = txOut.txId AND txIn.txOutIx = txOut.txIx
-            JOIN credentials USING (addressHeader, addressPaymentCredential)
-            WHERE block.rollbackToSlot IS NULL
-              AND block.slotNo > $3 :: bigint
-            GROUP BY block.slotNo
+              slotNo :: bigint,
+              (ARRAY_AGG(blockId))[1] :: bytea,
+              (ARRAY_AGG(blockNo))[1] :: bigint,
+              ARRAY_AGG(txId) :: bytea[]
+            FROM blocks
+            GROUP BY slotNo
             ORDER BY slotNo
             LIMIT $4 :: int
       |]

--- a/marlowe-chain-sync/marlowe-chain-sync/Main.hs
+++ b/marlowe-chain-sync/marlowe-chain-sync/Main.hs
@@ -91,7 +91,7 @@ run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseU
                   AlonzoEra -> AlonzoEraInCardanoMode
                   BabbageEra -> BabbageEraInCardanoMode
               , nodeTip
-              , scanBatchSize = 512 -- TODO make this a command line option
+              , scanBatchSize = 8192 -- TODO make this a command line option
               }
 
       tcpServerTraced "chain-seek" $ injectSelector ChainSeekServer

--- a/marlowe-chain-sync/marlowe-chain-sync/Main.hs
+++ b/marlowe-chain-sync/marlowe-chain-sync/Main.hs
@@ -91,6 +91,7 @@ run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseU
                   AlonzoEra -> AlonzoEraInCardanoMode
                   BabbageEra -> BabbageEraInCardanoMode
               , nodeTip
+              , scanBatchSize = 512 -- TODO make this a command line option
               }
 
       tcpServerTraced "chain-seek" $ injectSelector ChainSeekServer

--- a/marlowe-protocols/src/Network/Protocol/ChainSeek/Types.hs
+++ b/marlowe-protocols/src/Network/Protocol/ChainSeek/Types.hs
@@ -11,10 +11,10 @@
 -- | The type of the chain sync protocol.
 module Network.Protocol.ChainSeek.Types where
 
-import Control.Monad (join)
+import Control.Monad (join, replicateM)
 import Data.Binary (Binary (..), Get, Put, getWord8, putWord8)
 import Data.Data (type (:~:) (Refl))
-import Data.Foldable (fold)
+import Data.Foldable (fold, for_)
 import Data.Functor ((<&>))
 import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty ((:|)))
@@ -22,7 +22,7 @@ import Data.Maybe (catMaybes)
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import qualified Data.Text as T
-import GHC.Show (showSpace)
+import GHC.Show (showList__, showSpace)
 import Network.Protocol.Codec (BinaryMessage (..))
 import Network.Protocol.Codec.Spec (
   ArbitraryMessage (..),
@@ -62,10 +62,15 @@ data ChainSeek (query :: Type -> Type -> Type) point tip where
   -- a response, and the server is preparing to send a response. The server can
   -- respond immediately or it can send a 'Wait' message followed by a response
   -- at some point in the future.
-  StNext :: err -> result -> ChainSeek query point tip
+  StNext :: Type -> Type -> ChainSeek query point tip
+  -- | The client has initiated a scan, which is equivalent to fixing the query and repeatedly collecting the next block
+  -- that satisfies it.
+  StScan :: Type -> Type -> ChainSeek query point tip
+  -- | The client has requested a batch of blocks from the server from a scan.
+  StCollect :: Type -> Type -> ChainSeek query point tip
   -- | The server has sent a ping to the client to determine if it is still
   -- connected and is waiting for a pong.
-  StPoll :: err -> result -> ChainSeek query point tip
+  StPoll :: Type -> Type -> ChainSeek query point tip
   -- | The terminal state of the protocol.
   StDone :: ChainSeek query point tip
 
@@ -146,19 +151,65 @@ instance Protocol (ChainSeek query point tip) where
           (ChainSeek query point tip)
           ('StPoll err result)
           'StIdle
+    MsgScan
+      :: query err result
+      -> Message
+          (ChainSeek query point tip)
+          'StIdle
+          ('StScan err result)
+    MsgCollect
+      :: Message
+          (ChainSeek query point tip)
+          ('StScan err result)
+          ('StCollect err result)
+    MsgCancelScan
+      :: Message
+          (ChainSeek query point tip)
+          ('StScan err result)
+          'StIdle
+    MsgCollected
+      :: [(point, result)]
+      -> tip
+      -> Message
+          (ChainSeek query point tip)
+          ('StCollect err result)
+          ('StScan err result)
+    MsgCollectFailed
+      :: err
+      -> tip
+      -> Message
+          (ChainSeek query point tip)
+          ('StCollect err result)
+          'StIdle
+    MsgCollectRollBackward
+      :: point
+      -> tip
+      -> Message
+          (ChainSeek query point tip)
+          ('StCollect err result)
+          'StIdle
+    MsgCollectWait
+      :: tip
+      -> Message
+          (ChainSeek query point tip)
+          ('StCollect err result)
+          ('StPoll err result)
 
   data ClientHasAgency st where
     TokIdle :: ClientHasAgency 'StIdle
     TokPoll :: ClientHasAgency ('StPoll err result)
+    TokScan :: ClientHasAgency ('StScan err result)
 
   data ServerHasAgency st where
     TokNext :: Tag query err result -> ServerHasAgency ('StNext err result :: ChainSeek query point tip)
+    TokCollect :: Tag query err result -> ServerHasAgency ('StCollect err result :: ChainSeek query point tip)
 
   data NobodyHasAgency st where
     TokDone :: NobodyHasAgency 'StDone
 
   exclusionLemma_ClientAndServerHaveAgency TokIdle = \case {}
   exclusionLemma_ClientAndServerHaveAgency TokPoll = \case {}
+  exclusionLemma_ClientAndServerHaveAgency TokScan = \case {}
 
   exclusionLemma_NobodyAndClientHaveAgency TokDone = \case {}
 
@@ -178,6 +229,11 @@ instance
       putTag tag
       putQuery query
     MsgDone -> putWord8 0x02
+    MsgScan query -> do
+      putWord8 0x09
+      let tag = tagFromQuery query
+      putTag tag
+      putQuery query
   putMessage (ServerAgency (TokNext tag)) (MsgRejectQuery err tip) = do
     putWord8 0x03
     putTag tag
@@ -196,6 +252,29 @@ instance
   putMessage (ServerAgency TokNext{}) MsgWait = putWord8 0x06
   putMessage (ClientAgency TokPoll) MsgPoll = putWord8 0x07
   putMessage (ClientAgency TokPoll) MsgCancel = putWord8 0x08
+  putMessage (ClientAgency TokScan) msg = case msg of
+    MsgCollect -> putWord8 0x0a
+    MsgCancelScan -> putWord8 0x0b
+  putMessage (ServerAgency (TokCollect tag)) (MsgCollectFailed err tip) = do
+    putWord8 0x0c
+    putTag tag
+    putErr tag err
+    put tip
+  putMessage (ServerAgency (TokCollect tag)) (MsgCollected results tip) = do
+    putWord8 0x0d
+    putTag tag
+    put $ length results
+    for_ results \(point, result) -> do
+      put point
+      putResult tag result
+    put tip
+  putMessage (ServerAgency TokCollect{}) (MsgCollectRollBackward pos tip) = do
+    putWord8 0x0e
+    put pos
+    put tip
+  putMessage (ServerAgency TokCollect{}) (MsgCollectWait tip) = do
+    putWord8 0x0f
+    put tip
 
   getMessage tok = do
     tag <- getWord8
@@ -228,6 +307,35 @@ instance
       (0x06, ServerAgency (TokNext _)) -> pure $ SomeMessage MsgWait
       (0x07, ClientAgency TokPoll) -> pure $ SomeMessage MsgPoll
       (0x08, ClientAgency TokPoll) -> pure $ SomeMessage MsgCancel
+      (0x09, ClientAgency TokIdle) -> do
+        SomeTag qtag <- getTag
+        SomeMessage . MsgScan <$> getQuery qtag
+      (0x0a, ClientAgency TokScan) -> pure $ SomeMessage MsgCollect
+      (0x0b, ClientAgency TokScan) -> pure $ SomeMessage MsgCancelScan
+      (0x0c, ServerAgency (TokCollect qtag)) -> do
+        SomeTag qtag' :: SomeTag query <- getTag
+        case tagEq qtag qtag' of
+          Nothing -> fail "decoded query tag does not match expected query tag"
+          Just (Refl, Refl) -> do
+            err <- getErr qtag'
+            tip <- get
+            pure $ SomeMessage $ MsgCollectFailed err tip
+      (0x0d, ServerAgency (TokCollect qtag)) -> do
+        SomeTag qtag' :: SomeTag query <- getTag
+        case tagEq qtag qtag' of
+          Nothing -> fail "decoded query tag does not match expected query tag"
+          Just (Refl, Refl) -> do
+            len <- get
+            results <- replicateM len $ (,) <$> get <*> getResult qtag'
+            tip <- get
+            pure $ SomeMessage $ MsgCollected results tip
+      (0x0e, ServerAgency (TokCollect _)) -> do
+        point <- get
+        tip <- get
+        pure $ SomeMessage $ MsgCollectRollBackward point tip
+      (0x0f, ServerAgency (TokCollect _)) -> do
+        tip <- get
+        pure $ SomeMessage $ MsgCollectWait tip
       _ -> fail $ "Unexpected tag " <> show tag
 
 class (ShowQuery query) => OTelQuery query where
@@ -246,6 +354,11 @@ instance
     (_, MsgQueryNext query) ->
       MessageAttributes
         { messageType = "query/" <> queryName (tagFromQuery query)
+        , messageParameters = [toPrimitiveAttribute $ T.pack $ showsPrecQuery 0 query ""]
+        }
+    (_, MsgScan query) ->
+      MessageAttributes
+        { messageType = "scan/" <> queryName (tagFromQuery query)
         , messageParameters = [toPrimitiveAttribute $ T.pack $ showsPrecQuery 0 query ""]
         }
     (ServerAgency (TokNext tag), MsgRejectQuery err tip) ->
@@ -268,6 +381,26 @@ instance
         { messageType = "query/" <> queryName tag <> "/wait"
         , messageParameters = []
         }
+    (ServerAgency (TokCollect tag), MsgCollectFailed err tip) ->
+      MessageAttributes
+        { messageType = "scan/" <> queryName tag <> "/failed"
+        , messageParameters = toPrimitiveAttribute . T.pack <$> [showsPrecErr 0 tag err "", show tip]
+        }
+    (ServerAgency (TokCollect tag), MsgCollected _ _) ->
+      MessageAttributes
+        { messageType = "scan/" <> queryName tag <> "/collected"
+        , messageParameters = []
+        }
+    (ServerAgency (TokCollect tag), MsgCollectRollBackward point tip) ->
+      MessageAttributes
+        { messageType = "scan/" <> queryName tag <> "/roll_backward"
+        , messageParameters = toPrimitiveAttribute . T.pack <$> [show point, show tip]
+        }
+    (ServerAgency (TokCollect tag), MsgCollectWait _) ->
+      MessageAttributes
+        { messageType = "scan/" <> queryName tag <> "/wait"
+        , messageParameters = []
+        }
     (_, MsgDone) ->
       MessageAttributes
         { messageType = "done"
@@ -281,6 +414,16 @@ instance
     (_, MsgCancel) ->
       MessageAttributes
         { messageType = "cancel"
+        , messageParameters = []
+        }
+    (_, MsgCollect) ->
+      MessageAttributes
+        { messageType = "collect"
+        , messageParameters = []
+        }
+    (_, MsgCancelScan) ->
+      MessageAttributes
+        { messageType = "collect_Cancel"
         , messageParameters = []
         }
 
@@ -361,19 +504,26 @@ instance
     join
       [ pure $ SomePeerHasAgency $ ClientAgency TokIdle
       , pure $ SomePeerHasAgency $ ClientAgency TokPoll
+      , pure $ SomePeerHasAgency $ ClientAgency TokScan
       , do
           SomeTag tag <- tags
-          pure $ SomePeerHasAgency $ ServerAgency $ TokNext tag
+          [ SomePeerHasAgency $ ServerAgency $ TokNext tag
+            , SomePeerHasAgency $ ServerAgency $ TokCollect tag
+            ]
       ]
   messageVariations = \case
     ClientAgency TokIdle ->
       join
         [ do
             SomeTag tag <- tags
-            SomeMessage . MsgQueryNext <$> queryVariations tag
+            join
+              [ SomeMessage . MsgQueryNext <$> queryVariations tag
+              , SomeMessage . MsgScan <$> queryVariations tag
+              ]
         , pure $ SomeMessage MsgDone
         ]
     ClientAgency TokPoll -> [SomeMessage MsgPoll, SomeMessage MsgCancel]
+    ClientAgency TokScan -> [SomeMessage MsgCollect, SomeMessage MsgCancelScan]
     ServerAgency (TokNext tag) -> do
       let point :| points = variations
           tip :| tips = variations
@@ -416,6 +566,46 @@ instance
                   , MsgRejectQuery err <$> tips
                   ]
           ]
+    ServerAgency (TokCollect tag) -> do
+      let point :| points = variations
+          tip :| tips = variations
+          result :| results = resultVariations tag
+          errs = errVariations tag
+      join case errs of
+        [] ->
+          [ SomeMessage
+              <$> MsgCollected [(point, result)] tip
+                :| fold @[]
+                  [ pure $ MsgCollected (zip points results) tip
+                  , MsgCollected [] <$> tips
+                  ]
+          , SomeMessage
+              <$> MsgCollectRollBackward point tip
+                :| fold @[]
+                  [ MsgCollectRollBackward <$> points <*> pure tip
+                  , MsgCollectRollBackward point <$> tips
+                  ]
+          ]
+        err : errs' ->
+          [ SomeMessage
+              <$> MsgCollected [(point, result)] tip
+                :| fold @[]
+                  [ pure $ MsgCollected (zip points results) tip
+                  , MsgCollected [] <$> tips
+                  ]
+          , SomeMessage
+              <$> MsgCollectRollBackward point tip
+                :| fold @[]
+                  [ MsgCollectRollBackward <$> points <*> pure tip
+                  , MsgCollectRollBackward point <$> tips
+                  ]
+          , SomeMessage
+              <$> MsgCollectFailed err tip
+                :| fold @[]
+                  [ MsgCollectFailed <$> errs' <*> pure tip
+                  , MsgCollectFailed err <$> tips
+                  ]
+          ]
 
 class (Query query) => QueryEq query where
   queryEq :: query err result -> query err result -> Bool
@@ -432,6 +622,12 @@ instance
   messageEq (AnyMessageAndAgency agency msg) = case (agency, msg) of
     (_, MsgQueryNext query) -> \case
       AnyMessageAndAgency _ (MsgQueryNext query') ->
+        case tagEq (tagFromQuery query) (tagFromQuery query') of
+          Just (Refl, Refl) -> queryEq query query'
+          Nothing -> False
+      _ -> False
+    (_, MsgScan query) -> \case
+      AnyMessageAndAgency _ (MsgScan query') ->
         case tagEq (tagFromQuery query) (tagFromQuery query') of
           Just (Refl, Refl) -> queryEq query query'
           Nothing -> False
@@ -455,6 +651,25 @@ instance
     (_, MsgWait) -> \case
       AnyMessageAndAgency _ MsgWait -> True
       _ -> False
+    (ServerAgency (TokCollect tag), MsgCollectFailed err tip) -> \case
+      AnyMessageAndAgency (ServerAgency (TokCollect tag')) (MsgCollectFailed err' tip') ->
+        tip == tip' && case tagEq tag tag' of
+          Just (Refl, Refl) -> errEq tag err err'
+          Nothing -> False
+      _ -> False
+    (ServerAgency (TokCollect tag), MsgCollected results tip) -> \case
+      AnyMessageAndAgency (ServerAgency (TokCollect tag')) (MsgCollected results' tip') ->
+        tip == tip' && case tagEq tag tag' of
+          Just (Refl, Refl) -> all (\((point, result), (point', result')) -> point == point' && resultEq tag result result') $ zip results results'
+          Nothing -> False
+      _ -> False
+    (_, MsgCollectRollBackward point tip) -> \case
+      AnyMessageAndAgency _ (MsgCollectRollBackward point' tip') ->
+        point == point' && tip == tip'
+      _ -> False
+    (_, MsgCollectWait tip) -> \case
+      AnyMessageAndAgency _ (MsgCollectWait tip') -> tip == tip'
+      _ -> False
     (_, MsgDone) -> \case
       AnyMessageAndAgency _ MsgDone -> True
       _ -> False
@@ -463,6 +678,12 @@ instance
       _ -> False
     (_, MsgCancel) -> \case
       AnyMessageAndAgency _ MsgCancel -> True
+      _ -> False
+    (_, MsgCollect) -> \case
+      AnyMessageAndAgency _ MsgCollect -> True
+      _ -> False
+    (_, MsgCancelScan) -> \case
+      AnyMessageAndAgency _ MsgCancelScan -> True
       _ -> False
 
 class (Query query) => ShowQuery query where
@@ -483,6 +704,13 @@ instance
       showParen
         (p >= 11)
         ( showString "MsgQueryNext"
+            . showSpace
+            . showsPrecQuery 11 query
+        )
+    MsgScan query ->
+      showParen
+        (p >= 11)
+        ( showString "MsgScan"
             . showSpace
             . showsPrecQuery 11 query
         )
@@ -516,9 +744,49 @@ instance
             . showsPrec 11 tip
         )
     MsgWait -> showString "MsgWait"
+    MsgCollectFailed err tip ->
+      showParen
+        (p >= 11)
+        ( showString "MsgCollectFailed"
+            . showSpace
+            . case agency of ServerAgency (TokCollect tag) -> showsPrecErr 11 tag err
+            . showSpace
+            . showsPrec 11 tip
+        )
+    MsgCollected results tip ->
+      showParen
+        (p >= 11)
+        ( showString "MsgCollected"
+            . showSpace
+            . case agency of
+              ServerAgency (TokCollect tag) ->
+                showList__
+                  (\(point, result) -> showParen True $ shows point . showsPrecResult 0 tag result)
+                  results
+            . showSpace
+            . showsPrec 11 tip
+        )
+    MsgCollectRollBackward point tip ->
+      showParen
+        (p >= 11)
+        ( showString "MsgCollectRollBackward"
+            . showSpace
+            . showsPrec 11 point
+            . showSpace
+            . showsPrec 11 tip
+        )
+    MsgCollectWait tip ->
+      showParen
+        (p >= 11)
+        ( showString "MsgCollectWait"
+            . showSpace
+            . showsPrec 11 tip
+        )
     MsgDone -> showString "MsgDone"
     MsgPoll -> showString "MsgPoll"
     MsgCancel -> showString "MsgCancel"
+    MsgCollect -> showString "MsgCollect"
+    MsgCancelScan -> showString "MsgCancelScan"
 
   showsPrecServerHasAgency p = \case
     TokNext tag ->
@@ -528,8 +796,16 @@ instance
             . showSpace
             . showsPrecTag p tag
         )
+    TokCollect tag ->
+      showParen
+        (p >= 11)
+        ( showString "TokCollect"
+            . showSpace
+            . showsPrecTag p tag
+        )
 
   showsPrecClientHasAgency _ =
     showString . \case
       TokIdle -> "TokIdle"
       TokPoll -> "TokPoll"
+      TokScan -> "TokScan"

--- a/marlowe-runtime/changelog.d/20230725_142448_jhbertra_plt_6838_optimise_chainseek.md
+++ b/marlowe-runtime/changelog.d/20230725_142448_jhbertra_plt_6838_optimise_chainseek.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Sync performance of `marlowe-indexer` improved via bulk queries.

--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/ChainSeekClient.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/ChainSeekClient.hs
@@ -11,7 +11,10 @@ import Colog (Message, WithLog)
 import Control.Concurrent.Component
 import Control.Concurrent.STM (STM, TVar, newTQueue, newTVar, readTQueue, readTVar, writeTQueue, writeTVar)
 import Control.Monad.Event.Class (MonadInjectEvent, withEvent)
+import Control.Monad.State (execStateT, get, put)
 import Control.Monad.Trans (lift)
+import Data.Foldable (for_)
+import Data.Functor ((<&>))
 import Data.Set (Set)
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NESet
@@ -104,7 +107,6 @@ chainSeekClient = component "indexer-chain-seek-client" \ChainSeekClientDependen
       ChainSeekClient $ runConnector chainSyncQueryConnector do
         atomically $ writeTVar connectedVar True
         systemStart <- request GetSystemStart
-        securityParameter <- request GetSecurityParameter
         -- Get the intersection points - the most recent block headers stored locally.
         intersectionPoints <- lift getIntersectionPoints
         let -- A client state for handling the intersect response.
@@ -117,7 +119,7 @@ chainSeekClient = component "indexer-chain-seek-client" \ChainSeekClientDependen
                     emit $ RollBackward Genesis tip
 
                     -- Start the main synchronization loop
-                    pure $ clientIdle securityParameter systemStart $ MarloweUTxO mempty mempty
+                    pure $ clientIdle systemStart $ MarloweUTxO mempty mempty
                 , -- An intersection point was found, resume synchronization from
                   -- that point.
                   recvMsgRollForward = \_ point tip -> do
@@ -135,7 +137,7 @@ chainSeekClient = component "indexer-chain-seek-client" \ChainSeekClientDependen
                         pure utxo
 
                     -- Start the main synchronization loop.
-                    pure $ clientIdle securityParameter systemStart utxo
+                    pure $ clientIdle systemStart utxo
                 , -- Since the client is at Genesis at the start of this request,
                   -- it will never be rolled back. Handle the perfunctory case by
                   -- looping.
@@ -149,7 +151,7 @@ chainSeekClient = component "indexer-chain-seek-client" \ChainSeekClientDependen
 
         pure case intersectionPoints of
           -- Just start the loop right away with an empty UTxO.
-          [] -> clientIdle securityParameter systemStart $ MarloweUTxO mempty mempty
+          [] -> clientIdle systemStart $ MarloweUTxO mempty mempty
           -- Request an intersection
           _ -> clientIdleIntersect
       where
@@ -168,60 +170,82 @@ chainSeekClient = component "indexer-chain-seek-client" \ChainSeekClientDependen
           pure $ SendMsgPoll next
 
         -- The client's idle state handler for the main synchronization loop.
-        -- Sends the next query to the chain sync server and handles the
-        -- response.
+        -- Scans the chain for marlowe transactions.
         clientIdle
-          :: Int
-          -> SystemStart
+          :: SystemStart
           -> MarloweUTxO
           -> ClientStIdle Move ChainPoint (WithGenesis BlockHeader) m a
-        clientIdle securityParameter systemStart = SendMsgQueryNext (FindTxsFor allScriptCredentials) . clientNext securityParameter systemStart
+        clientIdle systemStart = let move = FindTxsFor allScriptCredentials in SendMsgScan move . clientScan move systemStart
 
-        -- Handles responses from the main synchronization loop query.
-        clientNext
-          :: Int
+        -- The client's scan loop.
+        clientScan
+          :: Move Void (Set Transaction)
           -> SystemStart
           -> MarloweUTxO
-          -> ClientStNext Move Void (Set Transaction) ChainPoint (WithGenesis BlockHeader) m a
-        clientNext securityParameter systemStart utxo =
-          ClientStNext
+          -> ClientStScan Move Void (Set Transaction) ChainPoint (WithGenesis BlockHeader) m a
+        clientScan move systemStart = SendMsgCollect . clientCollect move systemStart
+
+        -- Handles responses from the main synchronization loop query.
+        clientCollect
+          :: Move Void (Set Transaction)
+          -> SystemStart
+          -> MarloweUTxO
+          -> ClientStCollect Move Void (Set Transaction) ChainPoint (WithGenesis BlockHeader) m a
+        clientCollect move systemStart utxo =
+          ClientStCollect
             { -- Fail with an error if marlowe-chain-sync rejects the query. This is safe
               -- from bad user input, because our queries are derived from the ledger
               -- state, and so will only be rejected if the query derivation is
               -- incorrect, or marlowe-chain-sync is corrupt. Because both are unexpected
               -- errors, it is a non-recoverable error state.
-              recvMsgQueryRejected = absurd
+              recvMsgCollectFailed = absurd
             , -- Handle the next block by extracting Marlowe transactions into a
               -- MarloweBlock and updating the MarloweUTxO.
-              recvMsgRollForward = \txs point tip -> do
-                -- Get the current block (not expected ever to be Genesis).
-                block <- case point of
-                  Genesis -> fail "Rolled forward to Genesis"
-                  At block -> pure block
-
+              recvMsgCollected = \blocks tip -> do
                 -- Get the era history
                 eraHistory <- runConnector chainSyncQueryConnector $ request GetEraHistory
 
-                -- Extract the Marlowe block and compute the next MarloweUTxO.
-                nextUtxo <- case extractMarloweBlock systemStart eraHistory (NESet.toSet marloweScriptHashes) block txs utxo of
-                  -- If no MarloweBlock was extracted (not expected, but harmless), do nothing and return the current MarloweUTxO.
-                  -- This is not expected because the query would only be satisfied by a block that contains some usable Marlowe information.
-                  Nothing -> pure utxo
-                  Just (nextUtxo, marloweBlock) -> do
-                    -- Emit the marlowe block in a roll forward event to a downstream consumer.
-                    emit $ RollForward marloweBlock point tip
+                nextUtxo <- flip execStateT utxo $ for_ blocks \(point, txs) -> do
+                  -- Get the current block (not expected ever to be Genesis).
+                  block <- case point of
+                    Genesis -> fail "Rolled forward to Genesis"
+                    At block -> pure block
 
-                    -- Return the new MarloweUTxO
-                    pure nextUtxo
+                  utxo' <- get
+
+                  -- Extract the Marlowe block and compute the next MarloweUTxO.
+                  for_ (extractMarloweBlock systemStart eraHistory (NESet.toSet marloweScriptHashes) block txs utxo') \(nextUtxo, marloweBlock) -> do
+                    -- Emit the marlowe block in a roll forward event to a downstream consumer.
+                    lift $ emit $ RollForward marloweBlock point tip
+
+                    -- Update the MarloweUTxO
+                    put nextUtxo
 
                 -- Loop back into the main synchronization loop with an updated
                 -- rollback state.
-                pure $ clientIdle securityParameter systemStart nextUtxo
-            , recvMsgRollBackward = \point tip -> do
+                pure $ clientScan move systemStart nextUtxo
+            , recvMsgCollectRollBackward = \point tip -> do
                 emit $ RollBackward point tip
                 nextUtxo <- case point of
                   Genesis -> pure $ MarloweUTxO mempty mempty
                   At block -> getMarloweUTxO block
-                pure $ clientIdle securityParameter systemStart nextUtxo
-            , recvMsgWait = pollWithNext $ clientNext securityParameter systemStart utxo
+                pure $ clientIdle systemStart nextUtxo
+            , recvMsgCollectWait = \tip -> pollWithNext $ collectToNext move tip $ clientCollect move systemStart utxo
             }
+
+collectToNext
+  :: (Monad m)
+  => q err result
+  -> tip
+  -> ClientStCollect q err result point tip m a
+  -> ClientStNext q err result point tip m a
+collectToNext q tip ClientStCollect{..} =
+  ClientStNext
+    { recvMsgQueryRejected = recvMsgCollectFailed
+    , recvMsgRollBackward = recvMsgCollectRollBackward
+    , recvMsgWait = recvMsgCollectWait tip
+    , recvMsgRollForward = \result point tip' ->
+        recvMsgCollected [(point, result)] tip' <&> \case
+          SendMsgCollect collect -> SendMsgScan q $ SendMsgCollect collect
+          SendMsgCancelScan idle -> idle
+    }

--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/Database/PostgreSQL/CommitBlocks.hs
@@ -24,6 +24,7 @@ import Language.Marlowe.Core.V1.Semantics (MarloweData (..), MarloweParams (..))
 import Language.Marlowe.Runtime.ChainSync.Api
 import Language.Marlowe.Runtime.Core.Api (
   ContractId (..),
+  MarloweTransactionMetadata (..),
   MarloweVersion (..),
   TransactionScriptOutput (..),
   emptyMarloweTransactionMetadata,
@@ -303,7 +304,7 @@ createTxToTxOutRows blockHeader@BlockHeader{..} MarloweCreateTransaction{..} =
           , fromIntegral blockNo
           , if metadata == emptyMarloweTransactionMetadata
               then Nothing
-              else Just $ toStrict $ runPut $ put metadata
+              else Just $ toStrict $ runPut $ put let MarloweTransactionMetadata _ original = metadata in original
           )
         , txOutAssetRows
         , transactionMetadataToTagRows txId' txIx' metadata
@@ -365,7 +366,7 @@ applyTxToRows (MarloweApplyInputsTransaction MarloweV1 UnspentContractOutput{..}
         , utcToLocalTime utc validityUpperBound
         , if metadata == emptyMarloweTransactionMetadata
             then Nothing
-            else Just $ toStrict $ runPut $ put metadata
+            else Just $ toStrict $ runPut $ put let MarloweTransactionMetadata _ original = metadata in original
         , inputTxId'
         , inputTxIx'
         , toStrict $ runPut $ put $ toDatum inputs

--- a/marlowe-runtime/runtime/Language/Marlowe/Runtime.hs
+++ b/marlowe-runtime/runtime/Language/Marlowe/Runtime.hs
@@ -151,7 +151,7 @@ marloweRuntime = proc MarloweRuntimeDependencies{..} -> do
               MaryEra -> MaryEraInCardanoMode
               AlonzoEra -> AlonzoEraInCardanoMode
               BabbageEra -> BabbageEraInCardanoMode
-          , scanBatchSize = 512
+          , scanBatchSize = 8192
           , ..
           }
 

--- a/marlowe-runtime/runtime/Language/Marlowe/Runtime.hs
+++ b/marlowe-runtime/runtime/Language/Marlowe/Runtime.hs
@@ -151,6 +151,7 @@ marloweRuntime = proc MarloweRuntimeDependencies{..} -> do
               MaryEra -> MaryEraInCardanoMode
               AlonzoEra -> AlonzoEraInCardanoMode
               BabbageEra -> BabbageEraInCardanoMode
+          , scanBatchSize = 512
           , ..
           }
 

--- a/nix/marlowe-cardano/compose.nix
+++ b/nix/marlowe-cardano/compose.nix
@@ -277,9 +277,6 @@ let
       "--marlowe-contract-host"
       "marlowe-contract"
     ];
-    volumes = [
-      "marlowe-contract-store:/store"
-    ];
     environment = [ "OTEL_SERVICE_NAME=marlowe-proxy" ];
   };
 
@@ -308,6 +305,9 @@ let
     environment = [
       "TZ=UTC"
       "OTEL_SERVICE_NAME=marlowe-runtime"
+    ];
+    volumes = [
+      "marlowe-contract-store:/store"
     ];
   };
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -23,6 +23,8 @@ in
     pkgs.sqitchPg
     pkgs.postgresql
     pkgs.haskellPackages.hspec-golden
+    pkgs.jq
+    pkgs.docker-compose
   ];
 
 


### PR DESCRIPTION
- [x] Adds a new `Scan` mode to chain seek protocol
- [x] Implementation for `marlowe-chain-indexer` rewritten to use `Scan` for bulk querying. 
- [x] Tested on `preprod`
  - Time to sync (against fully synced chain DB) on the order of 1 minute
- [x] Tested on `preview`
  - Time to sync (against fully synced chain DB) on the order of 5 minutes
- [ ] Tested on `mainnet`
  - Time to sync (against fully synced chain DB) __

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
    - [x] Reviewer requested
