### PR TITLE
PLT-6842 Autodeploy on push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: "Deploy"
+name: "Build, Push, and Deploy"
 env:
   CACHE_NAME: marlowe-temp
   ALLOWED_URIS: "https://github.com https://api.github.com"
@@ -74,9 +74,14 @@ jobs:
             tagAndPush "marlowe-scaling"
             tagAndPush "marlowe-oracle"
             tagAndPush "marlowe-finder"
-          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]
+          elif [[ "${{ github.ref }}" == "refs/tags/marlowe-runtime-web@v"* ]]
           then
-            export TAG=latest
+            # Strip "marlowe-runtime-web@v" prefix from tag name
+            export TAG=$(echo "${{ github.ref_name }}" | sed -e "s/^marlowe-runtime-web@v//")
+            echo TAG=$TAG
+            tagAndPush "marlowe-web-server"
+          else
+            export "TAG=${GITHUB_SHA::8}"
             echo TAG=$TAG
             tagAndPush "marlowe-chain-indexer"
             tagAndPush "marlowe-chain-sync"
@@ -90,10 +95,43 @@ jobs:
             tagAndPush "marlowe-scaling"
             tagAndPush "marlowe-oracle"
             tagAndPush "marlowe-finder"
+          fi
+
+  autocommit:
+    name: Auto Commit
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update publish version
+        id: update
+        run: |
+          if [[ "${{ github.ref }}" == "refs/tags/runtime@v"* ]]
+          then
+            export TAG=$(echo "${{ github.ref_name }}" | sed -e "s/^runtime@v//")
+            echo TAG=$TAG
+            yq e -i '.instances.demo.webTag = env(TAG)' deploy/marlowe-runtime/values.yaml
           elif [[ "${{ github.ref }}" == "refs/tags/marlowe-runtime-web@v"* ]]
           then
-            # Strip "marlowe-runtime-web@v" prefix from tag name
             export TAG=$(echo "${{ github.ref_name }}" | sed -e "s/^marlowe-runtime-web@v//")
             echo TAG=$TAG
-            tagAndPush "marlowe-web-server"
+            yq e -i '.instances.demo.webTag = env(TAG)' deploy/marlowe-runtime/values.yaml
+          else
+            export "TAG=${GITHUB_SHA::8}"
+            echo TAG=$TAG
+            yq e -i '.instances.qa.tag = env(TAG)' deploy/marlowe-runtime/values.yaml
+            yq e -i '.instances.qa.webTag = env(TAG)' deploy/marlowe-runtime/values.yaml
           fi
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v7
+        with:
+          default_author: github_actions
+          add: '.'
+          message: "[ci skip] deploy from ${{ steps.update.outputs.VERSION }}"
+          signoff: true
+          branch: main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,7 @@ jobs:
           then
             export TAG=$(echo "${{ github.ref_name }}" | sed -e "s/^runtime@v//")
             echo TAG=$TAG
+            yq e -i '.instances.demo.tag = env(TAG)' deploy/marlowe-runtime/values.yaml
             yq e -i '.instances.demo.webTag = env(TAG)' deploy/marlowe-runtime/values.yaml
           elif [[ "${{ github.ref }}" == "refs/tags/marlowe-runtime-web@v"* ]]
           then


### PR DESCRIPTION
https://input-output.atlassian.net/browse/PLT-8402

Autodeploy to Kubernetes on push.
This PR adds a Github workflow similar to what currently exists in https://github.com/input-output-hk/marlowe-token-plans and https://github.com/input-output-hk/marlowe-playground/ for updating the values.yaml of the helm chart with the correct image tag and auto-committing, causing a deployment in KubeVela.

The `qa` environments track the latest commit. The `demo` environments are updated when a new version is tagged.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [ ] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Operables are updated with changes to executable command line options.
    - [ ] Deploy charts updated with changes to operables.
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested
