### PR TITLE
PLT-7681 Applicability test for `Close` fails for Marlowe "next" semantics

### DIFF
--- a/marlowe-test/test/Spec/Marlowe/Semantics/Next.hs
+++ b/marlowe-test/test/Spec/Marlowe/Semantics/Next.hs
@@ -40,7 +40,7 @@ import Spec.Marlowe.Semantics.Next.Contract.Generator (
 import Spec.Marlowe.Semantics.Next.Contract.When.Choice (onlyIndexedChoices)
 import Spec.Marlowe.Semantics.Next.Contract.When.Deposit (evaluateDeposits, hasNoIdenticalEvaluatedDeposits)
 import Spec.Marlowe.Semantics.Next.Contract.When.Notify (firstNotifyTrueIndex)
-import Test.QuickCheck (Arbitrary (..), forAllShrink, withMaxSuccess)
+import Test.QuickCheck (Arbitrary (..), forAllShrink, withMaxSuccess, (===))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
@@ -54,12 +54,12 @@ tests =
             "Can Reduce when contract is reducible"
             $ forAllSuchThat (getAll . on (<>) (fmap All . uncurry3) hasValidEnvironment isReducible)
             $ \(environment', state, contract) ->
-              Right (coerce True) == (canReduce <$> next environment' state contract)
+              Right (coerce True) === (canReduce <$> next environment' state contract)
         , testProperty
             "Can't Reduce when the contract provided is irreducible"
             $ forAllSuchThat (getAll . on (<>) (fmap All . uncurry3) hasValidEnvironment isIrreducible)
             $ \(environment', state, contract) ->
-              Right (coerce False) == (canReduce <$> next environment' state contract)
+              Right (coerce False) === (canReduce <$> next environment' state contract)
         ]
     , testGroup
         "Applicability"
@@ -67,7 +67,7 @@ tests =
             "\"Close\" is not applicable"
             $ forAllSuchThat (getAll . on (<>) (fmap All . uncurry3) hasValidEnvironment isReducibleToClose)
             $ \(environment', state, contract) ->
-              Right emptyApplicables == (applicables <$> next environment' state contract)
+              Right emptyApplicables === (applicables <$> next environment' state contract)
         , testGroup
             "Notify"
             [ testProperty
@@ -80,7 +80,7 @@ tests =
                 $ forAllShrink anyWithAtLeastOneNotifyTrue (filter (uncurry3 atLeastOneTrueNotify) . shrink)
                 $ \(environment', state, caseContracts) -> do
                   let expectedCaseIndex = fromJust . firstNotifyTrueIndex environment' state $ caseContracts
-                  Just expectedCaseIndex == ((getCaseIndex <$>) . notifyMaybe . mkApplicablesWhen environment' state $ caseContracts)
+                  Just expectedCaseIndex === ((getCaseIndex <$>) . notifyMaybe . mkApplicablesWhen environment' state $ caseContracts)
             ]
         , testGroup
             "Deposit"
@@ -89,14 +89,14 @@ tests =
                 $ forAllSuchThat (uncurry3 hasNoIdenticalEvaluatedDeposits)
                 $ \(environment', state, caseContracts) -> do
                   let evaluatedDeposits = evaluateDeposits environment' state caseContracts
-                  evaluatedDeposits == (to . deposits . mkApplicablesWhen environment' state $ caseContracts)
+                  evaluatedDeposits === (to . deposits . mkApplicablesWhen environment' state $ caseContracts)
             , testProperty
                 "Shadowing : Following Identical Evaluated Deposits are not applicable"
                 $ forAllShrink anyCaseContractsWithIdenticalEvaluatedDeposits (filter (uncurry3 hasDuplicateDeposits) . shrink)
                 $ \(environment', state, caseContracts) -> do
                   let evaluatedDeposits = evaluateDeposits environment' state caseContracts
                       canDeposits = to . deposits . mkApplicablesWhen environment' state $ caseContracts
-                  canDeposits == nubBy sameIndexedValue evaluatedDeposits
+                  canDeposits === nubBy sameIndexedValue evaluatedDeposits
             ]
         , testGroup
             "Choice"
@@ -120,7 +120,7 @@ tests =
                     $ forAllShrink anyCaseContractsWithChoiceOnlyNotShadowed shrink
                     $ \(environment', state, caseContracts) -> do
                       let indexedChoices = onlyIndexedChoices environment' state caseContracts
-                      indexedChoices == (to . choices . mkApplicablesWhen environment' state $ caseContracts)
+                      indexedChoices === (to . choices . mkApplicablesWhen environment' state $ caseContracts)
                 , testProperty
                     "\"[Indexed CanChoose]\" and [Choice] on the same id have the same merged Bounds "
                     $ withMaxSuccess 50
@@ -128,7 +128,7 @@ tests =
                     $ \(environment', state, caseContracts) -> do
                       let indexedChoices = to . onlyIndexedChoices environment' state $ caseContracts
                           canChooseList = choices . mkApplicablesWhen environment' state $ caseContracts
-                      compactAdjoinedBounds indexedChoices == compactAdjoinedBounds canChooseList
+                      compactAdjoinedBounds indexedChoices === compactAdjoinedBounds canChooseList
                 ]
             ]
         ]

--- a/marlowe-test/test/Spec/Marlowe/Semantics/Next.hs
+++ b/marlowe-test/test/Spec/Marlowe/Semantics/Next.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -6,10 +7,13 @@ module Spec.Marlowe.Semantics.Next (
 ) where
 
 import Data.Coerce (coerce)
-import Data.List (nubBy)
-import Data.Maybe (fromJust, isNothing)
+import Data.List (group, nubBy, sort)
+import Data.Maybe (fromJust, isNothing, mapMaybe)
 import Data.Types.Isomorphic (Injective (to))
 
+import Data.Function (on)
+import Data.Semigroup (All (..))
+import Language.Marlowe (Case, evalObservation, evalValue)
 import Language.Marlowe.Core.V1.Next (Next (..), next)
 import Language.Marlowe.Core.V1.Next.Applicables (
   ApplicableInputs (choices, deposits, notifyMaybe),
@@ -19,25 +23,24 @@ import Language.Marlowe.Core.V1.Next.Applicables (
 import Language.Marlowe.Core.V1.Next.Applicables.CanChoose (compactAdjoinedBounds, overlaps)
 import Language.Marlowe.Core.V1.Next.CanReduce (CanReduce (..))
 import Language.Marlowe.Core.V1.Next.Indexed (getCaseIndex, sameIndexedValue)
+import Language.Marlowe.Core.V1.Semantics.Types (Action (..), Contract, Environment, State, Value (..), getAction)
 import Spec.Marlowe.Semantics.Arbitrary ()
 import Spec.Marlowe.Semantics.Next.Common.Isomorphism ()
-import Spec.Marlowe.Semantics.Next.Common.QuickCheck (forAll')
+import Spec.Marlowe.Semantics.Next.Common.QuickCheck (forAllSuchThat)
+import Spec.Marlowe.Semantics.Next.Common.Tuple (uncurry3)
+import Spec.Marlowe.Semantics.Next.Contract (hasValidEnvironment, isIrreducible, isReducible, isReducibleToClose)
 import Spec.Marlowe.Semantics.Next.Contract.Generator (
   anyCaseContractsWithChoiceOnTheSameChoiceIdAndNonEmptyBounds,
   anyCaseContractsWithChoiceOnlyNotShadowed,
   anyCaseContractsWithEmptyBoundsChoiceOnly,
   anyCaseContractsWithIdenticalEvaluatedDeposits,
-  anyCaseContractsWithoutIdenticalEvaluatedDeposits,
-  anyCloseOrReducedToAClose,
-  anyIrreducibleContract,
   anyOnlyFalsifiedNotifies,
-  anyReducibleContract,
   anyWithAtLeastOneNotifyTrue,
  )
 import Spec.Marlowe.Semantics.Next.Contract.When.Choice (onlyIndexedChoices)
-import Spec.Marlowe.Semantics.Next.Contract.When.Deposit (evaluateDeposits)
+import Spec.Marlowe.Semantics.Next.Contract.When.Deposit (evaluateDeposits, hasNoIdenticalEvaluatedDeposits)
 import Spec.Marlowe.Semantics.Next.Contract.When.Notify (firstNotifyTrueIndex)
-import Test.QuickCheck (withMaxSuccess)
+import Test.QuickCheck (Arbitrary (..), forAllShrink, withMaxSuccess)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
@@ -49,12 +52,12 @@ tests =
         "Reducibility"
         [ testProperty
             "Can Reduce when contract is reducible"
-            $ forAll' anyReducibleContract
+            $ forAllSuchThat (getAll . on (<>) (fmap All . uncurry3) hasValidEnvironment isReducible)
             $ \(environment', state, contract) ->
               Right (coerce True) == (canReduce <$> next environment' state contract)
         , testProperty
             "Can't Reduce when the contract provided is irreducible"
-            $ forAll' anyIrreducibleContract
+            $ forAllSuchThat (getAll . on (<>) (fmap All . uncurry3) hasValidEnvironment isIrreducible)
             $ \(environment', state, contract) ->
               Right (coerce False) == (canReduce <$> next environment' state contract)
         ]
@@ -62,19 +65,19 @@ tests =
         "Applicability"
         [ testProperty
             "\"Close\" is not applicable"
-            $ forAll' anyCloseOrReducedToAClose
+            $ forAllSuchThat (getAll . on (<>) (fmap All . uncurry3) hasValidEnvironment isReducibleToClose)
             $ \(environment', state, contract) ->
               Right emptyApplicables == (applicables <$> next environment' state contract)
         , testGroup
             "Notify"
             [ testProperty
                 "\"Notify\" is not applicable when evaluated falsified"
-                $ forAll' anyOnlyFalsifiedNotifies
+                $ forAllShrink anyOnlyFalsifiedNotifies (filter (uncurry3 onlyFalseNotifies) . shrink)
                 $ \(environment', state, caseContracts) ->
                   isNothing (notifyMaybe . mkApplicablesWhen environment' state $ caseContracts)
             , testProperty
                 "Shadowing : Following Notifies evaluated to True are not applicable"
-                $ forAll' anyWithAtLeastOneNotifyTrue
+                $ forAllShrink anyWithAtLeastOneNotifyTrue (filter (uncurry3 atLeastOneTrueNotify) . shrink)
                 $ \(environment', state, caseContracts) -> do
                   let expectedCaseIndex = fromJust . firstNotifyTrueIndex environment' state $ caseContracts
                   Just expectedCaseIndex == ((getCaseIndex <$>) . notifyMaybe . mkApplicablesWhen environment' state $ caseContracts)
@@ -83,13 +86,13 @@ tests =
             "Deposit"
             [ testProperty
                 "\"CanDeposit\" is a \"Deposit\" with its quantity evaluated and its \"Case\" index preserved (when no shadowing involved)"
-                $ forAll' anyCaseContractsWithoutIdenticalEvaluatedDeposits
+                $ forAllSuchThat (uncurry3 hasNoIdenticalEvaluatedDeposits)
                 $ \(environment', state, caseContracts) -> do
                   let evaluatedDeposits = evaluateDeposits environment' state caseContracts
                   evaluatedDeposits == (to . deposits . mkApplicablesWhen environment' state $ caseContracts)
             , testProperty
                 "Shadowing : Following Identical Evaluated Deposits are not applicable"
-                $ forAll' anyCaseContractsWithIdenticalEvaluatedDeposits
+                $ forAllShrink anyCaseContractsWithIdenticalEvaluatedDeposits (filter (uncurry3 hasDuplicateDeposits) . shrink)
                 $ \(environment', state, caseContracts) -> do
                   let evaluatedDeposits = evaluateDeposits environment' state caseContracts
                       canDeposits = to . deposits . mkApplicablesWhen environment' state $ caseContracts
@@ -99,34 +102,54 @@ tests =
             "Choice"
             [ testProperty
                 "\"Choice\" with empty bounds is not applicables"
-                $ forAll' anyCaseContractsWithEmptyBoundsChoiceOnly
+                $ forAllShrink anyCaseContractsWithEmptyBoundsChoiceOnly shrink
                 $ \(environment', state, caseContracts) -> do
                   null (choices . mkApplicablesWhen environment' state $ caseContracts)
             , testGroup
                 "Shadowing : Bounds are not applicable when previously covered by Choices with the same Id"
                 [ testProperty
                     "Applicable [Indexed CanChoose]'s bounds on the same choiceId don't overlap"
-                    $ forAll' anyCaseContractsWithChoiceOnTheSameChoiceIdAndNonEmptyBounds
+                    $ forAllShrink anyCaseContractsWithChoiceOnTheSameChoiceIdAndNonEmptyBounds shrink
                     $ \(environment', state, caseContracts) -> do
                       let indexedChoices = to . onlyIndexedChoices environment' state $ caseContracts
-                          canchooseList = choices . mkApplicablesWhen environment' state $ caseContracts
-                      overlaps indexedChoices && (not . overlaps $ canchooseList)
-                        || (not . overlaps $ indexedChoices) && (not . overlaps $ canchooseList)
+                          canChooseList = choices . mkApplicablesWhen environment' state $ caseContracts
+                      overlaps indexedChoices && (not . overlaps $ canChooseList)
+                        || (not . overlaps $ indexedChoices) && (not . overlaps $ canChooseList)
                 , testProperty
                     "\"CanChoose\" is isomorphic to \"Choice\" and its \"Case\" index preserved when no shadowing involved"
-                    $ forAll' anyCaseContractsWithChoiceOnlyNotShadowed
+                    $ forAllShrink anyCaseContractsWithChoiceOnlyNotShadowed shrink
                     $ \(environment', state, caseContracts) -> do
                       let indexedChoices = onlyIndexedChoices environment' state caseContracts
                       indexedChoices == (to . choices . mkApplicablesWhen environment' state $ caseContracts)
                 , testProperty
                     "\"[Indexed CanChoose]\" and [Choice] on the same id have the same merged Bounds "
                     $ withMaxSuccess 50
-                    $ forAll' anyCaseContractsWithChoiceOnTheSameChoiceIdAndNonEmptyBounds
+                    $ forAllShrink anyCaseContractsWithChoiceOnTheSameChoiceIdAndNonEmptyBounds shrink
                     $ \(environment', state, caseContracts) -> do
                       let indexedChoices = to . onlyIndexedChoices environment' state $ caseContracts
-                          canchooseList = choices . mkApplicablesWhen environment' state $ caseContracts
-                      compactAdjoinedBounds indexedChoices == compactAdjoinedBounds canchooseList
+                          canChooseList = choices . mkApplicablesWhen environment' state $ caseContracts
+                      compactAdjoinedBounds indexedChoices == compactAdjoinedBounds canChooseList
                 ]
             ]
         ]
     ]
+
+onlyFalseNotifies :: Environment -> State -> [Case Contract] -> Bool
+onlyFalseNotifies env state = not . any (isTrueNotify env state . getAction)
+
+atLeastOneTrueNotify :: Environment -> State -> [Case Contract] -> Bool
+atLeastOneTrueNotify env state = any (isTrueNotify env state . getAction)
+
+hasDuplicateDeposits :: Environment -> State -> [Case Contract] -> Bool
+hasDuplicateDeposits env state = any ((> 1) . length) . group . sort . mapMaybe (normalizeDeposit . getAction)
+  where
+    normalizeDeposit :: Action -> Maybe Action
+    normalizeDeposit = \case
+      Deposit account party token value ->
+        Just $ Deposit account party token $ Constant $ evalValue env state value
+      _ -> Nothing
+
+isTrueNotify :: Environment -> State -> Action -> Bool
+isTrueNotify env state = \case
+  Notify obs -> not $ evalObservation env state obs
+  _ -> False

--- a/marlowe-test/test/Spec/Marlowe/Semantics/Next/Common/QuickCheck.hs
+++ b/marlowe-test/test/Spec/Marlowe/Semantics/Next/Common/QuickCheck.hs
@@ -1,18 +1,18 @@
 module Spec.Marlowe.Semantics.Next.Common.QuickCheck (
-  forAll',
+  forAllSuchThat,
 ) where
 
-import Test.QuickCheck (Arbitrary (shrink), Gen, Property, Testable, forAllShrink)
+import Test.QuickCheck (Arbitrary (..), Property, Testable, forAllShrink, suchThat)
 
--- | Test properties with shrinkage.
-forAll'
+-- | Test properties with shrinkage, applying a predicate to the generator and the shrink.
+forAllSuchThat
   :: (Arbitrary a)
   => (Show a)
   => (Testable prop)
-  => Gen a
-  -- ^ The test-case generator.
+  => (a -> Bool)
+  -- ^ The test-case predicate.
   -> (a -> prop)
   -- ^ The test.
   -> Property
   -- ^ The result of multiple applications of the test.
-forAll' = flip forAllShrink shrink
+forAllSuchThat p = forAllShrink (arbitrary `suchThat` p) (filter p . shrink)

--- a/marlowe-test/test/Spec/Marlowe/Semantics/Next/Contract.hs
+++ b/marlowe-test/test/Spec/Marlowe/Semantics/Next/Contract.hs
@@ -12,9 +12,11 @@ import Spec.Marlowe.Semantics.Arbitrary ()
 
 isIrreducible :: Environment -> State -> Contract -> Bool
 isIrreducible environment' state contract =
-  case reduceContractUntilQuiescent environment' state contract of
-    ContractQuiescent False _ _ _ _ -> True
-    _otherwise -> False
+  case fixInterval (timeInterval environment') state of
+    IntervalTrimmed e s -> case reduceContractUntilQuiescent e s contract of
+      ContractQuiescent False _ _ _ _ -> True
+      _otherwise -> False
+    _ -> False
 
 isNotClose :: Environment -> State -> Contract -> Bool
 isNotClose _ _ Close = False
@@ -22,9 +24,11 @@ isNotClose _ _ _ = True
 
 isReducible :: Environment -> State -> Contract -> Bool
 isReducible environment' state contract =
-  case reduceContractUntilQuiescent environment' state contract of
-    ContractQuiescent True _ _ _ _ -> True
-    _otherwise -> False
+  case fixInterval (timeInterval environment') state of
+    IntervalTrimmed e s -> case reduceContractUntilQuiescent e s contract of
+      ContractQuiescent True _ _ _ _ -> True
+      _otherwise -> False
+    _ -> False
 
 hasValidEnvironment :: Environment -> State -> Contract -> Bool
 hasValidEnvironment environment state contract =
@@ -37,6 +41,8 @@ hasValidEnvironment environment state contract =
 
 isReducibleToClose :: Environment -> State -> Contract -> Bool
 isReducibleToClose environment' state contract =
-  case reduceContractUntilQuiescent environment' state contract of
-    ContractQuiescent _ _ _ _ Close -> True
-    _otherwise -> False
+  case fixInterval (timeInterval environment') state of
+    IntervalTrimmed e s -> case reduceContractUntilQuiescent e s contract of
+      ContractQuiescent _ _ _ _ Close -> True
+      _otherwise -> False
+    _ -> False


### PR DESCRIPTION
There was an error and another error masking the first one:

- Invalid test cases were generated (this one was subtle and took me running `--quickcheck-tests 10000` to encounter.
- Shrinking broke invariants in the generator (tip: never do this: `forAllShrink myCustomGenerator shrink` - the shrink will likely destroy any invariants imposed by `myCustomGenerator`).

The primary issue was because of an inconsistency in the generator logic and the test logic. Some helper functions used in test case filtering failed to call `fixInterval`, and so some cases that passed the test case filtering failed the call to `next`. Notably:

```
( Environment {timeInterval = (POSIXTime {getPOSIXTime = -1},POSIXTime {getPOSIXTime = 0})}
, State
  {accounts = Map {unMap = []}
  , choices = Map {unMap = []}
  , boundValues = Map {unMap = []}
  , minTime = POSIXTime {getPOSIXTime = 0}
  }
, If
    (ValueGE TimeIntervalStart (UseValue "x"))
    (When [Case (Notify TrueObs) Close] (POSIXTime {getPOSIXTime = 1}) Close)
    Close
)
```

If you call `isReducibleToClose` on this input, it returns `True`, because the `If` condition evaluates to `False` (`TimeIntervalStart = -1`, `UseValue "x"` = 0 => -1 >= 0 = False)

However, if you first call `fixInterval`, you get a new environment:

```
Environment {timeInterval = (POSIXTime {getPOSIXTime = 0},POSIXTime {getPOSIXTime = 0})}
```

And now the `If` condition evaluates to `True`. So, `isReducibleToClose` has to call `fixInterval` first.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [x] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested
