### PR TITLE
Accept `State` in the `getAllInputs` and `findTransactions` API

### DIFF
--- a/marlowe-test/src/Spec/Marlowe/Reference.hs
+++ b/marlowe-test/src/Spec/Marlowe/Reference.hs
@@ -117,7 +117,7 @@ processContract
 processContract contractFile pathsFile =
   do
     contract <- ExceptT $ first show <$> eitherDecodeFileStrict contractFile
-    traces <- ExceptT $ first show <$> getAllInputs contract
+    traces <- ExceptT $ first show <$> getAllInputs contract Nothing
     paths <- runTransactions contract `mapM` traces
     lift $ encodeFile pathsFile paths
 

--- a/marlowe-test/test/Spec/Marlowe/Semantics/Compute.hs
+++ b/marlowe-test/test/Spec/Marlowe/Semantics/Compute.hs
@@ -186,7 +186,7 @@ arbitraryValid =
         do
           mcContract <- arbitrary `suchThat` (/= Close)
           (time, inputs') <-
-            case unsafePerformIO $ getAllInputs mcContract of
+            case unsafePerformIO $ getAllInputs mcContract Nothing of
               Right candidates -> elements candidates
               Left _ -> discard
           let -- TODO: Generalize to arbitrary starting state.

--- a/marlowe-test/test/Spec/Marlowe/Semantics/Functions.hs
+++ b/marlowe-test/test/Spec/Marlowe/Semantics/Functions.hs
@@ -942,7 +942,7 @@ checkComputeTransaction =
             TransactionOutput{} -> True
             e -> error $ show (time, contract, inputs, e)
     either (error . ("`getAllInputs` failed with " <>) . show) (all play)
-      <$> run (getAllInputs contract)
+      <$> run (getAllInputs contract Nothing)
 
 -- | Test `Language.Marlowe.Core.V1.Semantics.playTrace` somewhat tautologically ☹️.
 checkPlayTrace :: Property

--- a/marlowe-test/test/Spec/Marlowe/Semantics/Golden/Tests.hs
+++ b/marlowe-test/test/Spec/Marlowe/Semantics/Golden/Tests.hs
@@ -74,7 +74,7 @@ testGolden name printIt contract valids invalids =
 printValids :: Contract -> IO ()
 printValids contract =
   do
-    Right is <- getAllInputs contract
+    Right is <- getAllInputs contract Nothing
     sequence_
       [ case playTrace t contract i of
         Error{} -> pure ()


### PR DESCRIPTION
Because we want to use analysis during input application I was forced to a bit update the API and expose possibility to work with preexisting state to generate valid inputs.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [ ] Operables are updated with changes to executable command line options.
    - [ ] Deploy charts updated with changes to operables.
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested
