### PR TITLE
PLT-7951 Remedied inconsistent parsing of seconds for different `marl…

### DIFF
--- a/marlowe-cli/changelog.d/20231121_105313_brian.bush_PLT_7951.md
+++ b/marlowe-cli/changelog.d/20231121_105313_brian.bush_PLT_7951.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed `marlowe-cli` flags `--submit` and `--timeout` so they are consistent and so that the parser accepts an integer with or without the `s` suffix.

--- a/marlowe-cli/command/Language/Marlowe/CLI/Command/Parse.hs
+++ b/marlowe-cli/command/Language/Marlowe/CLI/Command/Parse.hs
@@ -532,7 +532,7 @@ publishingStrategyOpt =
       )
 
 parseSecond :: O.ReadM Second
-parseSecond = fromInteger <$> O.auto
+parseSecond = O.auto <|> (fromInteger <$> O.auto)
 
 parseMarloweValuePair :: O.ReadM (Token, Integer)
 parseMarloweValuePair = O.eitherReader $ \s ->

--- a/marlowe-cli/command/Language/Marlowe/CLI/Command/Run.hs
+++ b/marlowe-cli/command/Language/Marlowe/CLI/Command/Run.hs
@@ -641,7 +641,7 @@ withdrawOptions network socket =
       ( O.long "metadata-file" <> O.metavar "METADATA_FILE" <> O.help "JSON file containing metadata."
       )
     <*> txBodyFileOpt
-    <*> (O.optional . O.option O.auto)
+    <*> (O.optional . O.option parseSecond)
       ( O.long "submit"
           <> O.metavar "SECONDS"
           <> O.help "Also submit the transaction, and wait for confirmation."
@@ -695,7 +695,7 @@ autoRunOptions network socket =
       ( O.long "metadata-file" <> O.metavar "METADATA_FILE" <> O.help "JSON file containing metadata."
       )
     <*> txBodyFileOpt
-    <*> (O.optional . O.option O.auto)
+    <*> (O.optional . O.option parseSecond)
       ( O.long "submit"
           <> O.metavar "SECONDS"
           <> O.help "Also submit the transaction, and wait for confirmation."
@@ -766,7 +766,7 @@ autoWithdrawOptions network socket =
       ( O.long "metadata-file" <> O.metavar "METADATA_FILE" <> O.help "JSON file containing metadata."
       )
     <*> txBodyFileOpt
-    <*> (O.optional . O.option O.auto)
+    <*> (O.optional . O.option parseSecond)
       ( O.long "submit"
           <> O.metavar "SECONDS"
           <> O.help "Also submit the transaction, and wait for confirmation."

--- a/marlowe-cli/command/Language/Marlowe/CLI/Command/Transaction.hs
+++ b/marlowe-cli/command/Language/Marlowe/CLI/Command/Transaction.hs
@@ -729,7 +729,7 @@ submitOptions network socket =
               )
         )
     <*> requiredSignersOpt
-    <*> (O.optional . O.option O.auto)
+    <*> (O.optional . O.option parseSecond)
       ( O.long "timeout"
           <> O.metavar "SECONDS"
           <> O.help "Also submit the transaction, and wait for confirmation."

--- a/marlowe-cli/command/Language/Marlowe/CLI/Command/Util.hs
+++ b/marlowe-cli/command/Language/Marlowe/CLI/Command/Util.hs
@@ -373,7 +373,7 @@ cleanOptions network socket =
           <> O.help "Address to receive ADA in excess of fee."
       )
     <*> txBodyFileOpt
-    <*> (O.optional . O.option O.auto)
+    <*> (O.optional . O.option parseSecond)
       ( O.long "submit"
           <> O.metavar "SECONDS"
           <> O.help "Also submit the transaction, and wait for confirmation."
@@ -421,7 +421,7 @@ mintOptions network socket =
           <> O.help "The slot number after which minting is no longer possible."
       )
     <*> txBodyFileOpt
-    <*> (O.optional . O.option O.auto)
+    <*> (O.optional . O.option parseSecond)
       ( O.long "submit"
           <> O.metavar "SECONDS"
           <> O.help "Also submit the transaction, and wait for confirmation."
@@ -484,7 +484,7 @@ burnOptions network socket =
           <> O.metavar "SLOT_NO"
           <> O.help "The slot number after which miniting is no longer possible."
       )
-    <*> (O.optional . O.option O.auto)
+    <*> (O.optional . O.option parseSecond)
       ( O.long "submit"
           <> O.metavar "SECONDS"
           <> O.help "Also submit the transaction, and wait for confirmation."


### PR DESCRIPTION
Somewhat randomly, different `--submit` and `--timeout` flags in `marlowe-cli` either did or did not require the integer seconds to have an `s` suffix. This change makes them uniformly accept either an integer or an integer with an `s` suffix.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Operables are updated with changes to executable command line options.
    - [ ] Deploy charts updated with changes to operables.
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [x] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested