### PR TITLE
Fixed #189. Allow ada as default token for `marlowe-cli template swap`.

### DIFF
--- a/marlowe-cli/changelog.d/20231215_114608_brian.bush_issue189.md
+++ b/marlowe-cli/changelog.d/20231215_114608_brian.bush_issue189.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Marlowe CLI swap template tokens default to ada if not specified.

--- a/marlowe-cli/command/Language/Marlowe/CLI/Command/Template.hs
+++ b/marlowe-cli/command/Language/Marlowe/CLI/Command/Template.hs
@@ -40,7 +40,7 @@ import Language.Marlowe.CLI.Command.Parse (
 import Language.Marlowe.CLI.Examples (makeExample)
 import Language.Marlowe.CLI.IO (decodeFileStrict)
 import Language.Marlowe.CLI.Types (CliError (..), SomeTimeout, toMarloweExtendedTimeout, toMarloweTimeout)
-import Language.Marlowe.Extended.V1 as E (Contract (..), Party, Token, Value (..))
+import Language.Marlowe.Extended.V1 as E (Contract (..), Party, Token (..), Value (..))
 import Language.Marlowe.Util (ada)
 import Marlowe.Contracts (coveredCall, escrow, swap, trivial, zeroCouponBond)
 
@@ -455,7 +455,7 @@ templateSwapOptions =
       )
     <*> O.option
       parseToken
-      ( O.long "a-token" <> O.metavar "TOKEN" <> O.help "The first party's token."
+      ( O.long "a-token" <> O.value (Token "" "") <> O.metavar "TOKEN" <> O.help "The first party's token (default is ada)."
       )
     <*> O.option
       O.auto
@@ -473,7 +473,7 @@ templateSwapOptions =
       )
     <*> O.option
       parseToken
-      ( O.long "b-token" <> O.metavar "TOKEN" <> O.help "The second party's token."
+      ( O.long "b-token" <> O.value (Token "" "") <> O.metavar "TOKEN" <> O.help "The second party's token. (default is ada)"
       )
     <*> O.option
       O.auto


### PR DESCRIPTION
The token for the Marlowe CLI swap contract now defaults to ada if not specified.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Operables are updated with changes to executable command line options.
    - [ ] Deploy charts updated with changes to operables.
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [x] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested