### PR TITLE
PLT-6905 Marlowe Runtime fails to adjust min-UTxO when starting from low value

### DIFF
--- a/marlowe-apps/scaling/Main.hs
+++ b/marlowe-apps/scaling/Main.hs
@@ -102,7 +102,7 @@ runScenario
   -> [InputContent]
   -> App ContractId
 runScenario backend config address key contract inputs =
-  runWithEvents backend config address key contract (pure . NormalInput <$> inputs) 1_500_000
+  runWithEvents backend config address key contract (pure . NormalInput <$> inputs) Nothing
 
 currentTime :: (MonadIO m) => m POSIXTime
 currentTime = POSIXTime . floor . (* 1_000) . nominalDiffTimeToSeconds <$> liftIO P.getPOSIXTime

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Build.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Build.hs
@@ -45,7 +45,7 @@ buildCreation
   :: MarloweVersion v
   -> Contract v
   -> M.Map TokenName Address
-  -> Lovelace
+  -> Maybe Lovelace
   -> MarloweTransactionMetadata
   -> [Address]
   -> Address

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Transact.hs
@@ -53,7 +53,7 @@ run
   -> C.SigningKey C.PaymentExtendedKey
   -> Contract
   -> [[Input]]
-  -> Lovelace
+  -> Maybe Lovelace
   -> App ContractId
 run = runWithEvents unitEventBackend
 
@@ -64,7 +64,7 @@ runWithEvents
   -> C.SigningKey C.PaymentExtendedKey
   -> Contract
   -> [[Input]]
-  -> Lovelace
+  -> Maybe Lovelace
   -> App ContractId
 runWithEvents backend config address key contract inputs minUtxo =
   do
@@ -78,7 +78,7 @@ create
   -> Address
   -> C.SigningKey C.PaymentExtendedKey
   -> Contract
-  -> Lovelace
+  -> Maybe Lovelace
   -> App ContractId
 create = createWithEvents unitEventBackend
 
@@ -88,7 +88,7 @@ createWithEvents
   -> Address
   -> C.SigningKey C.PaymentExtendedKey
   -> Contract
-  -> Lovelace
+  -> Maybe Lovelace
   -> App ContractId
 createWithEvents backend config address key contract minUtxo =
   transactWithEvents' backend config key $

--- a/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
+++ b/marlowe-apps/src/Language/Marlowe/Runtime/App/Types.hs
@@ -186,7 +186,7 @@ data MarloweRequest v
   | Create
       { reqContract :: Contract v
       , reqRoles :: M.Map TokenName Address
-      , reqMinUtxo :: Lovelace
+      , reqMinUtxo :: Maybe Lovelace
       , --  , reqStakeAddress :: Maybe StakeCredential
         reqMetadata :: TransactionMetadata
       , reqAddresses :: [Address]
@@ -244,7 +244,7 @@ instance A.FromJSON (MarloweRequest 'V1) where
             "create" -> do
               reqContract <- o A..: "contract"
               reqRoles <- M.mapKeys fromString . M.map fromString <$> (o A..: "roles" :: A.Parser (M.Map String String))
-              reqMinUtxo <- Lovelace <$> o A..: "minUtxo"
+              reqMinUtxo <- fmap Lovelace <$> o A..:? "minUtxo"
               reqMetadata <- metadataFromJSON =<< o A..: "metadata"
               reqAddresses <- mapM addressFromJSON =<< o A..: "addresses"
               reqChange <- addressFromJSON =<< o A..: "change"
@@ -328,7 +328,7 @@ instance A.ToJSON (MarloweRequest 'V1) where
       [ "request" A..= ("create" :: String)
       , "contract" A..= reqContract
       , "roles" A..= M.mapKeys show reqRoles
-      , "minUtxo" A..= unLovelace reqMinUtxo
+      , "minUtxo" A..= fmap unLovelace reqMinUtxo
       , "metadata" A..= reqMetadata
       , "addresses" A..= fmap addressToJSON reqAddresses
       , "change" A..= addressToJSON reqChange

--- a/marlowe-cli/cli-test/Language/Marlowe/CLI/Test/Runtime/Interpret.hs
+++ b/marlowe-cli/cli-test/Language/Marlowe/CLI/Test/Runtime/Interpret.hs
@@ -476,7 +476,7 @@ interpret ro@RuntimeCreateContract{..} = do
            in (c, Just cnt)
 
   result <- liftIO $ flip runMarloweT connector do
-    let minLovelace = ChainSync.Lovelace roMinLovelace
+    let minLovelace = ChainSync.Lovelace <$> roMinLovelace
         walletAddresses =
           WalletAddresses
             { changeAddress = changeAddress

--- a/marlowe-cli/cli-test/Language/Marlowe/CLI/Test/Runtime/Types.hs
+++ b/marlowe-cli/cli-test/Language/Marlowe/CLI/Test/Runtime/Types.hs
@@ -209,7 +209,7 @@ data RuntimeOperation
       { roContractNickname :: Maybe ContractNickname
       , roSubmitter :: Maybe WalletNickname
       -- ^ A wallet which gonna submit the initial transaction.
-      , roMinLovelace :: Word64
+      , roMinLovelace :: Maybe Word64
       , roRoleCurrency :: Maybe CurrencyNickname
       -- ^ If contract uses roles then currency is required.
       , roContractSource :: Contract.Source

--- a/marlowe-client/README.md
+++ b/marlowe-client/README.md
@@ -21,7 +21,7 @@ main = connectToMarloweRuntime "localhost" 3700 do
   _ <- runMarloweQueryClient $ getContractHeaders Nothing
 
   -- Interact with contracts
-  contractCreated <- createContract Nothing MarloweV1 wallet roleTokens mempty minAdaDeposit myContract
+  contractCreated <- createContract Nothing MarloweV1 wallet roleTokens mempty Nothing myContract
   -- Sign with method of choice
   submitAndWait $ signTx $ case contractCreated of ContractCreated{..} -> txBody
 

--- a/marlowe-client/src/Control/Monad/Trans/Marlowe/Class.hs
+++ b/marlowe-client/src/Control/Monad/Trans/Marlowe/Class.hs
@@ -213,8 +213,8 @@ createContract
   -- ^ How to initialize role tokens
   -> MarloweTransactionMetadata
   -- ^ Optional metadata to attach to the transaction
-  -> Lovelace
-  -- ^ Min Lovelace which should be used for the contract output.
+  -> Maybe Lovelace
+  -- ^ Optional min Lovelace deposit which should be stored in the contract's accounts.
   -> Either (Contract v) DatumHash
   -- ^ The contract to run, or the hash of the contract to look up in the store.
   -> m (Either CreateError (ContractCreated v))

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/ApplyInputs.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/ApplyInputs.hs
@@ -87,7 +87,7 @@ closedSpec = parallel $ describe "Closed contract" $ aroundAll setup do
             (addresses wallet)
             RoleTokensNone
             emptyMarloweTransactionMetadata
-            2_000_000
+            Nothing
             (Left Close)
       _ <- submit wallet era0 createBody
       applyInputs MarloweV1 (addresses wallet) contractId emptyMarloweTransactionMetadata []
@@ -136,7 +136,7 @@ closeSpec = parallel $ describe "Close contract" $ aroundAll setup do
         (addresses wallet)
         RoleTokensNone
         emptyMarloweTransactionMetadata
-        2_000_000
+        Nothing
         (Left Close)
         >>= expectRight "Failed to create contract"
         >>= \created@(ContractCreated era0 ContractCreatedInEra{txBody = createBody, contractId}) -> do
@@ -281,7 +281,7 @@ paySpec = parallel $ describe "Pay contracts" $ aroundAll setup do
             (addresses wallet1)
             (mkRoleTokens [("Role", wallet2)])
             emptyMarloweTransactionMetadata
-            2_000_000
+            (Just 2_000_000)
             (Left $ mkPay (Account $ Role "Role") ada (Constant 2_000_000) Close)
       submitCreate wallet1 payRoleAccountCreated
       payAddressAccountCreated <-
@@ -292,7 +292,7 @@ paySpec = parallel $ describe "Pay contracts" $ aroundAll setup do
             (addresses wallet1)
             RoleTokensNone
             emptyMarloweTransactionMetadata
-            2_000_000
+            (Just 2_000_000)
             (Left $ mkPay (Account $ walletParty wallet2) ada (Constant 2_000_000) Close)
       submitCreate wallet1 payAddressAccountCreated
       payRolePartyCreated <-
@@ -303,7 +303,7 @@ paySpec = parallel $ describe "Pay contracts" $ aroundAll setup do
             (addresses wallet1)
             (mkRoleTokens [("Role", wallet2)])
             emptyMarloweTransactionMetadata
-            2_000_000
+            (Just 2_000_000)
             (Left $ mkPay (Party $ Role "Role") ada (Constant 2_000_000) Close)
       submitCreate wallet1 payRolePartyCreated
       payAddressPartyCreated <-
@@ -314,7 +314,7 @@ paySpec = parallel $ describe "Pay contracts" $ aroundAll setup do
             (addresses wallet1)
             RoleTokensNone
             emptyMarloweTransactionMetadata
-            2_000_000
+            (Just 2_000_000)
             (Left $ mkPay (Party $ walletParty wallet2) ada (Constant 2_000_000) Close)
       submitCreate wallet1 payAddressPartyCreated
       payDepth1Created <-
@@ -325,7 +325,7 @@ paySpec = parallel $ describe "Pay contracts" $ aroundAll setup do
             (addresses wallet1)
             (mkRoleTokens [("Role", wallet2)])
             emptyMarloweTransactionMetadata
-            2_000_000
+            (Just 2_000_000)
             ( Left $
                 mkPay (Account $ Role "Role") ada (Constant 2_000_000) $
                   When
@@ -343,7 +343,7 @@ paySpec = parallel $ describe "Pay contracts" $ aroundAll setup do
             (addresses wallet1)
             (mkRoleTokens [("Role", wallet2)])
             emptyMarloweTransactionMetadata
-            10_000_000
+            (Just 10_000_000)
             ( Left $
                 mkPay (Account $ Role "Role") ada (Constant 2_000_000) $
                   When
@@ -366,7 +366,7 @@ paySpec = parallel $ describe "Pay contracts" $ aroundAll setup do
             (addresses wallet1)
             (mkRoleTokens [("Role", wallet2)])
             emptyMarloweTransactionMetadata
-            10_000_000
+            (Just 10_000_000)
             ( Left $
                 mkPay (Party $ Role "Role") ada (Constant 2_000_000) $
                   When
@@ -511,7 +511,7 @@ whenTimeoutSpec = parallel $ describe "Timed out contracts" $ aroundAll setup do
             (addresses wallet)
             RoleTokensNone
             emptyMarloweTransactionMetadata
-            2_000_000
+            Nothing
             (Left $ When [Case (Notify TrueObs) Close] (utcTimeToPOSIXTime startTime) Close)
       submitCreate wallet depth1Created
       depth2InnerTimeoutCreated <-
@@ -522,7 +522,7 @@ whenTimeoutSpec = parallel $ describe "Timed out contracts" $ aroundAll setup do
             (addresses wallet)
             RoleTokensNone
             emptyMarloweTransactionMetadata
-            2_000_000
+            Nothing
             ( Left $
                 When [Case (Notify TrueObs) Close] (utcTimeToPOSIXTime startTime) $
                   When [] (utcTimeToPOSIXTime startTime) Close
@@ -536,7 +536,7 @@ whenTimeoutSpec = parallel $ describe "Timed out contracts" $ aroundAll setup do
             (addresses wallet)
             RoleTokensNone
             emptyMarloweTransactionMetadata
-            2_000_000
+            Nothing
             ( Left $
                 When [Case (Notify TrueObs) Close] (utcTimeToPOSIXTime startTime) $
                   When [] (utcTimeToPOSIXTime $ addUTCTime (secondsToNominalDiffTime 200) startTime) Close
@@ -632,7 +632,7 @@ whenEmptySpec = parallel $ describe "Empty When contracts" $ aroundAll setup do
             (addresses wallet)
             RoleTokensNone
             emptyMarloweTransactionMetadata
-            2_000_000
+            Nothing
             (Left $ When [] (utcTimeToPOSIXTime $ addUTCTime (secondsToNominalDiffTime 200) startTime) Close)
       submitCreate wallet $ ContractCreated era ContractCreatedInEra{..}
       runtime <- ask
@@ -900,7 +900,7 @@ whenNonEmptySpec = parallel $ describe "Non-Empty When contracts" $ aroundAll se
             (addresses wallet1)
             (mkRoleTokens [("Role1", wallet1), ("Role2", wallet2)])
             emptyMarloweTransactionMetadata
-            2_000_000
+            Nothing
             (Left $ When cases (utcTimeToPOSIXTime $ addUTCTime (secondsToNominalDiffTime 100) startTime) Close)
       submitCreate wallet1 contract
       runtime <- ask
@@ -956,7 +956,7 @@ merkleizedSpec = parallel $ describe "Merkleized contracts" $ aroundAll setup do
             (addresses wallet)
             RoleTokensNone
             emptyMarloweTransactionMetadata
-            2_000_000
+            Nothing
             ( Left $
                 When
                   [MerkleizedCase (Notify TrueObs) hash]
@@ -1021,7 +1021,7 @@ multiInputsSpec = parallel $ describe "Multi inputs" $ aroundAll setup do
             (addresses wallet)
             (mkRoleTokens [("role", wallet)])
             emptyMarloweTransactionMetadata
-            2_000_000
+            Nothing
             ( Left $
                 When
                   [Case action1 $ When [Case action2 Close] timeout Close, Case action2 $ When [Case action1 Close] timeout Close]

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Basic.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Basic.hs
@@ -181,7 +181,7 @@ spec = describe "Basic scenarios" do
           (wallet.addresses)
           (RoleTokensUsePolicy "")
           emptyMarloweTransactionMetadata
-          2_000_000
+          Nothing
           (Left contract)
     _ <- submit wallet era0 created.txBody
     InputsApplied era1 applied <-

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Common.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Common.hs
@@ -480,7 +480,7 @@ contractCreatedToCreateStep (ContractCreated _ ContractCreatedInEra{..}) =
     { createOutput =
         TransactionScriptOutput
           { address = marloweScriptAddress
-          , assets = Assets 2_000_000 mempty
+          , assets
           , utxo = unContractId contractId
           , datum
           }

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Create.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/Create.hs
@@ -322,6 +322,7 @@ addNFTMetadata ContractCreatedInEra{..} = \case
 
 minLovelaceSpec :: MinLovelaceCase -> Maybe (SpecWith (TestData, ContractCreated v))
 minLovelaceSpec = \case
+  MinLovelaceOmitted -> Just $ pure ()
   MinLovelaceSufficient -> Just $ pure ()
   MinLovelaceInsufficient -> Nothing
 
@@ -424,10 +425,11 @@ mkExtraMetadata (ExtraMetadataCase extraRandomMetadata extraMarloweMetadata extr
         , guard extraNFTMetadata $> (721, MetadataNumber 721)
         ]
 
-mkMinLovelace :: MinLovelaceCase -> Lovelace
+mkMinLovelace :: MinLovelaceCase -> Maybe Lovelace
 mkMinLovelace = \case
-  MinLovelaceSufficient -> 5_000_000
-  MinLovelaceInsufficient -> 500_000
+  MinLovelaceOmitted -> Nothing
+  MinLovelaceSufficient -> Just 5_000_000
+  MinLovelaceInsufficient -> Just 500_000
 
 mkContract :: RoleTokenCase -> V1.Contract
 mkContract = \case
@@ -503,6 +505,7 @@ data ExtraMetadataCase = ExtraMetadataCase Bool Bool Bool
   deriving (Show, Eq)
 
 data MinLovelaceCase
-  = MinLovelaceSufficient
+  = MinLovelaceOmitted
+  | MinLovelaceSufficient
   | MinLovelaceInsufficient
   deriving (Show, Eq, Enum, Bounded)

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/StandardContract.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Integration/StandardContract.hs
@@ -134,7 +134,7 @@ createStandardContractWithTags tags partyAWallet partyBWallet = do
                       }
               }
       )
-      2_000_000
+      Nothing
       (Right contractHash)
   contractCreated@(ContractCreated era0 ContractCreatedInEra{contractId, txBody = createTxBody}) <-
     expectRight "failed to create standard contract" result

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Common.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Common.hs
@@ -71,7 +71,7 @@ createCloseContract Wallet{..} = do
         , version = Web.V1
         , roles = Nothing
         , contract = ContractOrSourceId $ Left V1.Close
-        , minUTxODeposit = 2_000_000
+        , minUTxODeposit = Nothing
         , tags = mempty
         }
 

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Get.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Get.hs
@@ -38,7 +38,6 @@ getsFirstContractValidSpec = it "returns the first contract" \MarloweWebTestData
 
     liftIO do
       contractId `shouldBe` expectedContractId1
-      assets `shouldBe` Web.Assets{lovelace = 2_000_000, tokens = Web.Tokens mempty}
 
 getsSecondContractValidSpec :: SpecWith MarloweWebTestData
 getsSecondContractValidSpec = it "returns the second contract" \MarloweWebTestData{..} -> flip runIntegrationTest runtime do
@@ -47,7 +46,6 @@ getsSecondContractValidSpec = it "returns the second contract" \MarloweWebTestDa
 
     liftIO do
       contractId `shouldBe` expectedContractId2
-      assets `shouldBe` Web.Assets{lovelace = 2_000_000, tokens = Web.Tokens mempty}
 
 getsThirdContractValidSpec :: SpecWith MarloweWebTestData
 getsThirdContractValidSpec = it "returns the third contract" \MarloweWebTestData{..} -> flip runIntegrationTest runtime do
@@ -56,7 +54,6 @@ getsThirdContractValidSpec = it "returns the third contract" \MarloweWebTestData
 
     liftIO do
       contractId `shouldBe` expectedContractId3
-      assets `shouldBe` Web.Assets{lovelace = 2_000_000, tokens = Web.Tokens mempty}
 
 invalidTxIdSpec :: SpecWith MarloweWebTestData
 invalidTxIdSpec = it "returns not found for invalid contract id" \MarloweWebTestData{..} -> flip runIntegrationTest runtime do

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Post.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Post.hs
@@ -47,7 +47,7 @@ spec = describe "Valid POST /contracts" do
             , version = Web.V1
             , roles = Just $ Web.Mint $ Map.singleton "PartyA" $ Web.RoleTokenSimple partyAWebChangeAddress
             , contract = ContractOrSourceId $ Left contract
-            , minUTxODeposit = 2_000_000
+            , minUTxODeposit = Nothing
             , tags = mempty
             }
     case result of

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Put.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Contract/Put.hs
@@ -47,7 +47,7 @@ spec = describe "POST /contracts/{contractId}/transactions" do
             , version = Web.V1
             , roles = Just $ Web.Mint $ Map.singleton "PartyA" $ RoleTokenSimple partyAWebChangeAddress
             , contract = ContractOrSourceId $ Left contract
-            , minUTxODeposit = 2_000_000
+            , minUTxODeposit = Nothing
             , tags = mempty
             }
       signedCreateTx <- liftIO $ signShelleyTransaction' txEnvelope signingKeys

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Get.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Get.hs
@@ -38,12 +38,11 @@ getsFirstTransactionValidSpec = it "returns the first transaction" \MarloweWebTe
   either throw pure =<< runWebClient do
     case transactionIds of
       (txId1 : _) -> do
-        Web.Tx{transactionId = actualTransactionId, assets, payouts} <- getTransaction contractId txId1
+        Web.Tx{transactionId = actualTransactionId, payouts} <- getTransaction contractId txId1
 
         liftIO do
           actualTransactionId `shouldBe` txId1
           payouts `shouldBe` []
-          assets `shouldBe` Web.Assets{lovelace = 102_000_000, tokens = Web.Tokens mempty}
       _ -> do
         liftIO $ fail "Expected at least two transactions"
 
@@ -52,12 +51,11 @@ getsSecondTransactionValidSpec = it "returns the second transaction" \MarloweWeb
   either throw pure =<< runWebClient do
     case transactionIds of
       (_ : txId2 : _) -> do
-        Web.Tx{transactionId = actualTransactionId, assets, payouts} <- getTransaction contractId txId2
+        Web.Tx{transactionId = actualTransactionId, payouts} <- getTransaction contractId txId2
 
         liftIO do
           actualTransactionId `shouldBe` txId2
           payouts `shouldBe` []
-          assets `shouldBe` Web.Assets{lovelace = 102_000_000, tokens = Web.Tokens mempty}
       _ -> do
         liftIO $ fail "Expected at least two transactions"
 
@@ -66,11 +64,10 @@ getsThirdTransactionValidSpec = it "returns the third transaction" \MarloweWebTe
   either throw pure =<< runWebClient do
     case transactionIds of
       (_ : _ : txId3 : _) -> do
-        Web.Tx{transactionId = actualTransactionId, assets, payouts} <- getTransaction contractId txId3
+        Web.Tx{transactionId = actualTransactionId, payouts} <- getTransaction contractId txId3
 
         liftIO do
           actualTransactionId `shouldBe` txId3
-          assets `shouldBe` Web.Assets{lovelace = 2_000_000, tokens = Web.Tokens mempty}
           payouts `shouldBe` []
       _ -> do
         liftIO $ fail "Expected at least three transactions"

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Post.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Post.hs
@@ -50,7 +50,7 @@ spec = describe "POST /contracts/{contractId}/transactions" do
             , version = Web.V1
             , roles = Just $ Web.Mint $ Map.singleton "Party A" $ RoleTokenSimple partyAWebChangeAddress
             , contract = ContractOrSourceId $ Left contract
-            , minUTxODeposit = 2_000_000
+            , minUTxODeposit = Nothing
             , tags = mempty
             }
 

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Put.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/Contracts/Transactions/Transaction/Put.hs
@@ -55,7 +55,7 @@ spec = describe "PUT /contracts/{contractId}/transactions/{transaction}" do
             , version = Web.V1
             , roles = Just $ Web.Mint $ Map.singleton "Party A" $ RoleTokenSimple partyAWebChangeAddress
             , contract = ContractOrSourceId $ Left contract
-            , minUTxODeposit = 2_000_000
+            , minUTxODeposit = Nothing
             , tags = mempty
             }
 

--- a/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/StandardContract.hs
+++ b/marlowe-integration-tests/test/Language/Marlowe/Runtime/Web/StandardContract.hs
@@ -107,7 +107,7 @@ createStandardContractWithTags tags partyAWallet partyBWallet = do
         , version = Web.V1
         , roles = Just $ Web.Mint $ Map.singleton "Party A" $ RoleTokenSimple partyAWebChangeAddress
         , contract = ContractOrSourceId $ Right contractSourceId
-        , minUTxODeposit = 2_000_000
+        , minUTxODeposit = Nothing
         , tags = tags
         }
 

--- a/marlowe-integration/app/Main.hs
+++ b/marlowe-integration/app/Main.hs
@@ -59,7 +59,7 @@ main = withLocalMarloweRuntime \MarloweRuntime{..} -> do
           , version = Web.V1
           , roles = Nothing
           , contract = ContractOrSourceId $ Left V1.Close
-          , minUTxODeposit = 2_000_000
+          , minUTxODeposit = Nothing
           }
 
     liftIO $ print CreateTxEnvelope{txEnvelope = createTxBody, ..}

--- a/marlowe-runtime-cli/app/Language/Marlowe/Runtime/CLI/Command/Create.hs
+++ b/marlowe-runtime-cli/app/Language/Marlowe/Runtime/CLI/Command/Create.hs
@@ -66,7 +66,7 @@ data CreateCommand = CreateCommand
   , stakeCredential :: Maybe StakeCredential
   , roles :: Maybe RolesConfig
   , contractFiles :: ContractFiles
-  , minUTxO :: Lovelace
+  , minUTxO :: Maybe Lovelace
   }
 
 data RoleConfig = RoleConfig
@@ -221,12 +221,13 @@ createCommandParser = info (txCommandParser True parser) $ progDesc "Create a ne
           ]
     integerParser = maybe (Left "Invalid Integer value") Right . readMaybe
     minUTxOParser =
-      option (Lovelace <$> auto) $
-        mconcat
-          [ long "min-utxo"
-          , help "An amount which should be used as min ADA requirement for the Contract UTxO."
-          , metavar "LOVELACE"
-          ]
+      optional $
+        option (Lovelace <$> auto) $
+          mconcat
+            [ long "min-utxo"
+            , help "The amount of ADA to deposit into the contract to ensure the contract output satisfies min ADA requirements."
+            , metavar "LOVELACE"
+            ]
 
 runCreateCommand :: TxCommand CreateCommand -> CLI ()
 runCreateCommand TxCommand{walletAddresses, signingMethod, tagsFile, metadataFile, subCommand = CreateCommand{..}} = case marloweVersion of

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/ApiError.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/ApiError.hs
@@ -136,6 +136,8 @@ instance ToDTO CreateError where
     CreateToCardanoError -> ApiError "Internal error" "CreateToCardanoError" Null 400
     CreateSafetyAnalysisError _ -> ApiError "Safety analysis failed" "SafetyAnalysisFailed" Null 400
     CreateContractNotFound -> ApiError "Contract not found" "Not found" Null 404
+    ProtocolParamNoUTxOCostPerByte -> ApiError "Unable to compute min Ada deposit bound" "Internal error" Null 500
+    InsufficientMinAdaDeposit required -> ApiError "Min Ada deposit insufficient." "Bad Request" (object ["minimumRequiredDeposit" .= required]) 400
 
 instance HasDTO ApplyInputsError where
   type DTO ApplyInputsError = ApiError

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Contracts.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/REST/Contracts.hs
@@ -87,7 +87,7 @@ postCreateTxBody PostContractsRequest{..} stakeAddressDTO changeAddressDTO mAddr
     WalletAddresses{..}
     roles'
     MarloweTransactionMetadata{..}
-    (Lovelace minUTxODeposit)
+    (Lovelace <$> minUTxODeposit)
     (DatumHash . unContractSourceId <$> contract')
     >>= \case
       Left err -> throwDTOError err

--- a/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
+++ b/marlowe-runtime-web/server/Language/Marlowe/Runtime/Web/Server/TxClient.hs
@@ -78,7 +78,7 @@ type CreateContract m =
   -> WalletAddresses
   -> RoleTokensConfig
   -> MarloweTransactionMetadata
-  -> Lovelace
+  -> Maybe Lovelace
   -> Either (Contract v) DatumHash
   -> m (Either CreateError (ContractCreated v))
 

--- a/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
+++ b/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs
@@ -773,7 +773,7 @@ data PostContractsRequest = PostContractsRequest
   , version :: MarloweVersion
   , roles :: Maybe RolesConfig
   , contract :: ContractOrSourceId
-  , minUTxODeposit :: Word64
+  , minUTxODeposit :: Maybe Word64
   }
   deriving (Show, Eq, Ord, Generic)
 

--- a/marlowe-runtime/changelog.d/20230928_154632_jhbertra_plt_6905_min_utxo.md
+++ b/marlowe-runtime/changelog.d/20230928_154632_jhbertra_plt_6905_min_utxo.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Min lovelace deposit is optional, and a default will be computed if omitted.

--- a/marlowe-runtime/tx-api/Language/Marlowe/Runtime/Transaction/Api.hs
+++ b/marlowe-runtime/tx-api/Language/Marlowe/Runtime/Transaction/Api.hs
@@ -619,8 +619,8 @@ data MarloweTxCommand status err result where
     -- ^ How to initialize role tokens
     -> MarloweTransactionMetadata
     -- ^ Optional metadata to attach to the transaction
-    -> Lovelace
-    -- ^ Min Lovelace which should be used for the contract output.
+    -> Maybe Lovelace
+    -- ^ Optional min Lovelace deposit which should be used for the contract output.
     -> Either (Contract v) DatumHash
     -- ^ The contract to run, or the hash of the contract to load from the store.
     -> MarloweTxCommand Void CreateError (ContractCreated v)
@@ -897,6 +897,8 @@ data CreateError
   | CreateToCardanoError
   | CreateSafetyAnalysisError String -- FIXME: This is a placeholder, pending design of error handling for safety analysis.
   | CreateContractNotFound
+  | ProtocolParamNoUTxOCostPerByte
+  | InsufficientMinAdaDeposit Lovelace
   deriving (Generic)
 
 deriving instance Eq CreateError


### PR DESCRIPTION
New behaviour:

- Min Lovelace deposit is optional for the user to specify
  - If left unspecified, the worst-case deposit value is computed used
  - If specified, the specified amount is used. If it is less than the worst-case deposit, the request fails

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested
