### PR TITLE
PLT-8805 Embed Validators

### DIFF
--- a/marlowe-cli/cli-test/Language/Marlowe/CLI/Test/Interpret.hs
+++ b/marlowe-cli/cli-test/Language/Marlowe/CLI/Test/Interpret.hs
@@ -8,6 +8,7 @@
 module Language.Marlowe.CLI.Test.Interpret where
 
 import Cardano.Api (IsShelleyBasedEra)
+import Cardano.Api qualified as C
 import Contrib.Control.Concurrent (threadDelay)
 import Control.Monad.Except (MonadError (throwError), catchError)
 import Control.Monad.IO.Class (liftIO)
@@ -15,7 +16,6 @@ import Control.Monad.State.Class (get)
 import Data.Aeson qualified as A
 import Data.Aeson.OneLine qualified as A
 import Data.Text qualified as T
-import Language.Marlowe.CLI.Cardano.Api.PlutusScript (IsPlutusScriptLanguage)
 import Language.Marlowe.CLI.Test.CLI.Interpret qualified as CLI
 import Language.Marlowe.CLI.Test.InterpreterError (testExecutionFailed')
 import Language.Marlowe.CLI.Test.Log (Label (label), logLabeledMsg, logStoreLabeledMsg, throwLabeledError)
@@ -28,10 +28,9 @@ import Language.Marlowe.CLI.Test.Types (
 import Language.Marlowe.CLI.Test.Wallet.Interpret qualified as Wallet
 
 interpret
-  :: forall m lang era
+  :: forall m era
    . (IsShelleyBasedEra era)
-  => (IsPlutusScriptLanguage lang)
-  => (InterpretMonad m lang era)
+  => (InterpretMonad m C.PlutusScriptV2 era)
   => TestOperation
   -> m ()
 interpret (RuntimeOperation ro) = do

--- a/marlowe-cli/cli-test/Language/Marlowe/CLI/Test/Wallet/Interpret.hs
+++ b/marlowe-cli/cli-test/Language/Marlowe/CLI/Test/Wallet/Interpret.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Language.Marlowe.CLI.Test.Wallet.Interpret where
@@ -60,7 +59,6 @@ import Data.Tuple.Extra (uncurry3)
 import Language.Marlowe.CLI.Cardano.Api (toReferenceTxInsScriptsInlineDatumsSupportedInEra, toTxOutDatumInline)
 import Language.Marlowe.CLI.Cardano.Api.Value (lovelaceToPlutusValue, toCurrencySymbol, toPlutusValue)
 import Language.Marlowe.CLI.Cardano.Api.Value qualified as CV
-import Language.Marlowe.CLI.Export (readOpenRoleValidator)
 import Language.Marlowe.CLI.IO (readSigningKey, submitTxBody')
 import Language.Marlowe.CLI.Run (toCardanoPolicyId)
 import Language.Marlowe.CLI.Sync (toPlutusAddress)
@@ -132,6 +130,7 @@ import Language.Marlowe.CLI.Types (
 import Language.Marlowe.CLI.Types qualified as CT
 import Language.Marlowe.Cardano (marloweNetworkFromCaradnoNetworkId)
 import Language.Marlowe.Core.V1.Semantics.Types qualified as M
+import Language.Marlowe.Scripts (openRolesValidator)
 import PlutusLedgerApi.V1 (CurrencySymbol, TokenName)
 import PlutusLedgerApi.V1.Value (valueOf)
 import PlutusLedgerApi.V1.Value qualified as P
@@ -235,8 +234,7 @@ openRoleValidatorAddress
 openRoleValidatorAddress = do
   era <- view eraL
   networkId <- getNetworkId
-  openRoleScript <- readOpenRoleValidator @_ @C.PlutusScriptV2
-  pure $ validatorAddress openRoleScript era networkId NoStakeAddress
+  pure $ validatorAddress openRolesValidator era networkId NoStakeAddress
 
 getNetworkId
   :: forall env st m era

--- a/marlowe-cli/command/Language/Marlowe/CLI/Command/Contract.hs
+++ b/marlowe-cli/command/Language/Marlowe/CLI/Command/Contract.hs
@@ -22,6 +22,8 @@ module Language.Marlowe.CLI.Command.Contract (
 
 import Cardano.Api (NetworkId (..), StakeAddressReference (..))
 import Control.Monad.Except (MonadError, MonadIO)
+import Control.Monad.Reader.Class (MonadReader)
+import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Language.Marlowe.CLI.Command.Parse (
   parseCurrencySymbol,
@@ -36,15 +38,11 @@ import Language.Marlowe.CLI.Export (
   exportMarloweValidator,
   exportRedeemer,
  )
+import Language.Marlowe.CLI.IO (getDefaultCostModel)
 import Language.Marlowe.CLI.Types (CliEnv, CliError)
 import Language.Marlowe.Client (defaultMarloweParams, marloweParams)
-import PlutusLedgerApi.V1 (CurrencySymbol, ProtocolVersion)
-
-import Cardano.Api qualified as C
-import Control.Monad.Reader.Class (MonadReader)
-import Data.Map qualified as Map
-import Language.Marlowe.CLI.IO (getDefaultCostModel)
 import Options.Applicative qualified as O
+import PlutusLedgerApi.V1 (CurrencySymbol, ProtocolVersion)
 
 -- | Marlowe CLI commands and options for exporting data.
 data ContractCommand
@@ -131,7 +129,7 @@ runContractCommand command =
         stake' = fromMaybe NoStakeAddress $ stake command
     case command of
       Export{..} ->
-        exportMarlowe @_ @C.PlutusScriptV2
+        exportMarlowe @_
           marloweParams'
           protocolVersion
           (Map.elems costModel)
@@ -142,9 +140,9 @@ runContractCommand command =
           inputFiles
           outputFile
           printStats
-      ExportAddress{} -> exportMarloweAddress @_ @C.PlutusScriptV2 network' stake'
+      ExportAddress{} -> exportMarloweAddress @_ network' stake'
       ExportValidator{..} ->
-        exportMarloweValidator @_ @C.PlutusScriptV2
+        exportMarloweValidator @_
           protocolVersion
           (Map.elems costModel)
           network'

--- a/marlowe-cli/command/Language/Marlowe/CLI/Command/Role.hs
+++ b/marlowe-cli/command/Language/Marlowe/CLI/Command/Role.hs
@@ -21,7 +21,6 @@ module Language.Marlowe.CLI.Command.Role (
 ) where
 
 import Cardano.Api (NetworkId (..), StakeAddressReference (..))
-import Cardano.Api qualified as C
 import Control.Monad.Except (MonadError, MonadIO)
 import Control.Monad.Reader.Class (MonadReader)
 import Data.Map qualified as Map
@@ -100,9 +99,9 @@ runRoleCommand command =
     let network' = network command
         stake' = fromMaybe NoStakeAddress $ stake command
     case command of
-      ExportAddress{} -> exportRoleAddress @_ @C.PlutusScriptV2 network' stake'
+      ExportAddress{} -> exportRoleAddress @_ network' stake'
       ExportValidator{..} -> do
-        exportRoleValidator @_ @C.PlutusScriptV2
+        exportRoleValidator @_
           protocolVersion
           (Map.elems costModel)
           network'

--- a/marlowe-cli/command/Language/Marlowe/CLI/Command/Transaction.hs
+++ b/marlowe-cli/command/Language/Marlowe/CLI/Command/Transaction.hs
@@ -70,7 +70,6 @@ import Language.Marlowe.CLI.Types (
  )
 
 import Cardano.Api qualified as Api (Value)
-import Cardano.Api qualified as C
 import Control.Monad.Reader.Class (MonadReader)
 import Data.Time.Units (Second)
 import Options.Applicative qualified as O
@@ -357,7 +356,7 @@ runTransactionCommand command =
           (fromMaybe 0 submitTimeout)
           >>= printTxId
       Publish{..} ->
-        buildPublishing @_ @C.PlutusScriptV2
+        buildPublishing @_
           connection
           signingKeyFile
           expires
@@ -367,7 +366,7 @@ runTransactionCommand command =
           submitTimeout
           (PrintStats True)
       FindPublished{..} ->
-        findPublished @_ @C.PlutusScriptV2
+        findPublished @_
           (QueryNode connection)
           strategy
 

--- a/marlowe-cli/marlowe-cli.cabal
+++ b/marlowe-cli/marlowe-cli.cabal
@@ -111,7 +111,6 @@ library
     , directory
     , errors
     , extra
-    , filepath
     , indexed-traversable
     , marlowe-cardano
     , megaparsec

--- a/marlowe-cli/src/Language/Marlowe/CLI/Analyze.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Analyze.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -50,7 +49,7 @@ import Language.Marlowe.Analysis.Safety.Transaction (
   unitAnnotator,
  )
 import Language.Marlowe.Analysis.Safety.Types (Transaction (..))
-import Language.Marlowe.CLI.Cardano.Api.PlutusScript (IsPlutusScriptLanguage (..), toScriptLanguageInEra)
+import Language.Marlowe.CLI.Cardano.Api.PlutusScript (toScriptLanguageInEra)
 import Language.Marlowe.CLI.IO (decodeFileStrict, liftCli, liftCliIO, liftCliMaybe)
 import Language.Marlowe.CLI.Run (marloweAddressFromCardanoAddress, toCardanoAddressInEra, toCardanoValue)
 import Language.Marlowe.CLI.Types (
@@ -107,6 +106,7 @@ import Language.Marlowe.Scripts.Types (marloweTxInputsFromInputs)
 
 import Cardano.Api (bundleProtocolParams, unsafeHashableScriptData)
 import Cardano.Api qualified as Api
+import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as Api
 import Cardano.Ledger.Credential qualified as Shelley
 import Control.Monad.Writer (WriterT (..))
@@ -207,7 +207,7 @@ data ContractInstance lang era = ContractInstance
 analyzeImpl
   :: forall m lang era
    . (Api.IsShelleyBasedEra era)
-  => (IsPlutusScriptLanguage lang)
+  => (C.IsPlutusScriptLanguage lang)
   => (MonadError CliError m)
   => (MonadIO m)
   => Api.ScriptDataSupportedInEra era
@@ -558,7 +558,7 @@ calcMarloweTxExBudgets protocol ContractInstance{..} transactionsPath lockedRole
 checkTransactionSizes
   :: forall lang era m
    . (Api.IsShelleyBasedEra era)
-  => (IsPlutusScriptLanguage lang)
+  => (C.IsPlutusScriptLanguage lang)
   => (MonadError CliError m)
   => (MonadIO m)
   => Api.ScriptDataSupportedInEra era
@@ -591,7 +591,7 @@ checkTransactionSizes era protocol ci transactions verbose =
 checkTransactionSize
   :: forall lang era m
    . (Api.IsShelleyBasedEra era)
-  => (IsPlutusScriptLanguage lang)
+  => (C.IsPlutusScriptLanguage lang)
   => (MonadError CliError m)
   => (MonadIO m)
   => Api.ScriptDataSupportedInEra era
@@ -628,7 +628,7 @@ checkTransactionSize era protocol ContractInstance{..} (Transaction marloweState
               . Api.ScriptWitness Api.ScriptWitnessForSpending
               $ Api.PlutusScriptWitness
                 scriptInEra
-                (plutusScriptVersion @lang)
+                C.plutusScriptVersion
                 (validatorInfoScriptOrReference ciSemanticsValidator)
                 (Api.ScriptDatumForTxIn . unsafeHashableScriptData . Api.fromPlutusData $ P.toData inDatum)
                 (unsafeHashableScriptData . Api.fromPlutusData $ P.toData redeemer)

--- a/marlowe-cli/src/Language/Marlowe/CLI/Cardano/Api/PlutusScript.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Cardano/Api/PlutusScript.hs
@@ -5,16 +5,14 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- | Additional conversion functions for `PlutusScript` plus a copy of not exposed `IsPlutusScriptLanguage` class.
+-- | Additional conversion functions for `PlutusScript`
 module Language.Marlowe.CLI.Cardano.Api.PlutusScript (
-  IsPlutusScriptLanguage (..),
   toScript,
   toScriptLanguageInEra,
   withPlutusScriptVersion,
 ) where
 
 import Cardano.Api (
-  IsScriptLanguage,
   PlutusScriptV1,
   PlutusScriptV2,
   PlutusScriptVersion (..),
@@ -24,30 +22,20 @@ import Cardano.Api qualified as C
 import Cardano.Api.Shelley (PlutusScript)
 import Language.Marlowe.CLI.Orphans ()
 
-withPlutusScriptVersion :: PlutusScriptVersion lang -> ((IsPlutusScriptLanguage lang) => a) -> a
+withPlutusScriptVersion :: PlutusScriptVersion lang -> ((C.IsPlutusScriptLanguage lang) => a) -> a
 withPlutusScriptVersion PlutusScriptV1 = id
 withPlutusScriptVersion PlutusScriptV2 = id
--- FIXME update with next cardano-api
-withPlutusScriptVersion PlutusScriptV3 = const $ error "unsupported until cardano-api exposes PlutusScriptV3"
+withPlutusScriptVersion PlutusScriptV3 = id
 
-class (IsScriptLanguage lang) => IsPlutusScriptLanguage lang where
-  plutusScriptVersion :: PlutusScriptVersion lang
-
-instance IsPlutusScriptLanguage PlutusScriptV1 where
-  plutusScriptVersion = PlutusScriptV1
-
-instance IsPlutusScriptLanguage PlutusScriptV2 where
-  plutusScriptVersion = PlutusScriptV2
-
-toScript :: forall lang. (IsPlutusScriptLanguage lang) => PlutusScript lang -> Script lang
-toScript = PlutusScript (plutusScriptVersion :: PlutusScriptVersion lang)
+toScript :: forall lang. (C.IsPlutusScriptLanguage lang) => PlutusScript lang -> Script lang
+toScript = PlutusScript (C.plutusScriptVersion @lang)
 
 toScriptLanguageInEra
   :: forall era lang
-   . (IsPlutusScriptLanguage lang)
+   . (C.IsPlutusScriptLanguage lang)
   => C.ScriptDataSupportedInEra era
   -> Maybe (C.ScriptLanguageInEra lang era)
-toScriptLanguageInEra = case plutusScriptVersion @lang of
+toScriptLanguageInEra = case C.plutusScriptVersion @lang of
   PlutusScriptV1 -> Just . toPlutusScriptV1LanguageInEra
   PlutusScriptV2 -> toPlutusScriptV2LanguageInEra
   PlutusScriptV3 -> const Nothing

--- a/marlowe-cli/src/Language/Marlowe/CLI/Export.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Export.hs
@@ -19,9 +19,6 @@ module Language.Marlowe.CLI.Export (
   buildAddress,
   buildValidatorInfo,
   exportAddress,
-  readMarloweValidator,
-  readRolePayoutValidator,
-  readOpenRoleValidator,
 
   -- * Contract and Transaction
   buildMarlowe,
@@ -64,11 +61,8 @@ module Language.Marlowe.CLI.Export (
 
 import Cardano.Api (
   AddressInEra,
-  AsType (..),
-  File (..),
   NetworkId,
   PaymentCredential (..),
-  PlutusScriptVersion (..),
   Script (PlutusScript),
   ScriptDataJsonSchema (..),
   ScriptDataSupportedInEra (..),
@@ -77,12 +71,11 @@ import Cardano.Api (
   hashScript,
   hashScriptDataBytes,
   makeShelleyAddressInEra,
-  readFileTextEnvelope,
   scriptDataToJson,
   serialiseAddress,
   unsafeHashableScriptData,
  )
-import Cardano.Api.Shelley (PlutusScript (..), fromPlutusData)
+import Cardano.Api.Shelley (fromPlutusData)
 import Control.Monad (join, when)
 import Control.Monad.Except (MonadError, MonadIO, liftEither, liftIO)
 import Data.Aeson (encode)
@@ -126,17 +119,15 @@ import Codec.Serialise (serialise)
 import Control.Monad.Reader (MonadReader)
 import Data.ByteString.Short qualified as SBS
 import Language.Marlowe.CLI.Cardano.Api qualified as C
-import Language.Marlowe.CLI.Cardano.Api.PlutusScript (IsPlutusScriptLanguage (plutusScriptVersion))
-import Language.Marlowe.CLI.Cardano.Api.PlutusScript qualified as PlutusScript
+import Language.Marlowe.CLI.Cardano.Api.PlutusScript (withPlutusScriptVersion)
+import Language.Marlowe.Scripts (marloweValidator, openRolesValidator, payoutValidator)
 import Language.Marlowe.Scripts.Types (marloweTxInputsFromInputs)
-import Paths_marlowe_cardano (getDataFileName)
 import PlutusLedgerApi.Common (ProtocolVersion)
 import PlutusLedgerApi.V1 (DatumHash (..), toBuiltin, toData)
-import System.FilePath ((</>))
 
 -- | Build comprehensive information about a Marlowe contract and transaction.
 buildMarlowe
-  :: (MonadIO m, IsPlutusScriptLanguage lang)
+  :: (MonadIO m)
   => MarloweParams
   -> ScriptDataSupportedInEra era
   -> ProtocolVersion
@@ -152,11 +143,10 @@ buildMarlowe
   -- ^ The contract's state.
   -> [Input]
   -- ^ The contract's input,
-  -> m (Either CliError (MarloweInfo lang era))
+  -> m (Either CliError (MarloweInfo CS.PlutusScriptV2 era))
   -- ^ The contract and transaction information, or an error message.
 buildMarlowe marloweParams era protocolVersion costModel network stake contract state inputs =
   do
-    marloweValidator <- readMarloweValidator
     pure do
       miValidatorInfo <-
         validatorInfo' marloweValidator Nothing era protocolVersion costModel network stake
@@ -166,8 +156,8 @@ buildMarlowe marloweParams era protocolVersion costModel network stake contract 
 
 -- | Export to a file the comprehensive information about a Marlowe contract and transaction.
 exportMarlowe
-  :: forall m lang era
-   . (MonadError CliError m, IsPlutusScriptLanguage lang, MonadIO m, MonadReader (CliEnv era) m)
+  :: forall m era
+   . (MonadError CliError m, MonadIO m, MonadReader (CliEnv era) m)
   => MarloweParams
   -- ^ The Marlowe contract parameters.
   -> ProtocolVersion
@@ -197,7 +187,7 @@ exportMarlowe marloweParams protocolVersion costModel network stake contractFile
     marloweInfo@MarloweInfo{..} <-
       liftEither
         =<< join
-          (asksEra \era -> buildMarlowe @m @lang marloweParams era protocolVersion costModel network stake contract state inputs)
+          (asksEra \era -> buildMarlowe @m marloweParams era protocolVersion costModel network stake contract state inputs)
     let ValidatorInfo{..} = miValidatorInfo
         DatumInfo{..} = miDatumInfo
         RedeemerInfo{..} = miRedeemerInfo
@@ -215,27 +205,10 @@ exportMarlowe marloweParams protocolVersion costModel network stake contractFile
         hPutStrLn stderr $ "Redeemer size: " <> show riSize
         hPutStrLn stderr $ "Total size: " <> show (viSize + diSize + riSize)
 
-readMarloweValidator :: (MonadIO m, IsPlutusScriptLanguage lang) => m (PlutusScript lang)
-readMarloweValidator = readValidator "marlowe-semantics.plutus"
-
-readRolePayoutValidator :: (MonadIO m, IsPlutusScriptLanguage lang) => m (PlutusScript lang)
-readRolePayoutValidator = readValidator "marlowe-rolepayout.plutus"
-
-readOpenRoleValidator :: (MonadIO m, IsPlutusScriptLanguage lang) => m (PlutusScript lang)
-readOpenRoleValidator = readValidator "open-role.plutus"
-
-readValidator :: forall lang m. (MonadIO m, IsPlutusScriptLanguage lang) => FilePath -> m (PlutusScript lang)
-readValidator scriptFile = liftIO do
-  path <- getDataFileName $ "scripts" </> scriptFile
-  case plutusScriptVersion @lang of
-    PlutusScriptV1 -> either (fail . show) pure =<< readFileTextEnvelope (AsPlutusScript AsPlutusScriptV1) (File path)
-    PlutusScriptV2 -> either (fail . show) pure =<< readFileTextEnvelope (AsPlutusScript AsPlutusScriptV2) (File path)
-    PlutusScriptV3 -> either (fail . show) pure =<< readFileTextEnvelope (AsPlutusScript AsPlutusScriptV3) (File path)
-
 -- | Print information about a Marlowe contract and transaction.
 printMarlowe
   :: forall m lang era
-   . (MonadError CliError m, MonadIO m, IsPlutusScriptLanguage lang)
+   . (MonadError CliError m, MonadIO m, CS.IsPlutusScriptLanguage lang)
   => MarloweParams
   -- ^ The Marlowe contract parameters.
   -> ScriptDataSupportedInEra era
@@ -257,7 +230,7 @@ printMarlowe
 printMarlowe marloweParams era protocolVersion costModel network stake contract state inputs =
   do
     MarloweInfo{..} <-
-      liftEither =<< buildMarlowe @_ @lang marloweParams era protocolVersion costModel network stake contract state inputs
+      liftEither =<< buildMarlowe @_ marloweParams era protocolVersion costModel network stake contract state inputs
     let ValidatorInfo{..} = miValidatorInfo
         DatumInfo{..} = miDatumInfo
         RedeemerInfo{..} = miRedeemerInfo
@@ -271,10 +244,9 @@ printMarlowe marloweParams era protocolVersion costModel network stake contract 
         putStrLn $ "Inputs: " <> show inputs
         putStrLn ""
         putStrLn $
-          "Validator: " <> LBS8.unpack case plutusScriptVersion @lang of
-            PlutusScriptV1 -> encode $ C.serialiseToTextEnvelope Nothing viScript
-            PlutusScriptV2 -> encode $ C.serialiseToTextEnvelope Nothing viScript
-            PlutusScriptV3 -> encode $ C.serialiseToTextEnvelope Nothing viScript
+          "Validator: "
+            <> LBS8.unpack
+              (withPlutusScriptVersion (CS.plutusScriptVersion @lang) $ encode $ C.serialiseToTextEnvelope Nothing viScript)
         putStrLn ""
         putStrLn $ "Validator address: " <> T.unpack (withCardanoEra era $ serialiseAddress viAddress)
         putStrLn ""
@@ -303,8 +275,9 @@ printMarlowe marloweParams era protocolVersion costModel network stake contract 
 
 -- | Compute the address of a validator.
 buildAddress
-  :: forall era
-   . SBS.ShortByteString
+  :: forall lang era
+   . (CS.IsPlutusScriptLanguage lang)
+  => CS.PlutusScript lang
   -- ^ The validator.
   -> ScriptDataSupportedInEra era
   -> NetworkId
@@ -314,7 +287,7 @@ buildAddress
   -> AddressInEra era
   -- ^ The script address.
 buildAddress script era network stake =
-  let viScript = PlutusScript PlutusScriptV2 (PlutusScriptSerialised script)
+  let viScript = PlutusScript CS.plutusScriptVersion script
    in withShelleyBasedEra era $
         makeShelleyAddressInEra
           network
@@ -323,8 +296,8 @@ buildAddress script era network stake =
 
 -- | Compute the address of a Marlowe contract.
 buildMarloweAddress
-  :: forall m lang era
-   . (MonadIO m, IsPlutusScriptLanguage lang)
+  :: forall m era
+   . (MonadIO m)
   => ScriptDataSupportedInEra era
   -> NetworkId
   -- ^ The network ID.
@@ -333,15 +306,13 @@ buildMarloweAddress
   -> m (AddressInEra era)
   -- ^ The script address.
 buildMarloweAddress era network stake = do
-  PlutusScriptSerialised marloweValidator <- readMarloweValidator @_ @lang
   pure $ buildAddress marloweValidator era network stake
 
 -- | Print the address of a validator.
 exportAddress
-  :: forall era m
-   . (MonadIO m)
-  => (MonadReader (CliEnv era) m)
-  => SBS.ShortByteString
+  :: forall era lang m
+   . (MonadIO m, MonadReader (CliEnv era) m, CS.IsPlutusScriptLanguage lang)
+  => CS.PlutusScript lang
   -- ^ The validator.
   -> NetworkId
   -- ^ The network ID.
@@ -356,8 +327,8 @@ exportAddress validator network stake = do
 
 -- | Print the address of a Marlowe contract.
 exportMarloweAddress
-  :: forall m lang era
-   . (MonadIO m, MonadReader (CliEnv era) m, IsPlutusScriptLanguage lang)
+  :: forall m era
+   . (MonadIO m, MonadReader (CliEnv era) m)
   => NetworkId
   -- ^ The network ID.
   -> StakeAddressReference
@@ -365,11 +336,10 @@ exportMarloweAddress
   -> m ()
   -- ^ Action to print the script address.
 exportMarloweAddress network stake = do
-  PlutusScriptSerialised marloweValidator <- readMarloweValidator @_ @lang
   exportAddress marloweValidator network stake
 
 buildValidatorInfo
-  :: (MonadReader (CliEnv era) m, MonadIO m, MonadError CliError m, IsPlutusScriptLanguage lang)
+  :: (MonadReader (CliEnv era) m, MonadIO m, MonadError CliError m, CS.IsPlutusScriptLanguage lang)
   => QueryExecutionContext era
   -> CS.PlutusScript lang
   -> Maybe C.TxIn
@@ -386,9 +356,9 @@ buildValidatorInfo queryCtx plutusScript txIn stake = do
 -- | Export to a file the validator information.
 exportValidatorImpl
   :: forall lang era m
-   . (MonadError CliError m, MonadReader (CliEnv era) m, IsPlutusScriptLanguage lang)
+   . (MonadError CliError m, MonadReader (CliEnv era) m, CS.IsPlutusScriptLanguage lang)
   => (MonadIO m)
-  => SBS.ShortByteString
+  => CS.PlutusScript lang
   -> ProtocolVersion
   -> [Integer]
   -- ^ The cost model parameters.
@@ -404,12 +374,11 @@ exportValidatorImpl
   -- ^ Whether to print statistics about the validator.
   -> m ()
   -- ^ Action to export the validator information to a file.
-exportValidatorImpl validator protocolVersion costModel network stake outputFile printHash printStats =
+exportValidatorImpl plutusScript protocolVersion costModel network stake outputFile printHash printStats =
   do
     era <- askEra
-    let plutusScript = PlutusScriptSerialised @lang validator
     ValidatorInfo{..} <- validatorInfo' plutusScript Nothing era protocolVersion costModel network stake
-    maybeWriteTextEnvelope outputFile $ PlutusScript.toScript plutusScript
+    maybeWriteTextEnvelope outputFile $ C.PlutusScript C.plutusScriptVersion plutusScript
     doWithCardanoEra $
       liftIO $
         do
@@ -431,7 +400,7 @@ exportValidatorImpl validator protocolVersion costModel network stake outputFile
 
 -- | Current Marlowe validator information.
 marloweValidatorInfo
-  :: (MonadIO m, IsPlutusScriptLanguage lang)
+  :: (MonadIO m)
   => ScriptDataSupportedInEra era
   -- ^ The era to build he validator in.
   -> ProtocolVersion
@@ -441,16 +410,15 @@ marloweValidatorInfo
   -- ^ The network ID.
   -> StakeAddressReference
   -- ^ The stake address.
-  -> m (Either CliError (ValidatorInfo lang era))
+  -> m (Either CliError (ValidatorInfo CS.PlutusScriptV2 era))
   -- ^ The validator information, or an error message.
 marloweValidatorInfo script prot costModel network stake = do
-  marloweValidator <- readMarloweValidator
   pure $ validatorInfo' marloweValidator Nothing script prot costModel network stake
 
 -- | Export to a file the validator information about a Marlowe contract.
 exportMarloweValidator
-  :: forall era lang m
-   . (MonadError CliError m, MonadReader (CliEnv era) m, IsPlutusScriptLanguage lang)
+  :: forall era m
+   . (MonadError CliError m, MonadReader (CliEnv era) m)
   => (MonadIO m)
   => ProtocolVersion
   -> [Integer]
@@ -468,8 +436,7 @@ exportMarloweValidator
   -> m ()
   -- ^ Action to export the validator information to a file.
 exportMarloweValidator prot costModel network stake out printHash printStats = do
-  PlutusScriptSerialised marloweValidatorBytes <- readMarloweValidator @_ @lang
-  exportValidatorImpl @lang marloweValidatorBytes prot costModel network stake out printHash printStats
+  exportValidatorImpl marloweValidator prot costModel network stake out printHash printStats
 
 -- | Build the datum information about a Marlowe transaction.
 buildDatumImpl
@@ -619,8 +586,8 @@ exportRedeemer inputFiles outputFile printStats =
 
 -- -- | Compute the role address of a Marlowe contract.
 buildRoleAddress
-  :: forall era lang m
-   . (MonadIO m, IsPlutusScriptLanguage lang)
+  :: forall era m
+   . (MonadIO m)
   => ScriptDataSupportedInEra era
   -> NetworkId
   -- ^ The network ID.
@@ -629,13 +596,12 @@ buildRoleAddress
   -> m (AddressInEra era)
   -- ^ The script address.
 buildRoleAddress script network stake = do
-  PlutusScriptSerialised rolePayoutValidatorBytes <- readRolePayoutValidator @_ @lang
-  pure $ buildAddress rolePayoutValidatorBytes script network stake
+  pure $ buildAddress payoutValidator script network stake
 
 -- | Print the role address of a Marlowe contract.
 exportRoleAddress
-  :: forall era lang m
-   . (MonadIO m, MonadReader (CliEnv era) m, IsPlutusScriptLanguage lang)
+  :: forall era m
+   . (MonadIO m, MonadReader (CliEnv era) m)
   => NetworkId
   -- ^ The network ID.
   -> StakeAddressReference
@@ -643,12 +609,11 @@ exportRoleAddress
   -> m ()
   -- ^ Action to print the script address.
 exportRoleAddress network stake = do
-  PlutusScriptSerialised rolePayoutValidatorBytes <- readRolePayoutValidator @_ @lang
-  exportAddress rolePayoutValidatorBytes network stake
+  exportAddress payoutValidator network stake
 
 -- | Current Marlowe validator information.
 payoutValidatorInfo
-  :: (MonadIO m, IsPlutusScriptLanguage lang)
+  :: (MonadIO m)
   => ScriptDataSupportedInEra era
   -- ^ The era to build he validator in.
   -> ProtocolVersion
@@ -658,15 +623,14 @@ payoutValidatorInfo
   -- ^ The network ID.
   -> StakeAddressReference
   -- ^ The stake address.
-  -> m (Either CliError (ValidatorInfo lang era))
+  -> m (Either CliError (ValidatorInfo CS.PlutusScriptV2 era))
   -- ^ The validator information, or an error message.
 payoutValidatorInfo script prot cost network stake = do
-  roleValidator <- readRolePayoutValidator
-  pure $ validatorInfo' roleValidator Nothing script prot cost network stake
+  pure $ validatorInfo' payoutValidator Nothing script prot cost network stake
 
 -- | Open role validator
 openRoleValidatorInfo
-  :: (MonadIO m, IsPlutusScriptLanguage lang)
+  :: (MonadIO m)
   => ScriptDataSupportedInEra era
   -- ^ The era to build he validator in.
   -> ProtocolVersion
@@ -676,16 +640,15 @@ openRoleValidatorInfo
   -- ^ The network ID.
   -> StakeAddressReference
   -- ^ The stake address.
-  -> m (Either CliError (ValidatorInfo lang era))
+  -> m (Either CliError (ValidatorInfo CS.PlutusScriptV2 era))
   -- ^ The validator information, or an error message.
 openRoleValidatorInfo script prot cost network stake = do
-  validator <- readOpenRoleValidator
-  pure $ validatorInfo' validator Nothing script prot cost network stake
+  pure $ validatorInfo' openRolesValidator Nothing script prot cost network stake
 
 -- | Export to a file the role validator information about a Marlowe contract.
 exportRoleValidator
-  :: forall era lang m
-   . (MonadError CliError m, MonadReader (CliEnv era) m, IsPlutusScriptLanguage lang)
+  :: forall era m
+   . (MonadError CliError m, MonadReader (CliEnv era) m)
   => (MonadIO m)
   => ProtocolVersion
   -- ^ The currency symbol for Marlowe contract roles.
@@ -704,8 +667,7 @@ exportRoleValidator
   -> m ()
   -- ^ Action to export the validator information to a file.
 exportRoleValidator prot cost network stake out printHash printStats = do
-  PlutusScriptSerialised roleValidator <- readRolePayoutValidator @_ @lang
-  exportValidatorImpl @lang roleValidator prot cost network stake out printHash printStats
+  exportValidatorImpl payoutValidator prot cost network stake out printHash printStats
 
 -- | Build the role datum information about a Marlowe transaction.
 buildRoleDatum

--- a/marlowe-cli/src/Language/Marlowe/CLI/Run.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Run.hs
@@ -104,7 +104,6 @@ import Data.Tuple.Extra (uncurry3)
 import Data.Type.Equality (type (:~:) (..))
 import Language.Marlowe.CLI.Cardano.Api (adjustMinimumUTxO, toTxOutDatumInTx)
 import Language.Marlowe.CLI.Cardano.Api.Address (toShelleyStakeReference)
-import Language.Marlowe.CLI.Cardano.Api.PlutusScript (IsPlutusScriptLanguage (plutusScriptVersion))
 import Language.Marlowe.CLI.Export (
   buildMarloweDatum,
   buildRedeemer,
@@ -328,7 +327,7 @@ initializeTransaction connection marloweParams slotConfig protocolVersion costMo
           printStats
     maybeWriteJson outputFile $
       SomeMarloweTransaction
-        (plutusScriptVersion :: PlutusScriptVersion MarlowePlutusVersion)
+        (C.plutusScriptVersion :: PlutusScriptVersion MarlowePlutusVersion)
         era
         marloweTransaction
 
@@ -339,7 +338,7 @@ initializeTransactionImpl
   => (MonadIO m)
   => (C.IsShelleyBasedEra era)
   => (MonadReader (CliEnv era) m)
-  => (IsPlutusScriptLanguage lang)
+  => (C.IsPlutusScriptLanguage lang)
   => MarloweParams
   -- ^ The Marlowe contract parameters.
   -> SlotConfig
@@ -362,7 +361,7 @@ initializeTransactionImpl
   -- ^ Whether to print statistics about the validator.
   -> m (MarloweTransaction lang era)
   -- ^ Action to return a MarloweTransaction
-initializeTransactionImpl marloweParams mtSlotConfig protocolVersion costModelParams network stake mtContract mtState refs merkleize printStats = case plutusScriptVersion @lang of
+initializeTransactionImpl marloweParams mtSlotConfig protocolVersion costModelParams network stake mtContract mtState refs merkleize printStats = case C.plutusScriptVersion @lang of
   PlutusScriptV1 -> throwError "Plutus Script V1 not supported"
   PlutusScriptV3 -> throwError "Plutus Script V3 not supported"
   PlutusScriptV2 -> do
@@ -639,12 +638,12 @@ runTransaction connection marloweInBundle marloweOutFile inputs outputs changeAd
     SomeMarloweTransaction _ era' marloweOut' <- decodeFileStrict marloweOutFile
     era <- askEra @era
     signingKeys <- mapM readSigningKey signingKeyFiles
-    let go :: forall lang. (IsPlutusScriptLanguage lang) => MarloweTransaction lang era -> m TxId
+    let go :: forall lang. (C.IsPlutusScriptLanguage lang) => MarloweTransaction lang era -> m TxId
         go marloweOut'' = do
           marloweInBundle' <- case marloweInBundle of
             Nothing -> pure Nothing
             Just (marloweInFile, marloweTxIn, collateralTxIn) -> do
-              marloweIn <- readMarloweTransactionFile (plutusScriptVersion :: PlutusScriptVersion lang) marloweInFile
+              marloweIn <- readMarloweTransactionFile (C.plutusScriptVersion :: PlutusScriptVersion lang) marloweInFile
               pure $ Just (marloweIn, marloweTxIn, collateralTxIn)
 
           (body :: TxBody era) <-
@@ -682,7 +681,7 @@ testSameEra = \case
 runTransactionImpl
   :: forall era lang m
    . (MonadError CliError m, CS.IsCardanoEra era)
-  => (IsPlutusScriptLanguage lang)
+  => (C.IsPlutusScriptLanguage lang)
   => (MonadIO m)
   => (MonadReader (CliEnv era) m)
   => TxBuildupContext era
@@ -923,12 +922,12 @@ autoRunTransaction connection marloweInBundle marloweOutFile changeAddress signi
     SomeMarloweTransaction _ era' marloweOut' <- decodeFileStrict marloweOutFile
     era <- askEra @era
     signingKeys <- mapM readSigningKey signingKeyFiles
-    let go :: forall lang. (IsPlutusScriptLanguage lang) => MarloweTransaction lang era -> m TxId
+    let go :: forall lang. (C.IsPlutusScriptLanguage lang) => MarloweTransaction lang era -> m TxId
         go marloweOut'' = do
           marloweInBundle' <- case marloweInBundle of
             Nothing -> pure Nothing
             Just (marloweInFile, marloweTxIn) -> do
-              marloweIn <- readMarloweTransactionFile (plutusScriptVersion :: PlutusScriptVersion lang) marloweInFile
+              marloweIn <- readMarloweTransactionFile (C.plutusScriptVersion :: PlutusScriptVersion lang) marloweInFile
               pure $ Just (marloweIn, marloweTxIn)
 
           (body :: TxBody era) <-
@@ -954,7 +953,7 @@ autoRunTransaction connection marloweInBundle marloweOutFile changeAddress signi
 autoRunTransactionImpl
   :: forall era lang m
    . (MonadError CliError m, CS.IsCardanoEra era)
-  => (IsPlutusScriptLanguage lang)
+  => (C.IsPlutusScriptLanguage lang)
   => (MonadIO m)
   => (MonadReader (CliEnv era) m)
   => TxBuildupContext era
@@ -1196,7 +1195,7 @@ autoWithdrawFunds connection marloweOutFile roleName changeAddress signingKeyFil
     era <- askEra
     -- Read the Marlowe transaction information that was used to populate the role-payout address.
     SomeMarloweTransaction _ era' marloweOut <- decodeFileStrict marloweOutFile
-    let go :: forall lang. (IsPlutusScriptLanguage lang) => MarloweTransaction lang era -> m TxId
+    let go :: forall lang. (C.IsPlutusScriptLanguage lang) => MarloweTransaction lang era -> m TxId
         go marloweOut' = do
           -- Read the signing keys.
           signingKeys <- mapM readSigningKey signingKeyFiles
@@ -1235,7 +1234,7 @@ autoWithdrawFundsImpl
    . (MonadError CliError m, CS.IsCardanoEra era)
   => (MonadReader (CliEnv era) m)
   => (MonadIO m)
-  => (IsPlutusScriptLanguage lang)
+  => (C.IsPlutusScriptLanguage lang)
   => TxBuildupContext era
   -- ^ The connection info for the local node.
   -> Token

--- a/marlowe-cli/src/Language/Marlowe/CLI/Sync.hs
+++ b/marlowe-cli/src/Language/Marlowe/CLI/Sync.hs
@@ -63,9 +63,7 @@ import Cardano.Api (
   LocalNodeClientProtocols (..),
   LocalNodeConnectInfo (..),
   PaymentCredential (..),
-  PlutusScriptVersion (..),
   PolicyId,
-  Script (..),
   ScriptHash,
   SerialiseAsRawBytes (..),
   ShelleyBasedEra (..),
@@ -131,7 +129,7 @@ import Data.List.Extra (mconcatMap)
 import Data.Map.Strict qualified as M (elems, filter, null, toList)
 import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Data.Set qualified as S (singleton, toList)
-import Language.Marlowe.CLI.Export (readMarloweValidator, readRolePayoutValidator)
+import Language.Marlowe.CLI.Cardano.Api.PlutusScript (toScript)
 import Language.Marlowe.CLI.Sync.Types (
   MarloweAddress (..),
   MarloweEvent (..),
@@ -143,6 +141,7 @@ import Language.Marlowe.CLI.Transaction (querySlotConfig)
 import Language.Marlowe.CLI.Types (CliEnv, CliError (..))
 import Language.Marlowe.Client (marloweParams)
 import Language.Marlowe.Core.V1.Semantics.Types (Contract (..), Input (..), TimeInterval)
+import Language.Marlowe.Scripts (marloweValidator, payoutValidator)
 import Language.Marlowe.Scripts.Types (MarloweInput, MarloweTxInput (..))
 import Language.Marlowe.Util (dataHash)
 import Plutus.V1.Ledger.Slot (Slot (..))
@@ -527,12 +526,10 @@ extractMarlowe
   -> IO ()
   -- ^ Action to output potential Marlowe transactions.
 extractMarlowe _ printer slotConfig includeAll meBlock tx = do
-  marloweValidator <- readMarloweValidator
-  payoutValidator <- readRolePayoutValidator
   mapM_ printer $
     classifyMarlowe
-      (hashScript $ PlutusScript PlutusScriptV2 marloweValidator)
-      (hashScript $ PlutusScript PlutusScriptV2 payoutValidator)
+      (hashScript $ toScript marloweValidator)
+      (hashScript $ toScript payoutValidator)
       slotConfig
       includeAll
       meBlock

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -862,7 +862,6 @@ test-suite marlowe-runtime-test
     , cardano-api-gen ^>=8.1
     , containers ^>=0.6.5
     , errors >=2.3 && <3
-    , filepath ^>=1.4
     , hasql >=1.6 && <2
     , hedgehog-quickcheck ^>=0.1
     , hspec

--- a/marlowe/changelog.d/20240103_105823_jhbertra_plt_8805_embed_validators.md
+++ b/marlowe/changelog.d/20240103_105823_jhbertra_plt_8805_embed_validators.md
@@ -1,0 +1,3 @@
+### Added
+
+- Current validator bytes are now embedded in compiled library.

--- a/marlowe/marlowe-cardano.cabal
+++ b/marlowe/marlowe-cardano.cabal
@@ -78,6 +78,7 @@ library
     , range ==0.3.0.2
     , sbv ^>=9.2
     , scientific ^>=0.3.7
+    , template-haskell
     , text ^>=1.2
     , time >=1.9.3 && <2
     , transformers ^>=0.5.6
@@ -109,6 +110,7 @@ library
     Language.Marlowe.FindInputs
     Language.Marlowe.ParserUtil
     Language.Marlowe.Pretty
+    Language.Marlowe.Scripts
     Language.Marlowe.Scripts.Types
     Language.Marlowe.Util
     Paths_marlowe_cardano

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Language.Marlowe.Scripts where
+
+import Cardano.Api (PlutusScript, PlutusScriptV2)
+import Language.Marlowe.Scripts.Types (readPlutusScript)
+
+marloweValidator :: PlutusScript PlutusScriptV2
+marloweValidator = $(readPlutusScript "marlowe/scripts/marlowe-semantics.plutus")
+
+payoutValidator :: PlutusScript PlutusScriptV2
+payoutValidator = $(readPlutusScript "marlowe/scripts/marlowe-rolepayout.plutus")
+
+openRolesValidator :: PlutusScript PlutusScriptV2
+openRolesValidator = $(readPlutusScript "marlowe/scripts/open-role.plutus")

--- a/marlowe/src/Language/Marlowe/Scripts.hs
+++ b/marlowe/src/Language/Marlowe/Scripts.hs
@@ -7,10 +7,10 @@ import Cardano.Api (PlutusScript, PlutusScriptV2)
 import Language.Marlowe.Scripts.Types (readPlutusScript)
 
 marloweValidator :: PlutusScript PlutusScriptV2
-marloweValidator = $(readPlutusScript "marlowe/scripts/marlowe-semantics.plutus")
+marloweValidator = $(readPlutusScript "scripts/marlowe-semantics.plutus")
 
 payoutValidator :: PlutusScript PlutusScriptV2
-payoutValidator = $(readPlutusScript "marlowe/scripts/marlowe-rolepayout.plutus")
+payoutValidator = $(readPlutusScript "scripts/marlowe-rolepayout.plutus")
 
 openRolesValidator :: PlutusScript PlutusScriptV2
-openRolesValidator = $(readPlutusScript "marlowe/scripts/open-role.plutus")
+openRolesValidator = $(readPlutusScript "scripts/open-role.plutus")

--- a/marlowe/src/Language/Marlowe/Scripts/Types.hs
+++ b/marlowe/src/Language/Marlowe/Scripts/Types.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | Marlowe validators.
@@ -20,13 +23,25 @@ module Language.Marlowe.Scripts.Types (
 
   -- * Utilities
   marloweTxInputsFromInputs,
+
+  -- * TH utilities
+  readPlutusScript,
 ) where
 
+import Cardano.Api
+import Cardano.Api.Shelley (PlutusScript (..))
+import Data.ByteString.Char8 qualified as B8
+import Data.ByteString.Internal qualified as B
+import Data.ByteString.Short qualified as SBS
+import Data.ByteString.Unsafe qualified as BS
 import GHC.Generics (Generic)
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax (qAddDependentFile)
 import Language.Marlowe.Core.V1.Semantics.Types as Semantics
 import Language.Marlowe.Pretty (Pretty (..))
 import PlutusTx (makeIsDataIndexed, makeLift)
 import PlutusTx.Prelude as PlutusTxPrelude hiding (traceError, traceIfFalse)
+import System.IO.Unsafe (unsafePerformIO)
 import Prelude qualified as Haskell
 
 -- | Input to a Marlowe transaction.
@@ -51,3 +66,34 @@ marloweTxInputsFromInputs = fmap marloweTxInputFromInput
 -- Lifting data types to Plutus Core
 makeLift ''MarloweTxInput
 makeIsDataIndexed ''MarloweTxInput [('Input, 0), ('MerkleizedTxInput, 1)]
+
+readPlutusScript :: Haskell.FilePath -> Q Exp
+readPlutusScript fp = do
+  qAddDependentFile fp
+  runIO
+    $ either (Haskell.error . Haskell.show) id
+    Haskell.<$> readFileTextEnvelopeAnyOf
+      [ FromSomeType (AsPlutusScript AsPlutusScriptV1) plutusScriptToExpr
+      , FromSomeType (AsPlutusScript AsPlutusScriptV2) plutusScriptToExpr
+      , FromSomeType (AsPlutusScript AsPlutusScriptV3) plutusScriptToExpr
+      ]
+      (File fp)
+
+plutusScriptToExpr :: forall lang. (IsPlutusScriptLanguage lang) => PlutusScript lang -> Exp
+plutusScriptToExpr (PlutusScriptSerialised (SBS.fromShort -> script)) =
+  ConE 'PlutusScriptSerialised
+    `AppTypeE` ConT case plutusScriptVersion @lang of
+      PlutusScriptV1 -> ''PlutusScriptV1
+      PlutusScriptV2 -> ''PlutusScriptV2
+      PlutusScriptV3 -> Haskell.error "PlutusScriptV3 type constructor not exposed by cardano-api!"
+    `AppE` ( AppE (VarE 'SBS.toShort)
+              $ AppE (VarE 'unsafePerformIO)
+              $ VarE 'BS.unsafePackAddressLen
+              `AppE` LitE (IntegerL $ Haskell.fromIntegral $ B8.length script)
+              `AppE` LitE
+                ( bytesPrimL
+                    ( let B.PS ptr off sz = script
+                       in mkBytes ptr (Haskell.fromIntegral off) (Haskell.fromIntegral sz)
+                    )
+                )
+           )


### PR DESCRIPTION
- [x] Replaced usages of data files with template Haskell
- [x] bonus: type of splice is now determined by text envelope file, so no more dubious `lang` parameters which can really only be `PlutusScriptV2`, and changing the plutus version in the compiled code in the future will now cause a type error rather than a runtime error.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [ ] Operables are updated with changes to executable command line options.
    - [ ] Deploy charts updated with changes to operables.
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested
