### PR TITLE
chore: allow QA instance to use cardano-node-873

### DIFF
--- a/deploy/marlowe-runtime/Chart.yaml
+++ b/deploy/marlowe-runtime/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: marlowe-runtime
-version: v0.0.34
+version: v0.0.35
 appVersion: v0.0.5
 description: Marlowe smart contract language Cardano implementation
 home: https://marlowe.iohk.io

--- a/deploy/marlowe-runtime/templates/chain-indexer.yaml
+++ b/deploy/marlowe-runtime/templates/chain-indexer.yaml
@@ -59,7 +59,7 @@ spec:
         image: alpine/socat
         args:
         - UNIX-LISTEN:/ipc/node.socket,fork
-        - TCP-CONNECT:cardano-node-{{ $network }}.vela-system:8090
+        - TCP-CONNECT:{{ $instance.cardanoNode }}-{{ $network }}.vela-system:8090
         volumes:
         - name: ipc
           path: /ipc

--- a/deploy/marlowe-runtime/templates/chain-sync.yaml
+++ b/deploy/marlowe-runtime/templates/chain-sync.yaml
@@ -77,7 +77,7 @@ spec:
         image: alpine/socat
         args:
         - UNIX-LISTEN:/ipc/node.socket,fork
-        - TCP-CONNECT:cardano-node-{{ $network }}.vela-system:8090
+        - TCP-CONNECT:{{ $instance.cardanoNode }}-{{ $network }}.vela-system:8090
         volumes:
         - name: ipc
           path: /ipc

--- a/deploy/marlowe-runtime/values.yaml
+++ b/deploy/marlowe-runtime/values.yaml
@@ -9,18 +9,21 @@ instances:
     tag: 93816a71
     repo: ghcr.io
     org: input-output-hk
+    cardanoNode: cardano-node-873
   demo:
     parentDomain: demo.scdev.aws.iohkdev.io
     webTag: 0.0.5.1
     tag: 0.0.5
     repo: ghcr.io
     org: input-output-hk
+    cardanoNode: cardano-node
   0_0_6:
     parentDomain: 0.0.6.scdev.aws.iohkdev.io
     webTag: 0.0.6
     tag: 0.0.6
     repo: ghcr.io
     org: input-output-hk
+    cardanoNode: cardano-node
 namespace: marlowe-staging
 releaseName: marlowe-runtime
 databaseName: marlowe-runtime-database


### PR DESCRIPTION
This PR introduce an update to helm templates from `marlowe-runtime`, allowing instances to select which service of `cardano-node` they will use. 

Right now we have:

1. `cardano-node`  running on version 8.4.0
2. `cardano-node-873` running on version 8.7.3