### PR TITLE
Fix chain-indexer memory issues.

### DIFF
--- a/marlowe-chain-sync/marlowe-chain-indexer/Options.hs
+++ b/marlowe-chain-sync/marlowe-chain-indexer/Options.hs
@@ -199,7 +199,7 @@ parseOptions defaultNetworkId defaultSocketPath defaultDatabaseUri version = O.i
           O.option O.auto $
             mconcat
               [ O.long "max-cost"
-              , O.value 1_000_000
+              , O.value 250_000
               , O.metavar "COST_UNITS"
               , O.help
                   "The maximum number of cost units that can be batched when persisting blocks. If the cost of the current batch would exceed this value, the chain sync client will wait until the current batch is persisted before requesting another block."

--- a/marlowe-runtime/changelog.d/20240118_120513_jhbertra_decrease_indexer_batching.md
+++ b/marlowe-runtime/changelog.d/20240118_120513_jhbertra_decrease_indexer_batching.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Default batch size for chain-indexer decreased to 1/4 to prevent OOM errors.

--- a/nix/marlowe-cardano/deploy/operables.nix
+++ b/nix/marlowe-cardano/deploy/operables.nix
@@ -174,6 +174,9 @@ in
       #################
       # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
       # OTEL_SERVICE_NAME: The name of the open telemetry service
+      # BLOCK_COST: The number of cost units to associate with persisting a block
+      # TX_COST: The number of cost units to associate with persisting a transaction
+      # MAX_COST: The maximum cost of work to batch before committing
 
       [ -z "''${NODE_CONFIG:-}" ] && echo "NODE_CONFIG env var must be set -- aborting" && exit 1
       [ -z "''${CARDANO_NODE_SOCKET_PATH:-}" ] && echo "CARDANO_NODE_SOCKET_PATH env var must be set -- aborting" && exit 1
@@ -206,6 +209,9 @@ in
       ${wait-for-socket}/bin/wait-for-socket "$CARDANO_NODE_SOCKET_PATH"
 
       export OTEL_SERVICE_NAME="''${OTEL_SERVICE_NAME:-marlowe-chain-indexer}"
+      export BLOCK_COST="''${BLOCK_COST:-1}"
+      export TX_COST="''${TX_COST:-10}"
+      export MAX_COST="''${MAX_COST:-250000}"
 
       ${marlowe-chain-indexer}/bin/marlowe-chain-indexer \
         --socket-path "$CARDANO_NODE_SOCKET_PATH" \
@@ -213,6 +219,9 @@ in
         --shelley-genesis-config-file "$SHELLEY_GENESIS_CONFIG" \
         --genesis-config-file "$BYRON_GENESIS_CONFIG" \
         --genesis-config-file-hash "$BYRON_GENESIS_HASH" \
+        --block-cost "$BLOCK_COST" \
+        --tx-cost "$TX_COST" \
+        --max-cost "$MAX_COST" \
         --http-port "$HTTP_PORT"
     '';
   };


### PR DESCRIPTION
Not confirmed - test will be to deploy and compare memory usage by `qa` to `0.0.6` mainnet instances.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] [Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
    - [ ] Formatting, PNG optimization, etc. are updated
    - [ ] Operables are updated with changes to executable command line options.
    - [ ] Deploy charts updated with changes to operables.
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [ ] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested
