### PR TITLE
bump helm chart and using restored rds on QA

### DIFF
--- a/deploy/marlowe-runtime/Chart.yaml
+++ b/deploy/marlowe-runtime/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: marlowe-runtime
-version: v0.0.33
+version: v0.0.34
 appVersion: v0.0.5
 description: Marlowe smart contract language Cardano implementation
 home: https://marlowe.iohk.io

--- a/deploy/marlowe-runtime/templates/chain-indexer.yaml
+++ b/deploy/marlowe-runtime/templates/chain-indexer.yaml
@@ -33,13 +33,13 @@ spec:
             name: chainsync-{{ $network }}-owner-user.{{ $.Values.databaseName }}.credentials.postgresql.acid.zalan.do
             namespace: {{ $.Values.namespace }}
       - name: DB_HOST
-        value: {{ $.Values.databaseHost }}:5432
+        value: {{ $instance.databaseHost }}:5432
       - name: CARDANO_NODE_SOCKET_PATH
         value: /ipc/node.socket
       - name: HTTP_PORT
         value: "3781"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: {{ $.Values.otelExporterURL }}:{{ $.Values.otelExporterPort }}
+        value: {{ $.Values.otelExporter.url }}:{{ $.Values.otelExporter.port }}
       - name: OTEL_SERVICE_NAME
         value: marlowe-chain-indexer-{{ $network }}-{{ $instanceName }}
       image: {{ $instance.repo }}/{{ $instance.org }}/marlowe-chain-indexer:{{ $instance.tag }}

--- a/deploy/marlowe-runtime/templates/chain-sync.yaml
+++ b/deploy/marlowe-runtime/templates/chain-sync.yaml
@@ -26,7 +26,7 @@ spec:
       - name: HTTP_PORT
         value: "3782"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: {{ $.Values.otelExporterURL }}:{{ $.Values.otelExporterPort }}
+        value: {{ $.Values.otelExporter.url }}:{{ $.Values.otelExporter.port }}
       - name: OTEL_SERVICE_NAME
         value: marlowe-chain-sync-{{ $network }}-{{ $instanceName }}
       - name: CARDANO_NODE_SOCKET_PATH
@@ -36,7 +36,7 @@ spec:
       - name: DB_NAME
         value: chainsync_{{ $instanceName }}_{{ $network }}
       - name: DB_HOST
-        value: {{ $.Values.databaseHost }}:5432
+        value: {{ $instance.databaseHost }}:5432
       - name: DB_USER
         valueFrom:
           secretKeyRef:

--- a/deploy/marlowe-runtime/templates/marlowe-contract.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-contract.yaml
@@ -40,7 +40,7 @@ spec:
         - name: HTTP_PORT
           value: "3787"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: {{ $.Values.otelExporterURL }}:{{ $.Values.otelExporterPort }}
+          value: {{ $.Values.otelExporter.url }}:{{ $.Values.otelExporter.port }}
         - name: OTEL_SERVICE_NAME
           value: marlowe-contract-{{ . }}-{{ $instanceName }}
         cpu: "0.5"

--- a/deploy/marlowe-runtime/templates/marlowe-indexer.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-indexer.yaml
@@ -18,7 +18,7 @@ spec:
       - name: DB_NAME
         value: chainsync_{{ $instanceName }}_{{ . }}
       - name: DB_HOST
-        value: {{ $.Values.databaseHost }}:5432
+        value: {{ $instance.databaseHost }}:5432
       - name: DB_USER
         valueFrom:
           secretKeyRef:
@@ -42,7 +42,7 @@ spec:
       - name: HTTP_PORT
         value: "3783"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: {{ $.Values.otelExporterURL }}:{{ $.Values.otelExporterPort }}
+        value: {{ $.Values.otelExporter.url }}:{{ $.Values.otelExporter.port }}
       - name: OTEL_SERVICE_NAME
         value: marlowe-indexer-{{ . }}-{{ $instanceName }}
       cpu: "0.5"

--- a/deploy/marlowe-runtime/templates/marlowe-proxy.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-proxy.yaml
@@ -46,7 +46,7 @@ spec:
         - name: HTTP_PORT
           value: "3786"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: {{ $.Values.otelExporterURL }}:{{ $.Values.otelExporterPort }}
+          value: {{ $.Values.otelExporter.url }}:{{ $.Values.otelExporter.port }}
         - name: OTEL_SERVICE_NAME
           value: marlowe-proxy-{{ . }}-{{ $instanceName }}
         cpu: "0.5"

--- a/deploy/marlowe-runtime/templates/marlowe-sync.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-sync.yaml
@@ -44,11 +44,11 @@ spec:
             name: chainsync-{{ $network }}-owner-user.{{ $.Values.databaseName }}.credentials.postgresql.acid.zalan.do
             namespace: {{ $.Values.namespace }}
       - name: DB_HOST
-        value: {{ $.Values.databaseHost }}:5432
+        value: {{ $instance.databaseHost }}:5432
       - name: HTTP_PORT
         value: "3784"
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: {{ $.Values.otelExporterURL }}:{{ $.Values.otelExporterPort }}
+        value: {{ $.Values.otelExporter.url }}:{{ $.Values.otelExporter.port }}
       - name: OTEL_SERVICE_NAME
         value: marlowe-sync-{{ $network }}-{{ $instanceName }}
       cpu: "0.5"

--- a/deploy/marlowe-runtime/templates/marlowe-tx.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-tx.yaml
@@ -34,7 +34,7 @@ spec:
         - name: HTTP_PORT
           value: "3785"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: {{ $.Values.otelExporterURL }}:{{ $.Values.otelExporterPort }}
+          value: {{ $.Values.otelExporter.url }}:{{ $.Values.otelExporter.port }}
         - name: OTEL_SERVICE_NAME
           value: marlowe-tx-{{ . }}-{{ $instanceName }}
         cpu: "0.5"

--- a/deploy/marlowe-runtime/templates/marlowe-web-server.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-web-server.yaml
@@ -22,7 +22,7 @@ spec:
         - name: RUNTIME_PORT
           value: "3701"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: {{ $.Values.otelExporterURL }}:{{ $.Values.otelExporterPort }}
+          value: {{ $.Values.otelExporter.url }}:{{ $.Values.otelExporter.port }}
         - name: OTEL_SERVICE_NAME
           value: marlowe-web-server-{{ . }}-{{ $instanceName }}
         cpu: "0.5"

--- a/deploy/marlowe-runtime/values.yaml
+++ b/deploy/marlowe-runtime/values.yaml
@@ -26,5 +26,5 @@ releaseName: marlowe-runtime
 databaseName: marlowe-runtime-database
 
 otelExporter:
-  url: http://k8s-monitoring-grafana-agent
+  url: http://k8s-monitoring-grafana-agent.grafana-agent
   port: 4318

--- a/deploy/marlowe-runtime/values.yaml
+++ b/deploy/marlowe-runtime/values.yaml
@@ -10,12 +10,14 @@ instances:
     tag: 0.0.6-rc2
     repo: ghcr.io
     org: input-output-hk
+    databaseHost: prod-marlowe-runtime-db-new.csguv6v6ban1.us-east-1.rds.amazonaws.com
   demo:
     parentDomain: demo.scdev.aws.iohkdev.io
     webTag: 0.0.5.1
     tag: 0.0.5
     repo: ghcr.io
     org: input-output-hk
+    databaseHost: prod-marlowe-runtime-db.csguv6v6ban1.us-east-1.rds.amazonaws.com
 
 namespace: marlowe-staging
 
@@ -23,8 +25,6 @@ releaseName: marlowe-runtime
 
 databaseName: marlowe-runtime-database
 
-databaseHost: prod-marlowe-runtime-db.csguv6v6ban1.us-east-1.rds.amazonaws.com
-
-otelExporterURL: http://grafana-agent.grafana-agent
-
-otelExporterPort: 4318
+otelExporter:
+  url: http://k8s-monitoring-grafana-agent
+  port: 4318


### PR DESCRIPTION
This PR introduce the changes below:

1.  Adds the capability of using one database instance per instance
2. Change all the QA networks to use a RDS instance restored before the last cluster migration attempt
3. Update otelExporter URL