### PR TITLE
PLT-7027 Round maximum execution fee upward.

### DIFF
--- a/marlowe-runtime/changelog.d/20230803_091230_brian.bush_PLT_7027.md
+++ b/marlowe-runtime/changelog.d/20230803_091230_brian.bush_PLT_7027.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Computation of maximum possible Plutus execution costs now rounds upwards.

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Constraints.hs
@@ -425,7 +425,7 @@ maximumFee C.ProtocolParameters{..} =
           (Just C.ExecutionUnitPrices{..}, Just C.ExecutionUnits{..}) ->
             priceExecutionSteps * fromIntegral executionSteps + priceExecutionMemory * fromIntegral executionMemory
           _ -> 0
-   in txFee + round executionFee
+   in txFee + ceiling executionFee
 
 -- | Calculate the minimum UTxO requirement for a value.
 --   We must pack the address, datum and value into a dummy TxOut along with


### PR DESCRIPTION
Instead of rounding the maximum Plutus cost, use the ceiling function.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [x] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested