### PR TITLE
chore: adding k8s-update-strategy trait on marlowe-contract template

### DIFF
--- a/deploy/marlowe-runtime/templates/marlowe-contract.yaml
+++ b/deploy/marlowe-runtime/templates/marlowe-contract.yaml
@@ -67,6 +67,10 @@ spec:
             resources:
               requests:
                 storage: 200Gi
+      - type: k8s-update-strategy
+        properties:
+          strategy:
+            type: Recreate
   policies:
   - name: local-{{ $.Values.namespace }}
     properties:


### PR DESCRIPTION
This trait will introduce a change on `marlowe-contract` update strategy, instead of create a new pod before terminating an old one (Default policy, `RolloutUpdate`), it will terminate the old one before creating a new one (`Recreate` strategy). 

It is needed because with the default policy, the new pods are stuck in `ContainerCreating` waiting for the EBS volume allocation.