### PR TITLE
PLT-9014 Query volume benchmarking for Marlowe Runtime

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,6 +27,7 @@ packages:
   marlowe
   marlowe-actus
   marlowe-apps
+  marlowe-benchmark
   marlowe-chain-sync
   marlowe-cli
   marlowe-client

--- a/marlowe-benchmark/LICENSE
+++ b/marlowe-benchmark/LICENSE
@@ -1,0 +1,53 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/marlowe-benchmark/NOTICE
+++ b/marlowe-benchmark/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/marlowe-benchmark/ReadMe.md
+++ b/marlowe-benchmark/ReadMe.md
@@ -1,0 +1,110 @@
+# Benchmarks for Marlowe Runtime
+
+The `marlowe-benchmark` tool runs a series of benchmarks against Marlowe Runtime services.
+
+
+## Usage
+
+```bash
+marlowe-benchmark --help
+```
+
+```console
+marlowe-benchmark : execute Marlowe Runtime benchmarks
+
+Usage: marlowe-benchmark [--version] [--host HOST] [--port PORT] [--config FILE]
+
+  This command-line tool for executing benchmarks for Marlowe Runtime.
+
+Available options:
+  -h,--help                Show this help text
+  --version                Show version
+  --host HOST              Host for Marlowe proxy service.
+  --port PORT              Port for Marlowe proxy service.
+  --config FILE            Name of benchmark configuration file.
+```
+
+
+## Configuration
+
+The optional JSON configuration for benchmarking specifies the number clients run in parallel during benchmarking and the quantity of data processed.
+
+| JSON Key                | Haskell Type | Description                                                         |
+|-------------------------|--------------|---------------------------------------------------------------------|
+| `headerSyncParallelism` | `Int`        | Number of parallel clients for `HeaderSync` protocol.               |
+| `headerMaxContracts`    | `Int`        | Maximum number of contracts to be read by each `HeaderSync` client. |
+| `bulkParallelism`       | `Int`        | Number of parallel clients for the `BulkSync` protocol.             |
+| `bulkPageSize`          | `Word8`      | Number of blocks to fetch at a time for the `BulkSync` clients.     |
+| `bulkMaxBlocks`         | `Int`        | Maximum number of blocks to fetch for each `BulkSync` client.       |
+| `syncParallelism`       | `Int`        | Number of parallel clients for `Sync` protocol.                     |
+| `syncBatchSize`         | `Int`        | Number of contracts to be read by each `Sync` client.               |
+| `queryParallelism`      | `Int`        | Number of parallel clients for `Query` protocol.                    |
+| `queryBatchSize`        | `Int`        | Number of queries to be executed by each `Query` client.            |
+| `queryPageSize`         | `Int`        | Page size for each `Query` client.                                  |
+
+
+
+## Example output
+
+The output is lines of JSON, with one report per benchmarking client.
+
+```bash
+marlowe-benchmark
+```
+
+```console
+{"blocksPerSecond":11.771785516655209,"contractsPerSecond":15.269010744861106,"metric":"HeaderSync","seconds":574.169482653}
+{"blocksPerSecond":11.770062718147265,"contractsPerSecond":15.266776128125029,"metric":"HeaderSync","seconds":574.253524544}
+{"blocksPerSecond":11.771827242209914,"contractsPerSecond":15.269064866467572,"metric":"HeaderSync","seconds":574.167447494}
+{"blocksPerSecond":11.771792207230698,"contractsPerSecond":15.269019423108674,"metric":"HeaderSync","seconds":574.16915632}
+{"applyInputsPerSecond":942.8365324905556,"blocksPerSecond":978.2612577741164,"createsPerSecond":180.32465581089704,"metric":"BulkSync","seconds":37.487940679,"withdrawsPerSecond":20.806691055103503}
+{"applyInputsPerSecond":945.7512794506212,"blocksPerSecond":981.2855190633082,"createsPerSecond":180.88212332964207,"metric":"BulkSync","seconds":37.372405164,"withdrawsPerSecond":20.871014230343317}
+{"applyInputsPerSecond":927.177585961421,"blocksPerSecond":962.0139654820538,"createsPerSecond":177.3297632224984,"metric":"BulkSync","seconds":38.121068213,"withdrawsPerSecond":20.461126525672892}
+{"applyInputsPerSecond":949.2986468390368,"blocksPerSecond":984.9661699116706,"createsPerSecond":181.5605843155153,"metric":"BulkSync","seconds":37.23275085,"withdrawsPerSecond":20.949298190251767}
+{"contractsPerSecond":1.6611365871553612,"metric":"Sync","seconds":308.222697615,"stepsPerSecond":6.787300274080108}
+{"contractsPerSecond":1.6320142779350748,"metric":"Sync","seconds":313.722745519,"stepsPerSecond":6.830872260966534}
+{"contractsPerSecond":1.6615895324437109,"metric":"Sync","seconds":308.138676853,"stepsPerSecond":6.759943351719238}
+{"contractsPerSecond":1.6544344963387472,"metric":"Sync","seconds":309.471303417,"stepsPerSecond":6.750221997757115}
+{"contractsPerSecond":3072.685366781302,"metric":"Query","pagesPerSecond":12.266908616099643,"queriesPerSecond":0.35048310331713267,"query":"No policy ID","seconds":45.651273481}
+{"contractsPerSecond":3083.3628083568774,"metric":"Query","pagesPerSecond":12.309535564331096,"queriesPerSecond":0.3517010161237456,"query":"No policy ID","seconds":45.493186731}
+{"contractsPerSecond":3066.656834056088,"metric":"Query","pagesPerSecond":12.242841244663293,"queriesPerSecond":0.3497954641332369,"query":"No policy ID","seconds":45.741016224}
+{"contractsPerSecond":3087.258954561369,"metric":"Query","pagesPerSecond":12.325089929240097,"queriesPerSecond":0.35214542654971703,"query":"No policy ID","seconds":45.435773955}
+```
+
+Tools like `jq` and `dasel` can convert the output to CSV files.
+
+```bash
+marlowe-benchmark > results.json
+for x in Sync BulkSync HeaderSync Query
+do
+  echo
+  jq -s 'map(select(.metric == "'$x'"))' result.json \
+  | dasel -r json -w csv --csv-comma $'\t'
+done
+```
+
+```console
+contractsPerSecond      metric  seconds stepsPerSecond
+1.661137        Sync    308.222698      6.787300
+1.632014        Sync    313.722746      6.830872
+1.661590        Sync    308.138677      6.759943
+1.654434        Sync    309.471303      6.750222
+
+applyInputsPerSecond    blocksPerSecond createsPerSecond        metric  seconds withdrawsPerSecond
+942.836532      978.261258      180.324656      BulkSync        37.487941       20.806691
+945.751279      981.285519      180.882123      BulkSync        37.372405       20.871014
+927.177586      962.013965      177.329763      BulkSync        38.121068       20.461127
+949.298647      984.966170      181.560584      BulkSync        37.232751       20.949298
+
+blocksPerSecond contractsPerSecond      metric  seconds
+11.771786       15.269011       HeaderSync      574.169483
+11.770063       15.266776       HeaderSync      574.253525
+11.771827       15.269065       HeaderSync      574.167447
+11.771792       15.269019       HeaderSync      574.169156
+
+contractsPerSecond      metric  pagesPerSecond  queriesPerSecond        query   seconds
+3072.685367     Query   12.266909       0.350483        No policy ID    45.651273
+3083.362808     Query   12.309536       0.351701        No policy ID    45.493187
+3066.656834     Query   12.242841       0.349795        No policy ID    45.741016
+3087.258955     Query   12.325090       0.352145        No policy ID    45.435774
+```

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark.hs
@@ -1,29 +1,50 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Language.Marlowe.Runtime.Benchmark (
+  BenchmarkConfig (..),
   measure,
 ) where
 
 import Control.Monad (forM_)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Marlowe (MarloweT)
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generic)
 
 import qualified Data.Aeson as A (encode)
 import qualified Data.ByteString.Lazy.Char8 as LBS8 (putStrLn)
 import qualified Language.Marlowe.Runtime.Benchmark.HeaderSync as HeaderSync (measure)
+import qualified Language.Marlowe.Runtime.Benchmark.Query as Query (measure)
 import qualified Language.Marlowe.Runtime.Benchmark.Sync as Sync (measure)
 
+data BenchmarkConfig = BenchmarkConfig
+  { headerSyncParallelism :: Int
+  -- ^ Number of parallel clients for `HeaderSync` protocol.
+  , maxContracts :: Int
+  -- ^ Maximum number of contracts to be read by each `HeaderSync` client.
+  , syncParallelism :: Int
+  -- ^ Number of parallel clients for `Sync` protocol.
+  , syncBatchSize :: Int
+  -- ^ Number of contracts to be read by each `Sync` client.
+  , queryParallelism :: Int
+  -- ^ Number of parallel clients for `Query` protocol.
+  , queryBatchSize :: Int
+  -- ^ Number of queries to be executed by each `Query` client.
+  , queryPageSize :: Int
+  -- ^ Page size for each `Query` client.
+  }
+  deriving (Eq, FromJSON, Generic, Ord, Show, ToJSON)
+
 measure
-  :: Int
-  -- ^ Number of parallel workers for `HeaderSync` query.
-  -> Int
-  -- ^ Maximum number of contracts to read with each `HeaderSync` benchmark.
-  -> Int
-  -- ^ Number of parallel works for `Sync` query.
-  -> Int
-  -- ^ Number of contracts for each `Sync` worker to query.
+  :: BenchmarkConfig
   -> MarloweT IO ()
-measure headerSyncParallelism maxContracts syncParallelism syncBatchSize =
+measure BenchmarkConfig{..} =
   do
     (headerSyncResults, contractIds) <- HeaderSync.measure headerSyncParallelism maxContracts
     liftIO . forM_ headerSyncResults $ LBS8.putStrLn . A.encode
     syncResults <- Sync.measure syncParallelism syncBatchSize contractIds
     liftIO . forM_ syncResults $ LBS8.putStrLn . A.encode
+    queryResults <-
+      Query.measure queryParallelism queryBatchSize queryPageSize "No policy ID" $
+        replicate (queryParallelism * queryBatchSize) mempty
+    liftIO . forM_ queryResults $ LBS8.putStrLn . A.encode

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark.hs
@@ -1,0 +1,20 @@
+module Language.Marlowe.Runtime.Benchmark (
+  measure,
+) where
+
+import Control.Monad (forM_)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Marlowe (MarloweT)
+
+import qualified Data.Aeson as A (encode)
+import qualified Data.ByteString.Lazy.Char8 as LBS8 (putStrLn)
+import qualified Language.Marlowe.Runtime.Benchmark.HeaderSync as HeaderSync (measure)
+
+headerSyncParallelism :: Int
+headerSyncParallelism = 10
+
+measure :: MarloweT IO ()
+measure =
+  do
+    (results, _) <- HeaderSync.measure headerSyncParallelism
+    liftIO . forM_ results $ LBS8.putStrLn . A.encode

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark.hs
@@ -1,27 +1,39 @@
 {-# LANGUAGE RecordWildCards #-}
 
+-- | Benchmark for protocols.
 module Language.Marlowe.Runtime.Benchmark (
+  -- * Benchmarking
   BenchmarkConfig (..),
   measure,
 ) where
 
-import Control.Monad (forM_)
+import Control.Monad (forM_, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Marlowe (MarloweT)
 import Data.Aeson (FromJSON, ToJSON)
+import Data.Default (Default (..))
+import Data.Word (Word8)
 import GHC.Generics (Generic)
 
 import qualified Data.Aeson as A (encode)
 import qualified Data.ByteString.Lazy.Char8 as LBS8 (putStrLn)
+import qualified Language.Marlowe.Runtime.Benchmark.BulkSync as Bulk (measure)
 import qualified Language.Marlowe.Runtime.Benchmark.HeaderSync as HeaderSync (measure)
 import qualified Language.Marlowe.Runtime.Benchmark.Query as Query (measure)
 import qualified Language.Marlowe.Runtime.Benchmark.Sync as Sync (measure)
 
+-- | Benchmark configuration.
 data BenchmarkConfig = BenchmarkConfig
   { headerSyncParallelism :: Int
   -- ^ Number of parallel clients for `HeaderSync` protocol.
-  , maxContracts :: Int
+  , headerMaxContracts :: Int
   -- ^ Maximum number of contracts to be read by each `HeaderSync` client.
+  , bulkParallelism :: Int
+  -- ^ Number of parallel clients for the `BulkSync` protocol.
+  , bulkPageSize :: Word8
+  -- ^ Number of blocks to fetch at a time for the `BulkSync` clients.
+  , bulkMaxBlocks :: Int
+  -- ^ Maximum number of blocks to fetch for each `BulkSync` client.
   , syncParallelism :: Int
   -- ^ Number of parallel clients for `Sync` protocol.
   , syncBatchSize :: Int
@@ -35,16 +47,42 @@ data BenchmarkConfig = BenchmarkConfig
   }
   deriving (Eq, FromJSON, Generic, Ord, Show, ToJSON)
 
+instance Default BenchmarkConfig where
+  def =
+    BenchmarkConfig
+      { headerSyncParallelism = 4
+      , headerMaxContracts = maxBound
+      , bulkParallelism = 4
+      , bulkPageSize = 128
+      , bulkMaxBlocks = maxBound
+      , syncParallelism = 4
+      , syncBatchSize = 512
+      , queryParallelism = 4
+      , queryBatchSize = 16
+      , queryPageSize = 256
+      }
+
+-- | Run the benchmarks.
 measure
   :: BenchmarkConfig
   -> MarloweT IO ()
 measure BenchmarkConfig{..} =
   do
-    (headerSyncResults, contractIds) <- HeaderSync.measure headerSyncParallelism maxContracts
+    when (headerSyncParallelism == 0) $
+      error "At least one `HeaderSync` client must be run."
+    (headerSyncResults, contractIds) <- HeaderSync.measure headerSyncParallelism headerMaxContracts
     liftIO . forM_ headerSyncResults $ LBS8.putStrLn . A.encode
-    syncResults <- Sync.measure syncParallelism syncBatchSize contractIds
-    liftIO . forM_ syncResults $ LBS8.putStrLn . A.encode
-    queryResults <-
-      Query.measure queryParallelism queryBatchSize queryPageSize "No policy ID" $
-        replicate (queryParallelism * queryBatchSize) mempty
-    liftIO . forM_ queryResults $ LBS8.putStrLn . A.encode
+    when (bulkParallelism > 0) $
+      do
+        bulkResults <- Bulk.measure bulkParallelism bulkPageSize bulkMaxBlocks
+        liftIO . forM_ bulkResults $ LBS8.putStrLn . A.encode
+    when (syncParallelism > 0) $
+      do
+        syncResults <- Sync.measure syncParallelism syncBatchSize contractIds
+        liftIO . forM_ syncResults $ LBS8.putStrLn . A.encode
+    when (queryParallelism > 0) $
+      do
+        queryResults <-
+          Query.measure queryParallelism queryBatchSize queryPageSize "No policy ID" $
+            replicate (queryParallelism * queryBatchSize) mempty
+        liftIO . forM_ queryResults $ LBS8.putStrLn . A.encode

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark.hs
@@ -9,12 +9,21 @@ import Control.Monad.Trans.Marlowe (MarloweT)
 import qualified Data.Aeson as A (encode)
 import qualified Data.ByteString.Lazy.Char8 as LBS8 (putStrLn)
 import qualified Language.Marlowe.Runtime.Benchmark.HeaderSync as HeaderSync (measure)
+import qualified Language.Marlowe.Runtime.Benchmark.Sync as Sync (measure)
 
-headerSyncParallelism :: Int
-headerSyncParallelism = 10
-
-measure :: MarloweT IO ()
-measure =
+measure
+  :: Int
+  -- ^ Number of parallel workers for `HeaderSync` query.
+  -> Int
+  -- ^ Maximum number of contracts to read with each `HeaderSync` benchmark.
+  -> Int
+  -- ^ Number of parallel works for `Sync` query.
+  -> Int
+  -- ^ Number of contracts for each `Sync` worker to query.
+  -> MarloweT IO ()
+measure headerSyncParallelism maxContracts syncParallelism syncBatchSize =
   do
-    (results, _) <- HeaderSync.measure headerSyncParallelism
-    liftIO . forM_ results $ LBS8.putStrLn . A.encode
+    (headerSyncResults, contractIds) <- HeaderSync.measure headerSyncParallelism maxContracts
+    liftIO . forM_ headerSyncResults $ LBS8.putStrLn . A.encode
+    syncResults <- Sync.measure syncParallelism syncBatchSize contractIds
+    liftIO . forM_ syncResults $ LBS8.putStrLn . A.encode

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/BulkSync.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/BulkSync.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Benchmark for the `BulkSync` protocol.
+module Language.Marlowe.Runtime.Benchmark.BulkSync (
+  -- * Benchmarking
+  Benchmark (..),
+  measure,
+) where
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Marlowe (MarloweT)
+import Data.Aeson (ToJSON)
+import Data.Default (Default (..))
+import Data.Time.Clock (NominalDiffTime)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Language.Marlowe.Protocol.BulkSync.Client (
+  ClientStIdle (..),
+  ClientStNext (..),
+  ClientStPoll (..),
+  MarloweBulkSyncClient (MarloweBulkSyncClient),
+ )
+import Language.Marlowe.Runtime.Client (runMarloweBulkSyncClient)
+import Language.Marlowe.Runtime.History.Api (MarloweBlock (..), MarloweCreateTransaction (newContracts))
+import UnliftIO (replicateConcurrently)
+
+data Benchmark = Benchmark
+  { metric :: String
+  , blocksPerSecond :: Double
+  , createsPerSecond :: Double
+  , applyInputsPerSecond :: Double
+  , withdrawsPerSecond :: Double
+  , seconds :: Double
+  }
+  deriving (Eq, Generic, Ord, Show, ToJSON)
+
+data Statistics = Statistics
+  { blocks :: Int
+  , creates :: Int
+  , applyInputs :: Int
+  , withdraws :: Int
+  , duration :: NominalDiffTime
+  }
+  deriving (Eq, Generic, Ord, Show, ToJSON)
+
+instance Default Statistics where
+  def = Statistics def def def def 0
+
+-- | Measure the performance of the protocol.
+measure
+  :: Int
+  -- ^ Number of parallel clients for the `BulkSync` protocol.
+  -> Word8
+  -- ^ Number of blocks to fetch at a time for the `BulkSync` clients.
+  -> Int
+  -- ^ Maximum number of blocks to fetch for each `BulkSync` client.
+  -> MarloweT IO [Benchmark]
+  -- ^ Action for running the benchmark.
+measure parallelism pageSize maxBlocks =
+  replicateConcurrently parallelism $
+    run "BulkSync" pageSize maxBlocks
+
+-- | Run the benchmarking client.
+run
+  :: String
+  -- ^ Label for the benchmark.
+  -> Word8
+  -- ^ Number of blocks to fetch at a time for the `BulkSync` clients.
+  -> Int
+  -- ^ Maximum number of blocks to fetch for each `BulkSync` client.
+  -> MarloweT IO Benchmark
+  -- ^ Action for running the benchmark.
+run metric pageSize maxBlocks =
+  do
+    Statistics{..} <- runMarloweBulkSyncClient . benchmark pageSize maxBlocks =<< liftIO getPOSIXTime
+    let seconds = realToFrac duration
+        blocksPerSecond = realToFrac blocks / seconds
+        createsPerSecond = realToFrac creates / seconds
+        applyInputsPerSecond = realToFrac applyInputs / seconds
+        withdrawsPerSecond = realToFrac withdraws / seconds
+    pure Benchmark{..}
+
+-- | Run a benchmark.
+benchmark
+  :: (MonadIO m)
+  => Word8
+  -- ^ Number of blocks to fetch at a time for the `BulkSync` clients.
+  -> Int
+  -- ^ Maximum number of blocks to fetch for each `BulkSync` client.
+  -> NominalDiffTime
+  -- ^ When the benchmark started.
+  -> MarloweBulkSyncClient m Statistics
+  -- ^ Action for running the benchmark.
+benchmark pageSize maxBlocks start =
+  let idle = SendMsgRequestNext pageSize . next
+      next stats@Statistics{..} =
+        ClientStNext
+          { recvMsgRollForward = \blocks' _tip ->
+              if blocks >= maxBlocks
+                then pure $ SendMsgDone stats
+                else do
+                  now <- liftIO getPOSIXTime
+                  pure $
+                    idle
+                      stats
+                        { blocks = blocks + length blocks'
+                        , creates = creates + sum (length . mconcat . fmap newContracts . createTransactions <$> blocks')
+                        , applyInputs = applyInputs + sum (length . applyInputsTransactions <$> blocks')
+                        , withdraws = withdraws + sum (length . withdrawTransactions <$> blocks')
+                        , duration = now - start
+                        }
+          , recvMsgRollBackward = \_point _tip -> pure $ idle stats
+          , recvMsgWait = pure . SendMsgCancel $ SendMsgDone stats
+          }
+   in MarloweBulkSyncClient . pure $ idle def

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/HeaderSync.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/HeaderSync.hs
@@ -48,9 +48,9 @@ measure
   :: Int
   -> Int
   -> MarloweT IO ([Benchmark], S.Set ContractId)
-measure count maxContracts =
+measure parallelism maxContracts =
   second head . unzip
-    <$> replicateConcurrently count (run "HeaderSync" maxContracts)
+    <$> replicateConcurrently parallelism (run "HeaderSync" maxContracts)
 
 run
   :: String

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/HeaderSync.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/HeaderSync.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Language.Marlowe.Runtime.Benchmark.HeaderSync (
+  Benchmark (..),
+  measure,
+) where
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Marlowe (MarloweT)
+import Control.Monad.Trans.Marlowe.Class
+import Data.Aeson (ToJSON)
+import Data.Bifunctor (second)
+import Data.Default (Default (..))
+import Data.Time.Clock
+import Data.Time.Clock.POSIX
+import GHC.Generics (Generic)
+import Language.Marlowe.Protocol.HeaderSync.Client (
+  ClientStIdle (..),
+  ClientStNext (..),
+  ClientStWait (..),
+  MarloweHeaderSyncClient (MarloweHeaderSyncClient),
+ )
+import Language.Marlowe.Runtime.Core.Api (ContractId)
+import Language.Marlowe.Runtime.Discovery.Api (contractId)
+import UnliftIO (replicateConcurrently)
+
+import qualified Data.Set as S (Set, fromList, size)
+
+data Benchmark = Benchmark
+  { metric :: String
+  , blocksPerSecond :: Double
+  , contractsPerSecond :: Double
+  , seconds :: Double
+  }
+  deriving (Eq, Generic, Ord, Show, ToJSON)
+
+data Statistics = Statistics
+  { blocks :: Integer
+  , contracts :: S.Set ContractId
+  , duration :: NominalDiffTime
+  }
+  deriving (Eq, Generic, Ord, Show, ToJSON)
+
+instance Default Statistics where
+  def = Statistics def mempty 0
+
+measure
+  :: Int
+  -> MarloweT IO ([Benchmark], S.Set ContractId)
+measure count =
+  second head . unzip
+    <$> replicateConcurrently
+      count
+      (run "HeaderSync")
+
+run
+  :: String
+  -> MarloweT IO (Benchmark, S.Set ContractId)
+run metric =
+  do
+    Statistics{..} <- runMarloweHeaderSyncClient . benchmark =<< liftIO getPOSIXTime
+    let seconds = realToFrac duration
+        blocksPerSecond = fromInteger blocks / seconds
+        contractsPerSecond = fromIntegral (S.size contracts) / seconds
+    pure (Benchmark{..}, contracts)
+
+benchmark
+  :: (MonadIO m)
+  => NominalDiffTime
+  -> MarloweHeaderSyncClient m Statistics
+benchmark start =
+  let clientIdle = SendMsgRequestNext . clientNext
+      clientWait = pure . SendMsgCancel . SendMsgDone
+      clientNext stats@Statistics{..} =
+        ClientStNext
+          { recvMsgNewHeaders = \_blockHeader results ->
+              do
+                now <- liftIO getPOSIXTime
+                pure $
+                  clientIdle $
+                    stats
+                      { blocks = blocks + 1
+                      , contracts = contracts <> S.fromList (contractId <$> results)
+                      , duration = now - start
+                      }
+          , recvMsgRollBackward = \_chainPoint ->
+              pure $ clientIdle stats
+          , recvMsgWait = clientWait stats
+          }
+   in MarloweHeaderSyncClient . pure $ clientIdle def

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Query.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Query.hs
@@ -16,10 +16,8 @@ import Data.List.Split (chunksOf)
 import Data.Time.Clock (NominalDiffTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import GHC.Generics (Generic)
-import Language.Marlowe.Protocol.Query.Client (MarloweQueryClient)
-import qualified Language.Marlowe.Protocol.Query.Client as Query
-import Language.Marlowe.Protocol.Query.Types (ContractFilter)
-import qualified Language.Marlowe.Protocol.Query.Types as Query
+import Language.Marlowe.Protocol.Query.Client (MarloweQueryClient, getContractHeaders)
+import Language.Marlowe.Protocol.Query.Types (ContractFilter, Order (Ascending), Page (..), Range (..))
 import Language.Marlowe.Runtime.Client (runMarloweQueryClient)
 import UnliftIO (forConcurrently)
 
@@ -98,9 +96,9 @@ benchmark
   -> MarloweQueryClient m Statistics
   -- ^ Action to run the benchmark.
 benchmark start pageSize initial@Statistics{queries} cFilter =
-  let accumulate = (. Query.getContractHeaders cFilter) . (=<<) . handleNextPage
+  let accumulate = (. getContractHeaders cFilter) . (=<<) . handleNextPage
       handleNextPage stats Nothing = pure stats
-      handleNextPage stats@Statistics{pages, contracts} (Just Query.Page{..}) =
+      handleNextPage stats@Statistics{pages, contracts} (Just Page{..}) =
         do
           now <- liftIO getPOSIXTime
           let stats' =
@@ -112,4 +110,4 @@ benchmark start pageSize initial@Statistics{queries} cFilter =
           case nextRange of
             Nothing -> pure stats'
             Just range -> stats' `accumulate` range
-   in initial{queries = queries + 1} `accumulate` Query.Range Nothing 0 pageSize Query.Ascending
+   in initial{queries = queries + 1} `accumulate` Range Nothing 0 pageSize Ascending

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Query.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Query.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Language.Marlowe.Runtime.Benchmark.Query (
+  Benchmark (..),
+  measure,
+) where
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Marlowe (MarloweT)
+import Data.Aeson (ToJSON)
+import Data.Default (Default (..))
+import Data.Foldable (foldlM)
+import Data.List.Split (chunksOf)
+import Data.Time.Clock (NominalDiffTime)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import GHC.Generics (Generic)
+import Language.Marlowe.Protocol.Query.Client (MarloweQueryClient)
+import qualified Language.Marlowe.Protocol.Query.Client as Query
+import Language.Marlowe.Protocol.Query.Types (ContractFilter)
+import qualified Language.Marlowe.Protocol.Query.Types as Query
+import Language.Marlowe.Runtime.Client (runMarloweQueryClient)
+import UnliftIO (forConcurrently)
+
+data Benchmark = Benchmark
+  { metric :: String
+  , query :: String
+  , queriesPerSecond :: Double
+  , pagesPerSecond :: Double
+  , contractsPerSecond :: Double
+  , seconds :: Double
+  }
+  deriving (Eq, Generic, Ord, Show, ToJSON)
+
+data Statistics = Statistics
+  { queries :: Integer
+  , pages :: Integer
+  , contracts :: Integer
+  , duration :: NominalDiffTime
+  }
+  deriving (Eq, Generic, Ord, Show, ToJSON)
+
+instance Default Statistics where
+  def = Statistics def def def 0
+
+measure
+  :: Int
+  -> Int
+  -> Int
+  -> String
+  -> [ContractFilter]
+  -> MarloweT IO [Benchmark]
+measure parallelism batchSize pageSize query filters =
+  let batches = take parallelism $ chunksOf batchSize filters
+   in forConcurrently batches $
+        run "Query" pageSize query
+
+run
+  :: String
+  -> Int
+  -> String
+  -> [ContractFilter]
+  -> MarloweT IO Benchmark
+run metric pageSize query filters =
+  do
+    start <- liftIO getPOSIXTime
+    Statistics{..} <- foldlM ((runMarloweQueryClient .) . benchmark start pageSize) def filters
+    let seconds = realToFrac duration
+        queriesPerSecond = fromInteger queries / seconds
+        pagesPerSecond = fromInteger pages / seconds
+        contractsPerSecond = fromInteger contracts / seconds
+    pure Benchmark{..}
+
+benchmark
+  :: (MonadIO m)
+  => NominalDiffTime
+  -> Int
+  -> Statistics
+  -> ContractFilter
+  -> MarloweQueryClient m Statistics
+benchmark start pageSize initial@Statistics{queries} cFilter =
+  let accumulate = (. Query.getContractHeaders cFilter) . (=<<) . handleNextPage
+      handleNextPage stats Nothing = pure stats
+      handleNextPage stats@Statistics{pages, contracts} (Just Query.Page{..}) =
+        do
+          now <- liftIO getPOSIXTime
+          let stats' =
+                stats
+                  { pages = pages + 1
+                  , contracts = contracts + toInteger (length items)
+                  , duration = now - start
+                  }
+          case nextRange of
+            Nothing -> pure stats'
+            Just range -> stats' `accumulate` range
+   in initial{queries = queries + 1} `accumulate` Query.Range Nothing 0 pageSize Query.Ascending

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Sync.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Sync.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Language.Marlowe.Runtime.Benchmark.Sync (
+  Benchmark (..),
+  measure,
+) where
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Marlowe (MarloweT)
+import Data.Aeson (ToJSON)
+import Data.Default (Default (..))
+import Data.Foldable (foldlM, toList)
+import Data.List.Split (chunksOf)
+import Data.Time.Clock (NominalDiffTime)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Type.Equality ((:~:) (Refl))
+import GHC.Generics (Generic)
+import Language.Marlowe.Protocol.Sync.Client (
+  ClientStFollow (ClientStFollow, recvMsgContractFound, recvMsgContractNotFound),
+  ClientStIdle (SendMsgDone, SendMsgRequestNext),
+  ClientStInit (SendMsgFollowContract),
+  ClientStNext (..),
+  ClientStWait (SendMsgCancel),
+  MarloweSyncClient (MarloweSyncClient),
+ )
+import Language.Marlowe.Runtime.Client (runMarloweSyncClient)
+import Language.Marlowe.Runtime.Core.Api (
+  ContractId,
+  IsMarloweVersion (..),
+  MarloweVersion (..),
+  MarloweVersionTag (V1),
+  assertVersionsEqual,
+ )
+import UnliftIO (forConcurrently)
+
+import qualified Data.Set as S (Set)
+
+data Benchmark = Benchmark
+  { metric :: String
+  , contractsPerSecond :: Double
+  , stepsPerSecond :: Double
+  , seconds :: Double
+  }
+  deriving (Eq, Generic, Ord, Show, ToJSON)
+
+data Statistics v = Statistics
+  { contracts :: Integer
+  , steps :: Integer
+  , duration :: NominalDiffTime
+  , version :: MarloweVersion v
+  }
+  deriving (Eq, Generic, Ord, Show, ToJSON)
+
+instance (IsMarloweVersion v) => Default (Statistics v) where
+  def = Statistics def def 0 marloweVersion
+
+measure
+  :: Int
+  -> Int
+  -> S.Set ContractId
+  -> MarloweT IO [Benchmark]
+measure count batchSize contractIds =
+  let batches = take count . chunksOf batchSize $ toList contractIds
+   in forConcurrently batches $
+        run "Sync"
+
+run
+  :: String
+  -> [ContractId]
+  -> MarloweT IO Benchmark
+run metric contractIds =
+  do
+    start <- liftIO getPOSIXTime
+    Statistics{..} <- foldlM ((runMarloweSyncClient .) . benchmark start) (def :: Statistics 'V1) contractIds
+    let seconds = realToFrac duration
+        contractsPerSecond = fromInteger contracts / seconds
+        stepsPerSecond = fromInteger steps / seconds
+    pure Benchmark{..}
+
+benchmark
+  :: forall v m
+   . (IsMarloweVersion v)
+  => (MonadIO m)
+  => NominalDiffTime
+  -> Statistics v
+  -> ContractId
+  -> MarloweSyncClient m (Statistics v)
+benchmark start initial@Statistics{contracts} contractId =
+  let clientInit =
+        SendMsgFollowContract
+          contractId
+          ClientStFollow
+            { recvMsgContractNotFound = pure initial
+            , recvMsgContractFound = \_blockHeader version _createStep ->
+                case version `assertVersionsEqual` (marloweVersion :: MarloweVersion v) of
+                  Refl -> do
+                    now <- liftIO getPOSIXTime
+                    pure $
+                      clientIdle version $
+                        initial
+                          { contracts = contracts + 1
+                          , duration = now - start
+                          }
+            }
+      clientIdle = (SendMsgRequestNext .) . clientNext
+      clientNext :: MarloweVersion v -> Statistics v -> ClientStNext v m (Statistics v)
+      clientNext version stats@Statistics{steps} =
+        ClientStNext
+          { recvMsgRollBackCreation = pure stats
+          , recvMsgRollBackward = \_blockHeader ->
+              pure $ clientIdle version stats
+          , recvMsgRollForward = \_blockHeader steps' ->
+              do
+                now <- liftIO getPOSIXTime
+                pure
+                  . clientIdle version
+                  $ stats
+                    { steps = toInteger (length steps') + steps
+                    , duration = now - start
+                    }
+          , recvMsgWait =
+              pure . SendMsgCancel $ SendMsgDone stats
+          }
+   in MarloweSyncClient $ pure clientInit

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Sync.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Sync.hs
@@ -21,11 +21,11 @@ import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Type.Equality ((:~:) (Refl))
 import GHC.Generics (Generic)
 import Language.Marlowe.Protocol.Sync.Client (
-  ClientStFollow (ClientStFollow, recvMsgContractFound, recvMsgContractNotFound),
-  ClientStIdle (SendMsgDone, SendMsgRequestNext),
-  ClientStInit (SendMsgFollowContract),
+  ClientStFollow (..),
+  ClientStIdle (..),
+  ClientStInit (..),
   ClientStNext (..),
-  ClientStWait (SendMsgCancel),
+  ClientStWait (..),
   MarloweSyncClient (MarloweSyncClient),
  )
 import Language.Marlowe.Runtime.Client (runMarloweSyncClient)

--- a/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Sync.hs
+++ b/marlowe-benchmark/app/Language/Marlowe/Runtime/Benchmark/Sync.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -63,8 +62,8 @@ measure
   -> Int
   -> S.Set ContractId
   -> MarloweT IO [Benchmark]
-measure count batchSize contractIds =
-  let batches = take count . chunksOf batchSize $ toList contractIds
+measure parallelism batchSize contractIds =
+  let batches = take parallelism . chunksOf batchSize $ toList contractIds
    in forConcurrently batches $
         run "Sync"
 

--- a/marlowe-benchmark/app/Main.hs
+++ b/marlowe-benchmark/app/Main.hs
@@ -6,4 +6,10 @@ import Language.Marlowe.Runtime.Benchmark (measure)
 import Language.Marlowe.Runtime.Client (connectToMarloweRuntime)
 
 main :: IO ()
-main = connectToMarloweRuntime "localhost" 13700 measure
+main =
+  connectToMarloweRuntime "localhost" 13700 $
+    measure
+      3 -- HeaderSync parallelism
+      100 -- maximum number of contracts
+      3 -- Sync parallelism
+      20 -- Sync batch size

--- a/marlowe-benchmark/app/Main.hs
+++ b/marlowe-benchmark/app/Main.hs
@@ -1,0 +1,9 @@
+module Main (
+  main,
+) where
+
+import Language.Marlowe.Runtime.Benchmark (measure)
+import Language.Marlowe.Runtime.Client (connectToMarloweRuntime)
+
+main :: IO ()
+main = connectToMarloweRuntime "localhost" 13700 measure

--- a/marlowe-benchmark/app/Main.hs
+++ b/marlowe-benchmark/app/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 -- | Execute Benchmarks.
 module Main (
   -- * Entry point
@@ -8,22 +6,34 @@ module Main (
 
 import Data.Aeson (eitherDecodeFileStrict')
 import Data.Default (def)
+import Data.Version (showVersion)
 import Language.Marlowe.Runtime.Benchmark (measure)
 import Language.Marlowe.Runtime.Client (connectToMarloweRuntime)
-import System.Environment (getArgs)
+import Paths_marlowe_benchmark (version)
+
+import qualified Options.Applicative as O
 
 -- | Execute the benchmarks.
 main :: IO ()
 main =
   do
-    (host, port, config) <-
-      getArgs >>= \case
-        [] -> pure ("localhost", 3700, def)
-        [h] -> pure (h, 3700, def)
-        [h, p] -> pure (h, read p, def)
-        [h, p, c] ->
-          eitherDecodeFileStrict' c >>= \case
-            Right c' -> pure (h, read p, c')
-            Left e -> error e
-        _ -> error "USAGE: marlowe-benchmark [host [port [configfile]]]"
-    connectToMarloweRuntime host port $ measure config
+    (host, port, config) <- O.execParser commandParser
+    config' <-
+      case config of
+        Nothing -> pure def
+        Just config'' -> either error id <$> eitherDecodeFileStrict' config''
+    connectToMarloweRuntime host (fromIntegral port) $ measure config'
+
+commandParser :: O.ParserInfo (String, Int, Maybe FilePath)
+commandParser =
+  let commandOptions =
+        (,,)
+          <$> O.strOption (O.long "host" <> O.value "localhost" <> O.metavar "HOST" <> O.help "Host for Marlowe proxy service.")
+          <*> O.option O.auto (O.long "port" <> O.value 3700 <> O.metavar "PORT" <> O.help "Port for Marlowe proxy service.")
+          <*> (O.optional . O.strOption) (O.long "config" <> O.metavar "FILE" <> O.help "Path to the benchmark configuration file.")
+   in O.info
+        (O.helper <*> (O.infoOption (showVersion version) $ O.long "version" <> O.help "Show version") <*> commandOptions)
+        ( O.fullDesc
+            <> O.progDesc "This command-line tool executes benchmarks for Marlowe Runtime."
+            <> O.header "marlowe-benchmark : execute Marlowe Runtime benchmarks"
+        )

--- a/marlowe-benchmark/app/Main.hs
+++ b/marlowe-benchmark/app/Main.hs
@@ -2,14 +2,19 @@ module Main (
   main,
 ) where
 
-import Language.Marlowe.Runtime.Benchmark (measure)
+import Language.Marlowe.Runtime.Benchmark (BenchmarkConfig (..), measure)
 import Language.Marlowe.Runtime.Client (connectToMarloweRuntime)
 
 main :: IO ()
 main =
-  connectToMarloweRuntime "localhost" 13700 $
-    measure
-      3 -- HeaderSync parallelism
-      100 -- maximum number of contracts
-      3 -- Sync parallelism
-      20 -- Sync batch size
+  connectToMarloweRuntime "localhost" 13700
+    . measure
+    $ BenchmarkConfig
+      { headerSyncParallelism = 3
+      , maxContracts = 100
+      , syncParallelism = 3
+      , syncBatchSize = 20
+      , queryParallelism = 3
+      , queryBatchSize = 1
+      , queryPageSize = 50
+      }

--- a/marlowe-benchmark/changelog.d/20240104_144839_brian.bush_PLT_9014.rst
+++ b/marlowe-benchmark/changelog.d/20240104_144839_brian.bush_PLT_9014.rst
@@ -1,0 +1,4 @@
+Added
+-----
+
+- Implemented basic benchmarking for Marlowe Runtime sync and query protocols.

--- a/marlowe-benchmark/marlowe-benchmark.cabal
+++ b/marlowe-benchmark/marlowe-benchmark.cabal
@@ -62,6 +62,7 @@ executable marlowe-benchmark
   main-is:        Main.hs
   other-modules:
     Language.Marlowe.Runtime.Benchmark
+    Language.Marlowe.Runtime.Benchmark.BulkSync
     Language.Marlowe.Runtime.Benchmark.HeaderSync
     Language.Marlowe.Runtime.Benchmark.Query
     Language.Marlowe.Runtime.Benchmark.Sync

--- a/marlowe-benchmark/marlowe-benchmark.cabal
+++ b/marlowe-benchmark/marlowe-benchmark.cabal
@@ -1,0 +1,76 @@
+cabal-version: 3.4
+name:          marlowe-benchmark
+version:       0.1.0.0
+synopsis:      Benchmarking for the Marlowe Runtime
+bug-reports:   https://github.com/input-output-hk/marlowe-marlowe/issues
+license:       Apache-2.0
+author:        Brian W Bush
+maintainer:    brian.bush@iohk.io
+category:      Language
+license-files:
+  LICENSE
+  NOTICE
+
+flag defer-plugin-errors
+  description:
+    Defer errors from the plugin, useful for things like Haddock that can't handle it.
+
+  default:     False
+  manual:      True
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/marlowe-cardano
+  subdir:   marlowe-benchmark
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    BlockArguments
+    DeriveAnyClass
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    EmptyCase
+    ExplicitForAll
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    NamedFieldPuns
+    NumericUnderscores
+    OverloadedStrings
+    RecordWildCards
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wunused-packages
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities -threaded
+
+  if flag(defer-plugin-errors)
+    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
+
+executable marlowe-benchmark
+  import:         lang
+  hs-source-dirs: app
+  main-is:        Main.hs
+  other-modules:
+    Language.Marlowe.Runtime.Benchmark
+    Language.Marlowe.Runtime.Benchmark.HeaderSync
+
+  build-depends:
+    , aeson
+    , base >=4.9 && <5
+    , bytestring
+    , containers
+    , data-default
+    , marlowe-client
+    , marlowe-runtime:{marlowe-runtime, discovery-api}
+    , time
+    , unliftio

--- a/marlowe-benchmark/marlowe-benchmark.cabal
+++ b/marlowe-benchmark/marlowe-benchmark.cabal
@@ -66,6 +66,7 @@ executable marlowe-benchmark
     Language.Marlowe.Runtime.Benchmark.HeaderSync
     Language.Marlowe.Runtime.Benchmark.Query
     Language.Marlowe.Runtime.Benchmark.Sync
+    Paths_marlowe_benchmark
 
   build-depends:
     , aeson
@@ -75,6 +76,7 @@ executable marlowe-benchmark
     , data-default
     , marlowe-client
     , marlowe-runtime:{marlowe-runtime, discovery-api, history-api, sync-api}
+    , optparse-applicative
     , split
     , time
     , unliftio

--- a/marlowe-benchmark/marlowe-benchmark.cabal
+++ b/marlowe-benchmark/marlowe-benchmark.cabal
@@ -63,6 +63,7 @@ executable marlowe-benchmark
   other-modules:
     Language.Marlowe.Runtime.Benchmark
     Language.Marlowe.Runtime.Benchmark.HeaderSync
+    Language.Marlowe.Runtime.Benchmark.Query
     Language.Marlowe.Runtime.Benchmark.Sync
 
   build-depends:
@@ -72,7 +73,7 @@ executable marlowe-benchmark
     , containers
     , data-default
     , marlowe-client
-    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api}
+    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api, sync-api}
     , split
     , time
     , unliftio

--- a/marlowe-benchmark/marlowe-benchmark.cabal
+++ b/marlowe-benchmark/marlowe-benchmark.cabal
@@ -63,6 +63,7 @@ executable marlowe-benchmark
   other-modules:
     Language.Marlowe.Runtime.Benchmark
     Language.Marlowe.Runtime.Benchmark.HeaderSync
+    Language.Marlowe.Runtime.Benchmark.Sync
 
   build-depends:
     , aeson
@@ -71,6 +72,7 @@ executable marlowe-benchmark
     , containers
     , data-default
     , marlowe-client
-    , marlowe-runtime:{marlowe-runtime, discovery-api}
+    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api}
+    , split
     , time
     , unliftio


### PR DESCRIPTION
This PR provides configurable volume/load tests for the following Marlowe Runtime protocols:
- `BulkSync`
- `HeaderSync`
- `Sync`
- `Query`

See https://github.com/input-output-hk/marlowe-cardano/tree/PLT-9014/marlowe-benchmark#readme for documentation and example output.

Subsequent PRs will address other protocols and data management for reporting.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
    - [x] Formatting, PNG optimization, etc. are updated
    - [ ] Operables are updated with changes to executable command line options.
    - [ ] Deploy charts updated with changes to operables.
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [x] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [x] Reviewer requested