### PR TITLE
chore: disable qa instances and preview/mainnet networks

### DIFF
--- a/deploy/marlowe-runtime/values.yaml
+++ b/deploy/marlowe-runtime/values.yaml
@@ -1,15 +1,15 @@
 networks:
   - preprod
-  - preview
-  - mainnet
+#  - preview
+#  - mainnet
 
 instances:
-  qa:
-    parentDomain: scdev.aws.iohkdev.io
-    webTag: latest
-    tag: latest
-    repo: ghcr.io
-    org: input-output-hk
+#  qa:
+#    parentDomain: scdev.aws.iohkdev.io
+#    webTag: latest
+#    tag: latest
+#    repo: ghcr.io
+#    org: input-output-hk
   demo:
     parentDomain: demo.scdev.aws.iohkdev.io
     webTag: 0.0.5.1


### PR DESCRIPTION
This PR will disable temporarily the instances from QA, mainnet and preview networks.
The goal is to have only applications from demo-preprod running.