### PR TITLE
Fixed #245. Remove validity interval from `marlowe-cli run withdraw`.

### DIFF
--- a/marlowe-cli/changelog.d/20231215_115221_brian.bush_issue245.md
+++ b/marlowe-cli/changelog.d/20231215_115221_brian.bush_issue245.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Marlowe CLI withdrawal no longer includes a validity interval.

--- a/marlowe-cli/src/Language/Marlowe/CLI/Run.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Run.hs
@@ -879,7 +879,7 @@ withdrawFunds connection marloweOutFile roleName collateral inputs outputs chang
         outputs'
         (Just collateral)
         changeAddress
-        (mtRange marloweOut)
+        Nothing
         (hashSigningKey <$> signingKeys)
         TxMintNone
         metadata


### PR DESCRIPTION
As noted in #245, `marlowe-cli run withdraw` erroneously includes a validity interval in the transaction. Although that was mostly harmless, it was unnecessary, so this PR removes it.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Operables are updated with changes to executable command line options.
    - [ ] Deploy charts updated with changes to operables.
- PR
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [x] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested