### PR TITLE
PLT-6849 Fixed inconsistency in system history for safety checks.

### DIFF
--- a/marlowe-runtime/changelog.d/20230808_154617_brian.bush_PLT_6849.md
+++ b/marlowe-runtime/changelog.d/20230808_154617_brian.bush_PLT_6849.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Signature of `Language.Marlowe.Runtime.Transaction.Safety.checkTransactions` change to use protocol parameters in place of constraint solver.
+
+### Fixed
+
+- Removed inconsistency in system start for safety checks (PLT-6849).

--- a/marlowe-runtime/test/Language/Marlowe/Runtime/Transaction/SafetySpec.hs
+++ b/marlowe-runtime/test/Language/Marlowe/Runtime/Transaction/SafetySpec.hs
@@ -4,18 +4,16 @@ module Language.Marlowe.Runtime.Transaction.SafetySpec where
 
 import Data.List (isInfixOf, nub)
 import Data.Maybe (fromJust)
-import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Language.Marlowe.Analysis.Safety.Types (SafetyError (..))
 import Language.Marlowe.Runtime.Core.Api (MarloweVersion (MarloweV1))
 import Language.Marlowe.Runtime.Core.ScriptRegistry (MarloweScripts (..), getCurrentScripts)
 import Language.Marlowe.Runtime.Transaction.Api (Mint (..), RoleTokensConfig (..))
 import Language.Marlowe.Runtime.Transaction.BuildConstraintsSpec ()
-import Language.Marlowe.Runtime.Transaction.Constraints (MarloweContext (..), solveConstraints)
+import Language.Marlowe.Runtime.Transaction.Constraints (MarloweContext (..))
 import Language.Marlowe.Runtime.Transaction.ConstraintsSpec (protocolTestnet)
 import Language.Marlowe.Runtime.Transaction.Safety (
   checkContract,
   checkTransactions,
-  makeSystemHistory,
   minAdaUpperBound,
   noContinuations,
  )
@@ -259,10 +257,7 @@ spec =
 
     describe "checkTransactions" do
       referenceContracts <- runIO readReferenceContracts
-      let zeroTime = posixSecondsToUTCTime 0
-          (systemStart, eraHistory) = makeSystemHistory zeroTime
-          solveConstraints' = solveConstraints systemStart eraHistory protocolTestnet
-          networkId = Cardano.Testnet $ Cardano.NetworkMagic 1
+      let networkId = Cardano.Testnet $ Cardano.NetworkMagic 1
           MarloweScripts{..} = getCurrentScripts version
           stakeReference = Shelley.NoStakeAddress
           marloweContext =
@@ -296,7 +291,7 @@ spec =
       for_ referenceContracts \(name, contract) -> it ("Passes for reference contract " <> name) do
         (policy, address) <- generate arbitrary
         let minAda = maybe 0 toInteger $ minAdaUpperBound protocolTestnet version contract continuations
-        actual <- checkTransactions solveConstraints' version marloweContext policy address minAda contract continuations
+        actual <- checkTransactions protocolTestnet version marloweContext policy address minAda contract continuations
         case actual of
           -- Overspending or warnings are not a test failures.
           Right errs
@@ -319,7 +314,7 @@ spec =
                   ]
                   1000
                   V1.Close
-          actual <- checkTransactions solveConstraints' version marloweContext policy address minAda contract continuations
+          actual <- checkTransactions protocolTestnet version marloweContext policy address minAda contract continuations
           case actual of
             Right errs
               | all overspent errs -> pure ()

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Safety.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Safety.hs
@@ -43,9 +43,9 @@ import Language.Marlowe.Runtime.Transaction.Constraints (
   MarloweContext (..),
   MarloweOutputConstraints (..),
   RoleTokenConstraints (..),
-  SolveConstraints,
   TxConstraints (..),
   WalletContext (..),
+  solveConstraints,
  )
 
 import qualified Cardano.Api as Cardano (Lovelace, NetworkId (Mainnet))
@@ -170,7 +170,7 @@ checkContract network config MarloweV1 contract continuations =
 -- | Mock-execute all possible transactions for a contract.
 checkTransactions
   :: (MonadIO m)
-  => SolveConstraints
+  => Shelley.ProtocolParameters
   -> MarloweVersion v
   -> MarloweContext v
   -> Chain.PolicyId
@@ -179,7 +179,7 @@ checkTransactions
   -> Contract v
   -> Continuations v
   -> m (Either String [SafetyError])
-checkTransactions solveConstraints version@MarloweV1 marloweContext rolesCurrency changeAddress minAda contract continuations =
+checkTransactions protocolParameters version@MarloweV1 marloweContext rolesCurrency changeAddress minAda contract continuations =
   runExceptT $
     do
       let changeAddress' = uncurry V1.Address . fromJust . V1.deserialiseAddress $ Chain.unAddress changeAddress
@@ -187,18 +187,18 @@ checkTransactions solveConstraints version@MarloweV1 marloweContext rolesCurrenc
         findTransactions False changeAddress' minAda . V1.MerkleizedContract contract $ remapContinuations continuations
       either throwE (pure . mconcat)
         . forM transactions
-        $ checkTransaction solveConstraints version marloweContext rolesCurrency changeAddress
+        $ checkTransaction protocolParameters version marloweContext rolesCurrency changeAddress
 
 -- | Check a transaction for safety issues.
 checkTransaction
-  :: SolveConstraints
+  :: Shelley.ProtocolParameters
   -> MarloweVersion v
   -> MarloweContext v
   -> Chain.PolicyId
   -> Chain.Address
   -> Transaction
   -> Either String [SafetyError]
-checkTransaction solveConstraints version@MarloweV1 marloweContext@MarloweContext{..} (Chain.PolicyId rolesCurrency) changeAddress transaction@Transaction{..} =
+checkTransaction protocolParameters version@MarloweV1 marloweContext@MarloweContext{..} (Chain.PolicyId rolesCurrency) changeAddress transaction@Transaction{..} =
   do
     let V1.TransactionInput{..} = txInput
         rolesCurrency' = V1.MarloweParams . Plutus.CurrencySymbol $ Plutus.toBuiltin rolesCurrency
@@ -229,6 +229,7 @@ checkTransaction solveConstraints version@MarloweV1 marloweContext@MarloweContex
         metadata = MarloweTransactionMetadata Nothing $ Chain.TransactionMetadata mempty
         (start, history) =
           makeSystemHistory . posixTimeToUTCTime $ Plutus.POSIXTime 0
+        solveConstraints' = solveConstraints start history protocolParameters
     tipSlot <-
       utcTimeToSlotNo start history now
     constraints <-
@@ -251,7 +252,7 @@ checkTransaction solveConstraints version@MarloweV1 marloweContext@MarloweContex
       . either
         (pure . TransactionValidationError transaction . show)
         (const $ TransactionWarning transaction <$> V1.txOutWarnings txOutput)
-      $ solveConstraints version marloweContext' walletContext constraints
+      $ solveConstraints' version marloweContext' walletContext constraints
 
 -- | Create a wallet context that will satisfy the given constraints.
 walletForConstraints

--- a/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Server.hs
+++ b/marlowe-runtime/tx/Language/Marlowe/Runtime/Transaction/Server.hs
@@ -199,6 +199,7 @@ transactionServer = component "tx-job-server" \TransactionServerDependencies{..}
                       contractQueryConnector
                       getCurrentScripts
                       solveConstraints
+                      protocolParameters
                       loadWalletContext
                       networkId
                       mStakeCredential
@@ -257,6 +258,7 @@ execCreate
   => Connector (QueryClient ContractRequest) m
   -> (MarloweVersion v -> MarloweScripts)
   -> SolveConstraints
+  -> ProtocolParameters
   -> LoadWalletContext m
   -> NetworkId
   -> Maybe Chain.StakeCredential
@@ -268,7 +270,7 @@ execCreate
   -> Either (Contract v) DatumHash
   -> NominalDiffTime
   -> m (ServerStCmd MarloweTxCommand Void (CreateError v) (ContractCreated BabbageEra v) m ())
-execCreate contractQueryConnector getCurrentScripts solveConstraints loadWalletContext networkId mStakeCredential version addresses roleTokens metadata minAda contract analysisTimeout = execExceptT do
+execCreate contractQueryConnector getCurrentScripts solveConstraints protocolParameters loadWalletContext networkId mStakeCredential version addresses roleTokens metadata minAda contract analysisTimeout = execExceptT do
   walletContext <- lift $ loadWalletContext addresses
   (contract', continuations) <- case contract of
     Right hash -> case version of
@@ -323,7 +325,7 @@ execCreate contractQueryConnector getCurrentScripts solveConstraints loadWalletC
       first CreateSafetyAnalysisError
         <$> limitAnalysisTime
           ( checkTransactions
-              solveConstraints
+              protocolParameters
               version
               marloweContext
               rolesCurrency


### PR DESCRIPTION
The safety checks were using inconsistent system history because this was obtained both locally in `checkTransaction` and separately from its `solveConstraints` argument. This is fixed by using the same system history for both building constraints and solving them.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested