### PR TITLE
chore: increase cpu resource for indexer deployments

### DIFF
--- a/deploy/marlowe-runtime/templates/chain-indexer.yaml
+++ b/deploy/marlowe-runtime/templates/chain-indexer.yaml
@@ -14,7 +14,7 @@ spec:
   - name: chain-indexer-{{ $network }}-{{ $instanceName }}
     type: webservice
     properties:
-      cpu: "0.5"
+      cpu: "1"
       env:
       - name: NODE_CONFIG
         value: /node-config/network/{{ $network }}/cardano-node/config.json

--- a/deploy/marlowe-runtime/templates/chain-sync.yaml
+++ b/deploy/marlowe-runtime/templates/chain-sync.yaml
@@ -49,7 +49,7 @@ spec:
             key: password
             name: chainsync-{{ $network }}-owner-user.{{ $.Values.databaseName }}.credentials.postgresql.acid.zalan.do
             namespace: {{ $.Values.namespace }}
-      cpu: "0.5"
+      cpu: "1"
       image: {{ $instance.repo }}/{{ $instance.org }}/marlowe-chain-sync:{{ $instance.tag }}
       imagePullPolicy: Always
       memory: 4096Mi


### PR DESCRIPTION
Increasing resources.cpu (Requests/Limits) for indexer deployments to avoid `CPUThrottlingHigh` alerts.