### PR TITLE
DO NOT MERGE - hotfix PR for runtime 0.0.7

### DIFF
--- a/marlowe-chain-sync/marlowe-chain-indexer/Main.hs
+++ b/marlowe-chain-sync/marlowe-chain-indexer/Main.hs
@@ -63,7 +63,7 @@ run Options{..} = do
             -<
               ChainIndexerDependencies
                 { connectToLocalNode = liftIO . Cardano.connectToLocalNode localNodeConnectInfo
-                , databaseQueries = PostgreSQL.databaseQueries pool genesisBlock
+                , databaseQueries = PostgreSQL.databaseQueries pool
                 , persistRateLimit
                 , genesisBlock
                 , maxCost

--- a/marlowe-chain-sync/marlowe-chain-indexer/Options.hs
+++ b/marlowe-chain-sync/marlowe-chain-indexer/Options.hs
@@ -199,7 +199,7 @@ parseOptions defaultNetworkId defaultSocketPath defaultDatabaseUri version = O.i
           O.option O.auto $
             mconcat
               [ O.long "max-cost"
-              , O.value 1_000_000
+              , O.value 250_000
               , O.metavar "COST_UNITS"
               , O.help
                   "The maximum number of cost units that can be batched when persisting blocks. If the cost of the current batch would exceed this value, the chain sync client will wait until the current batch is persisted before requesting another block."

--- a/marlowe-chain-sync/marlowe-chain-sync.cabal
+++ b/marlowe-chain-sync/marlowe-chain-sync.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          marlowe-chain-sync
-version:       0.0.6
+version:       0.0.7
 synopsis:      Cardano chain sync system for thee Marlowe Runtime
 description:
   Marlowe runtime component for Cardano node synchronization. Communicates with
@@ -136,7 +136,7 @@ library libchainsync
     , hasql-th ^>=0.4
     , hasql-transaction ^>=1
     , hs-opentelemetry-api >=0.0.3 && <0.0.4
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
     , nonempty-containers ^>=0.3.4
     , ouroboros-network-protocols ^>=0.5
@@ -180,7 +180,7 @@ library chain-indexer
     , hasql-th ^>=0.4
     , hasql-transaction ^>=1
     , hs-opentelemetry-api >=0.0.3 && <0.0.4
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , mtl >=2.2 && <3
     , ouroboros-network-api ^>=0.5
     , postgresql-simple
@@ -207,7 +207,7 @@ library plutus-compat
     , cardano-ledger-binary ^>=1.1
     , cardano-ledger-byron ^>=1.0
     , containers ^>=0.6.5
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , plutus-ledger-api ^>=1.5
     , plutus-tx ^>=1.5
 
@@ -224,7 +224,7 @@ library gen
     , cardano-api-gen ^>=8.1
     , containers ^>=0.6.5
     , hedgehog-quickcheck ^>=0.1
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
     , nonempty-containers ^>=0.3.4
     , ouroboros-consensus ^>=0.7
@@ -244,7 +244,7 @@ test-suite marlowe-chain-sync-test
   build-depends:
     , base >=4.9 && <5
     , hspec >=2.10 && <3
-    , marlowe-chain-sync:{marlowe-chain-sync, gen} ==0.0.6
+    , marlowe-chain-sync:{marlowe-chain-sync, gen} ==0.0.7
     , marlowe-protocols ==0.3.0.0
 
   build-tool-depends: hspec-discover:hspec-discover
@@ -307,7 +307,7 @@ executable marlowe-chain-sync
     , hasql >=1.6 && <2
     , hasql-pool ^>=0.8
     , hs-opentelemetry-sdk ==0.0.3.4
-    , marlowe-chain-sync:{marlowe-chain-sync, libchainsync} ==0.0.6
+    , marlowe-chain-sync:{marlowe-chain-sync, libchainsync} ==0.0.7
     , marlowe-protocols ==0.3.0.0
     , mtl >=2.2 && <3
     , network >=3.1 && <4
@@ -332,7 +332,7 @@ executable marlowe-chain-copy
     , bytestring >=0.10.12 && <0.12
     , cardano-api ^>=8.2
     , cassava
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , optparse-applicative
     , postgresql-simple
     , prettyprinter

--- a/marlowe-client/marlowe-client.cabal
+++ b/marlowe-client/marlowe-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          marlowe-client
-version:       0.0.6
+version:       0.0.7
 synopsis:      A client library for the Marlowe Runtime.
 bug-reports:   https://github.com/input-output-hk/marlowe-marlowe/issues
 license:       Apache-2.0
@@ -61,10 +61,10 @@ library
     , eventuo11y-extras ==0.1.1.0
     , exceptions ^>=0.10
     , general-allocate ^>=0.2
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-object ==0.2.0.1
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, contract-api, discovery-api, history-api, proxy-api, sync-api, tx-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, contract-api, discovery-api, history-api, proxy-api, sync-api, tx-api} ==0.0.7
     , monad-control ^>=1
     , mtl >=2.2 && <3
     , network >=3.1 && <4

--- a/marlowe-integration/src/Test/Integration/Marlowe/Local.hs
+++ b/marlowe-integration/src/Test/Integration/Marlowe/Local.hs
@@ -242,7 +242,7 @@ withLocalMarloweRuntime' MarloweRuntimeOptions{..} test = withRunInIO \runInIO -
             byronGenesisConfig
             shelleyGenesisConfig
 
-        chainIndexerDatabaseQueries = ChainIndexer.databaseQueries pool genesisBlock
+        chainIndexerDatabaseQueries = ChainIndexer.databaseQueries pool
 
         chainSyncDatabaseQueries = ChainSync.databaseQueries pool localNodeNetworkId
 

--- a/marlowe-runtime-cli/marlowe-runtime-cli.cabal
+++ b/marlowe-runtime-cli/marlowe-runtime-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          marlowe-runtime-cli
-version:       0.0.6
+version:       0.0.7
 synopsis:      A command line interface for the Marlowe Runtime.
 bug-reports:   https://github.com/input-output-hk/marlowe-cardano/issues
 license:       Apache-2.0

--- a/marlowe-runtime-web/.golden/OpenApi/golden
+++ b/marlowe-runtime-web/.golden/OpenApi/golden
@@ -3273,7 +3273,7 @@
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
         },
         "title": "Marlowe Runtime REST API",
-        "version": "0.0.5.1"
+        "version": "0.0.7"
     },
     "openapi": "3.1.0",
     "paths": {

--- a/marlowe-runtime-web/marlowe-runtime-web.cabal
+++ b/marlowe-runtime-web/marlowe-runtime-web.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          marlowe-runtime-web
-version:       0.0.6
+version:       0.0.7
 synopsis:      Web server for Marlowe Runtime on Cardano.
 bug-reports:   https://github.com/input-output-hk/marlowe-cardano/issues
 license:       Apache-2.0
@@ -138,12 +138,12 @@ library server
     , lens >=5.2 && <6
     , lens-aeson ^>=1.2
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync ==0.0.6
-    , marlowe-client ==0.0.6
+    , marlowe-chain-sync ==0.0.7
+    , marlowe-client ==0.0.7
     , marlowe-object ==0.2.0.1
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime-web ==0.0.6
-    , marlowe-runtime:{marlowe-runtime, contract-api, discovery-api, proxy-api, sync-api, tx-api} ==0.0.6
+    , marlowe-runtime-web ==0.0.7
+    , marlowe-runtime:{marlowe-runtime, contract-api, discovery-api, proxy-api, sync-api, tx-api} ==0.0.7
     , monad-control ^>=1
     , mtl >=2.2 && <3
     , nonempty-containers ^>=0.3.4

--- a/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/ChainSeekClient.hs
+++ b/marlowe-runtime/indexer/Language/Marlowe/Runtime/Indexer/ChainSeekClient.hs
@@ -268,7 +268,9 @@ chainSeekClient = component "indexer-chain-seek-client" \ChainSeekClientDependen
                     pure (point, marloweBlock)
 
                 -- Emit the marlowe blocks in a roll forward event to a downstream consumer.
-                emit $ RollForward (catMaybes blocks') tip
+                case catMaybes blocks' of
+                  [] -> pure ()
+                  blocks'' -> emit $ RollForward blocks'' tip
 
                 -- Loop back into the main synchronization loop with an updated
                 -- rollback state.

--- a/marlowe-runtime/marlowe-runtime.cabal
+++ b/marlowe-runtime/marlowe-runtime.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          marlowe-runtime
-version:       0.0.6
+version:       0.0.7
 synopsis:
   Runtime system for running Marlowe financial contracts on the Cardano Computation Layer
 
@@ -202,7 +202,7 @@ library
     , cardano-api ^>=8.2
     , containers ^>=0.6.5
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
     , plutus-ledger-api ^>=1.5
     , text ^>=1.2
@@ -236,9 +236,9 @@ library gen
     , hedgehog-quickcheck ^>=0.1
     , http-media ^>=0.8
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync:{gen, plutus-compat} ==0.0.6
+    , marlowe-chain-sync:{gen, plutus-compat} ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api, tx-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api, tx-api} ==0.0.7
     , marlowe-test ==0.2.1.0
     , network-uri >=2.6 && <3
     , nonempty-containers ^>=0.3.4
@@ -264,9 +264,9 @@ library history-api
     , errors >=2.3 && <3
     , hs-opentelemetry-api ==0.0.3.6
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime ==0.0.6
+    , marlowe-runtime ==0.0.7
     , ouroboros-consensus ^>=0.7
     , ouroboros-network-api ^>=0.5
     , plutus-ledger-api ^>=1.5
@@ -308,9 +308,9 @@ library indexer
     , hasql-transaction ^>=1
     , hs-opentelemetry-api ==0.0.3.6
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, history-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, history-api} ==0.0.7
     , mtl >=2.2 && <3
     , nonempty-containers ^>=0.3.4
     , plutus-ledger-api ^>=1.5
@@ -341,9 +341,9 @@ library sync-api
     , binary ^>=0.8.8
     , cardano-api ^>=8.2
     , containers ^>=0.6.5
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api} ==0.0.7
     , ouroboros-consensus ^>=0.7
     , time >=1.9 && <2
     , typed-protocols ^>=0.1
@@ -369,10 +369,10 @@ library contract-api
     , containers ^>=0.6.5
     , hs-opentelemetry-api ==0.0.3.6
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-object ==0.2.0.1
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime ==0.0.6
+    , marlowe-runtime ==0.0.7
     , plutus-ledger-api ^>=1.5
     , text ^>=1.2
     , typed-protocols ^>=0.1
@@ -410,10 +410,10 @@ library contract
     , hs-opentelemetry-api ==0.0.3.6
     , lock-file ^>=0.7
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-object ==0.2.0.1
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, contract-api, history-api, sync-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, contract-api, history-api, sync-api} ==0.0.7
     , plutus-ledger-api ^>=1.5
     , resourcet >=1.3 && <2
     , text ^>=1.2
@@ -471,9 +471,9 @@ library sync
     , hasql-transaction ^>=1
     , hs-opentelemetry-api ==0.0.3.6
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api, schema, sync-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, discovery-api, history-api, schema, sync-api} ==0.0.7
     , plutus-ledger-api ^>=1.5
     , postgresql-syntax ^>=0.4.1
     , profunctors >=5.6 && <6
@@ -499,9 +499,9 @@ library discovery-api
     , base >=4.9 && <5
     , binary ^>=0.8.8
     , hs-opentelemetry-api ==0.0.3.6
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime ==0.0.6
+    , marlowe-runtime ==0.0.7
     , typed-protocols ^>=0.1
 
 library tx-api
@@ -519,9 +519,9 @@ library tx-api
     , http-media ^>=0.8
     , keys
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, history-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, history-api} ==0.0.7
     , network-uri >=2.6 && <3
     , nonempty-containers ^>=0.3.4
     , plutus-core ^>=1.5
@@ -562,9 +562,9 @@ library tx
     , eventuo11y-otel ^>=0.1
     , hs-opentelemetry-api ==0.0.3.6
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync:{marlowe-chain-sync, plutus-compat} ==0.0.6
+    , marlowe-chain-sync:{marlowe-chain-sync, plutus-compat} ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, contract-api, history-api, tx-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, contract-api, history-api, tx-api} ==0.0.7
     , nonempty-containers ^>=0.3.4
     , ouroboros-consensus ^>=0.7
     , ouroboros-network-api ^>=0.5
@@ -591,7 +591,7 @@ library proxy-api
     , base >=4.9 && <5
     , binary ^>=0.8.8
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{contract-api, discovery-api, history-api, sync-api, tx-api} ==0.0.6
+    , marlowe-runtime:{contract-api, discovery-api, history-api, sync-api, tx-api} ==0.0.7
     , typed-protocols ^>=0.1
 
 library proxy
@@ -605,7 +605,7 @@ library proxy
     , eventuo11y >=0.9 && <0.11
     , eventuo11y-extras ==0.1.1.0
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{contract-api, discovery-api, history-api, proxy-api, sync-api, tx-api} ==0.0.6
+    , marlowe-runtime:{contract-api, discovery-api, history-api, proxy-api, sync-api, tx-api} ==0.0.7
     , resourcet >=1.3 && <2
     , transformers ^>=0.5.6
     , typed-protocols ^>=0.1
@@ -623,9 +623,9 @@ library runtime
     , co-log >=0.5.0.0 && <0.6.0.0
     , containers ^>=0.6.5
     , eventuo11y-extras ==0.1.1.0
-    , marlowe-chain-sync:{marlowe-chain-sync, chain-indexer, libchainsync} ==0.0.6
+    , marlowe-chain-sync:{marlowe-chain-sync, chain-indexer, libchainsync} ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, contract, indexer, proxy, proxy-api, sync, sync-api, tx} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, contract, indexer, proxy, proxy-api, sync, sync-api, tx} ==0.0.7
     , nonempty-containers ^>=0.3.4
     , random ^>=1.2.1
     , time >=1.9 && <2
@@ -639,8 +639,8 @@ library config
   exposed-modules: Language.Marlowe.Runtime.CLI.Option
   build-depends:
     , base >=4.9 && <5
-    , marlowe-chain-sync ==0.0.6
-    , marlowe-runtime ==0.0.6
+    , marlowe-chain-sync ==0.0.7
+    , marlowe-runtime ==0.0.7
     , network >=3.1 && <4
     , optparse-applicative ^>=0.17
     , split ^>=0.2.3
@@ -665,9 +665,9 @@ executable marlowe-indexer
     , hasql >=1.6 && <2
     , hasql-pool ^>=0.8
     , hs-opentelemetry-sdk ==0.0.3.4
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, indexer} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, indexer} ==0.0.7
     , mtl >=2.2 && <3
     , network >=3.1 && <4
     , nonempty-containers ^>=0.3.4
@@ -698,9 +698,9 @@ executable marlowe-sync
     , hasql >=1.6 && <2
     , hasql-pool ^>=0.8
     , hs-opentelemetry-sdk ==0.0.3.4
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{discovery-api, history-api, sync, sync-api} ==0.0.6
+    , marlowe-runtime:{discovery-api, history-api, sync, sync-api} ==0.0.7
     , mtl >=2.2 && <3
     , network >=3.1 && <4
     , optparse-applicative ^>=0.17
@@ -727,9 +727,9 @@ executable marlowe-tx
     , eventuo11y-extras ==0.1.1.0
     , eventuo11y-otel ^>=0.1
     , hs-opentelemetry-sdk ==0.0.3.4
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, contract-api, tx, tx-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, contract-api, tx, tx-api} ==0.0.7
     , network >=3.1 && <4
     , optparse-applicative ^>=0.17
     , prettyprinter
@@ -755,9 +755,9 @@ executable marlowe-contract
     , eventuo11y-extras ==0.1.1.0
     , eventuo11y-otel ^>=0.1
     , hs-opentelemetry-sdk ==0.0.3.4
-    , marlowe-chain-sync ==0.0.6
+    , marlowe-chain-sync ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{config, contract, contract-api, sync-api} ==0.0.6
+    , marlowe-runtime:{config, contract, contract-api, sync-api} ==0.0.7
     , network >=3.1 && <4
     , optparse-applicative ^>=0.17
     , prettyprinter
@@ -784,7 +784,7 @@ executable marlowe-proxy
     , eventuo11y-otel ^>=0.1
     , hs-opentelemetry-sdk ==0.0.3.4
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{config, contract-api, discovery-api, history-api, proxy, proxy-api, sync-api, tx-api} ==0.0.6
+    , marlowe-runtime:{config, contract-api, discovery-api, history-api, proxy, proxy-api, sync-api, tx-api} ==0.0.7
     , network >=3.1 && <4
     , optparse-applicative ^>=0.17
     , prettyprinter
@@ -815,9 +815,9 @@ executable marlowe-runtime
     , hasql >=1.6 && <2
     , hasql-pool ^>=0.8
     , hs-opentelemetry-sdk >=0.0.3 && <0.0.4
-    , marlowe-chain-sync:{marlowe-chain-sync, chain-indexer, libchainsync} ==0.0.6
+    , marlowe-chain-sync:{marlowe-chain-sync, chain-indexer, libchainsync} ==0.0.7
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, contract, indexer, proxy-api, runtime, sync, tx} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, contract, indexer, proxy-api, runtime, sync, tx} ==0.0.7
     , mtl >=2.2 && <3
     , network >=3.1 && <4
     , nonempty-containers ^>=0.3.4
@@ -869,10 +869,10 @@ test-suite marlowe-runtime-test
     , hspec-golden ^>=0.2
     , http-media ^>=0.8
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync:{marlowe-chain-sync, gen, plutus-compat} ==0.0.6
+    , marlowe-chain-sync:{marlowe-chain-sync, gen, plutus-compat} ==0.0.7
     , marlowe-object:gen
     , marlowe-protocols ==0.3.0.0
-    , marlowe-runtime:{marlowe-runtime, contract, contract-api, discovery-api, gen, history-api, sync, sync-api, tx, tx-api} ==0.0.6
+    , marlowe-runtime:{marlowe-runtime, contract, contract-api, discovery-api, gen, history-api, sync, sync-api, tx, tx-api} ==0.0.7
     , marlowe-test ==0.2.1.0
     , network-uri >=2.6 && <3
     , nonempty-containers ^>=0.3.4
@@ -905,8 +905,8 @@ test-suite indexer-test
     , containers ^>=0.6.5
     , hspec
     , marlowe-cardano ==0.2.1.0
-    , marlowe-chain-sync:{marlowe-chain-sync, plutus-compat} ==0.0.6
-    , marlowe-runtime:{marlowe-runtime, gen, history-api, indexer} ==0.0.6
+    , marlowe-chain-sync:{marlowe-chain-sync, plutus-compat} ==0.0.7
+    , marlowe-runtime:{marlowe-runtime, gen, history-api, indexer} ==0.0.7
     , marlowe-test ==0.2.1.0
     , ouroboros-consensus ^>=0.7
     , plutus-tx ^>=1.5

--- a/marlowe-runtime/marlowe-runtime/Main.hs
+++ b/marlowe-runtime/marlowe-runtime/Main.hs
@@ -128,7 +128,7 @@ run Options{..} = bracket (Pool.acquire 100 (Just 5000000) (fromString databaseU
     NESet.IsNonEmpty scripts -> pure scripts
 
   runAppMTraced instrumentationLibrary (renderRootSelectorOTel dbName dbUser dbHost dbPort) do
-    let chainIndexerDatabaseQueries = ChainIndexerPostgres.databaseQueries pool genesisBlock
+    let chainIndexerDatabaseQueries = ChainIndexerPostgres.databaseQueries pool
 
     runGetGenesisBlock (getGenesisBlock chainIndexerDatabaseQueries) >>= \case
       Just dbGenesisBlock -> unless (dbGenesisBlock == genesisBlock) do

--- a/nix/marlowe-cardano/deploy/operables.nix
+++ b/nix/marlowe-cardano/deploy/operables.nix
@@ -174,6 +174,9 @@ in
       #################
       # OTEL_EXPORTER_OTLP_ENDPOINT: The url of the open telemetry collector
       # OTEL_SERVICE_NAME: The name of the open telemetry service
+      # BLOCK_COST: The number of cost units to associate with persisting a block
+      # TX_COST: The number of cost units to associate with persisting a transaction
+      # MAX_COST: The maximum cost of work to batch before committing
 
       [ -z "''${NODE_CONFIG:-}" ] && echo "NODE_CONFIG env var must be set -- aborting" && exit 1
       [ -z "''${CARDANO_NODE_SOCKET_PATH:-}" ] && echo "CARDANO_NODE_SOCKET_PATH env var must be set -- aborting" && exit 1
@@ -206,6 +209,9 @@ in
       ${wait-for-socket}/bin/wait-for-socket "$CARDANO_NODE_SOCKET_PATH"
 
       export OTEL_SERVICE_NAME="''${OTEL_SERVICE_NAME:-marlowe-chain-indexer}"
+      export BLOCK_COST="''${BLOCK_COST:-1}"
+      export TX_COST="''${TX_COST:-10}"
+      export MAX_COST="''${MAX_COST:-250000}"
 
       ${marlowe-chain-indexer}/bin/marlowe-chain-indexer \
         --socket-path "$CARDANO_NODE_SOCKET_PATH" \
@@ -213,6 +219,9 @@ in
         --shelley-genesis-config-file "$SHELLEY_GENESIS_CONFIG" \
         --genesis-config-file "$BYRON_GENESIS_CONFIG" \
         --genesis-config-file-hash "$BYRON_GENESIS_HASH" \
+        --block-cost "$BLOCK_COST" \
+        --tx-cost "$TX_COST" \
+        --max-cost "$MAX_COST" \
         --http-port "$HTTP_PORT"
     '';
   };


### PR DESCRIPTION
This PR applies some of the critical fixes found since 0.0.6 directly on top of 0.0.6. This will be used to create a new 0.0.7 release to avoid delays while waiting for the last bits of new functionality to be added for 0.0.7.