### PR TITLE
infra: cluster migration

### DIFF
--- a/deploy/marlowe-runtime/templates/marlowe-proxy.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-proxy.yaml
@@ -58,6 +58,10 @@ spec:
         properties:
           annotations:
             "external-dns.alpha.kubernetes.io/hostname": "marlowe-runtime-{{ . }}.{{ $instance.parentDomain }}"
+            "service.beta.kubernetes.io/aws-load-balancer-name": "marlowe-runtime-{{ . }}-{{ $instanceName }}"
+            "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance"
+            "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing"
+            "service.beta.kubernetes.io/aws-load-balancer-type": "external"
           type: LoadBalancer
           ports:
           - port: 3700

--- a/deploy/marlowe-runtime/templates/marlowe-web-server.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-web-server.yaml
@@ -40,27 +40,6 @@ spec:
           - marlowe-runtime-{{ . }}-web.{{ $instance.parentDomain }}
           rules:
           - port: 3780
-      - type: opentelemetry-collector
-        properties:
-          mode: sidecar
-          config: |
-            receivers:
-              otlp:
-                protocols:
-                  http:
-                  grpc:
-            processors:
-
-            exporters:
-              logging:
-
-            service:
-              pipelines:
-                traces:
-                  receivers: [otlp]
-                  processors: []
-                  exporters: [logging]
-
   policies:
   - name: local-{{ $.Values.namespace }}
     properties:

--- a/deploy/marlowe-runtime/values.yaml
+++ b/deploy/marlowe-runtime/values.yaml
@@ -23,4 +23,4 @@ releaseName: marlowe-runtime
 
 databaseName: marlowe-runtime-database
 
-databaseHost: dapps-marlowe-runtime-database.csguv6v6ban1.us-east-1.rds.amazonaws.com
+databaseHost: prod-marlowe-runtime-db.csguv6v6ban1.us-east-1.rds.amazonaws.com


### PR DESCRIPTION
This PR prepares marlowe-cardano for EKS cluster migration.

Changes:

1. Adding some annotations on marlowe-proxy LoadBalancer as they are needed to create public instances of Network Load Balancer (they are private by default);

2. Removing opentelemetry-collector trait from marlowe-web-server, it's not needed anymore;

3. Changing DB hostname (New RDS instance is already synced);

IMPORTANT: Making it a Draft because we only need to merge it on main when the DNS switch is completed. These changes are already published on the new EKS cluster.