### PR TITLE
Removed RoleTokenConfig Serialization Alternatives

### DIFF
--- a/marlowe-runtime-web/changelog.d/20231206_110509_nicolas.henin.md
+++ b/marlowe-runtime-web/changelog.d/20231206_110509_nicolas.henin.md
@@ -1,0 +1,4 @@
+
+### Removed
+
+- Alternatives of Roles Configuration at the Contract Creation Endpoint.


### PR DESCRIPTION
While testing https://github.com/input-output-hk/marlowe-ts-sdk/pull/54 , some serialization issues have been discovered. 
This is an attempt to fix this issue but by also removing roles configuration alternatives.