### PR TITLE
Add support for aarch64-linux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2408,17 +2408,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1709130968,
+        "lastModified": 1710149994,
         "narHash": "sha256-kvb0YtGf/if62DHLMQLuc164bIH66XBWMpNx1U1sRBM=",
         "owner": "input-output-hk",
         "repo": "marlowe-plutus",
-        "rev": "9b19078c02e9a6741d5d76e109cce910322eb3e6",
+        "rev": "581e95bb9c93a16dc5c9a3181e90abed4639f728",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "marlowe-plutus",
-        "rev": "9b19078c02e9a6741d5d76e109cce910322eb3e6",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -2408,16 +2408,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1703278640,
-        "narHash": "sha256-NBkdhcslPcif8zqpRWvSTM64DLdyJvE8HRoBMxjX9TI=",
+        "lastModified": 1709130968,
+        "narHash": "sha256-kvb0YtGf/if62DHLMQLuc164bIH66XBWMpNx1U1sRBM=",
         "owner": "input-output-hk",
         "repo": "marlowe-plutus",
-        "rev": "2156e3bc0819b93f6ef8774f0be9022c0d55a34a",
+        "rev": "9b19078c02e9a6741d5d76e109cce910322eb3e6",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "marlowe-plutus",
+        "rev": "9b19078c02e9a6741d5d76e109cce910322eb3e6",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,8 @@
     # Use upstream when https://github.com/nlewo/nix2container/pull/82 is merged
     n2c.url = "github:shlevy/nix2container/no-Size-on-dir";
 
-    marlowe-plutus.url = "github:input-output-hk/marlowe-plutus";
+    # Version of marlowe-plutus supporting aarch64-linux (TODO: Merge on main)
+    marlowe-plutus.url = "github:input-output-hk/marlowe-plutus/9b19078c02e9a6741d5d76e109cce910322eb3e6";
 
     cardano-node.url = "github:input-output-hk/cardano-node?ref=8.7.3";
 
@@ -46,7 +47,7 @@
   outputs = inputs: inputs.iogx.lib.mkFlake {
     inherit inputs;
     repoRoot = ./.;
-    systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
     outputs = import ./nix/outputs.nix;
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,7 @@
     # Use upstream when https://github.com/nlewo/nix2container/pull/82 is merged
     n2c.url = "github:shlevy/nix2container/no-Size-on-dir";
 
-    # Version of marlowe-plutus supporting aarch64-linux (TODO: Merge on main)
-    marlowe-plutus.url = "github:input-output-hk/marlowe-plutus/9b19078c02e9a6741d5d76e109cce910322eb3e6";
+    marlowe-plutus.url = "github:input-output-hk/marlowe-plutus";
 
     cardano-node.url = "github:input-output-hk/cardano-node?ref=8.7.3";
 

--- a/marlowe-runtime/changelog.d/20240312_114424_nicolas.henin.md
+++ b/marlowe-runtime/changelog.d/20240312_114424_nicolas.henin.md
@@ -1,0 +1,8 @@
+
+
+### Added
+
+- Support for compiling/building/running the repository using new Mac CPUs (M1/M2/M3) within a linux VM (`aarch64-linux` system).
+
+
+

--- a/nix/marlowe-cardano/cardano-tools.nix
+++ b/nix/marlowe-cardano/cardano-tools.nix
@@ -4,12 +4,18 @@
 
 {
   cardano-node =
-    if system == "aarch64-darwin"
-    then inputs.cardano-node.packages.x86_64-darwin.cardano-node
-    else inputs.cardano-node.packages.${system}.cardano-node;
+    if system == "aarch64-darwin" then
+      inputs.cardano-node.packages.x86_64-darwin.cardano-node
+    else if system == "aarch64-linux" then
+      inputs.cardano-node.packages.x86_64-linux.cardano-node
+    else
+      inputs.cardano-node.packages.${system}.cardano-node;
 
   cardano-cli =
-    if system == "aarch64-darwin"
-    then inputs.cardano-node.packages.x86_64-darwin.cardano-cli
-    else inputs.cardano-node.packages.${system}.cardano-cli;
+    if system == "aarch64-darwin" then
+      inputs.cardano-node.packages.x86_64-darwin.cardano-cli
+    else if system == "aarch64-linux" then
+      inputs.cardano-node.packages.x86_64-linux.cardano-cli
+    else
+      inputs.cardano-node.packages.${system}.cardano-cli;
 }

--- a/nix/marlowe-cardano/compose.nix
+++ b/nix/marlowe-cardano/compose.nix
@@ -1,4 +1,4 @@
-{ inputs, pkgs, lib, ... }:
+{ system, inputs, pkgs, lib, ... }:
 
 let
   inherit (pkgs) z3 sqitchPg postgresql runCommand writeShellScriptBin writeText glibcLocales;
@@ -22,7 +22,7 @@ let
     cd /src
     # Hard-coding linux because this won't work on Mac anyway.
     # TODO find a setup that works on MacOS
-    BIN=./dist-newstyle/build/x86_64-linux/ghc-9.2.8/$PKG/x/$PROG/build/$PROG/$PROG
+    BIN=./dist-newstyle/build/${system}/ghc-9.2.8/$PKG/x/$PROG/build/$PROG/$PROG
     export PATH="$PATH:${lib.makeBinPath [ sqitchPg postgresql ]}"
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
     cd marlowe-chain-sync
@@ -38,7 +38,7 @@ let
     cd /src
     # Hard-coding linux because this won't work on Mac anyway.
     # TODO find a setup that works on MacOS
-    BIN=./dist-newstyle/build/x86_64-linux/ghc-9.2.8/$PKG/x/$PROG/build/$PROG/$PROG
+    BIN=./dist-newstyle/build/${system}/ghc-9.2.8/$PKG/x/$PROG/build/$PROG/$PROG
     export PATH="$PATH:${lib.makeBinPath [ sqitchPg postgresql ]}"
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
     cd marlowe-runtime/marlowe-indexer
@@ -55,7 +55,7 @@ let
     cd /src
     # Hard-coding linux because this won't work on Mac anyway.
     # TODO find a setup that works on MacOS
-    BIN=./dist-newstyle/build/x86_64-linux/ghc-9.2.8/$PKG/x/$PROG/build/$PROG/$PROG
+    BIN=./dist-newstyle/build/${system}/ghc-9.2.8/$PKG/x/$PROG/build/$PROG/$PROG
     export PATH="$PATH:${lib.makeBinPath [ sqitchPg postgresql ]}"
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
     cd marlowe-chain-sync
@@ -75,7 +75,7 @@ let
     cd /src
     # Hard-coding linux because this won't work on Mac anyway.
     # TODO find a setup that works on MacOS
-    BIN=./dist-newstyle/build/x86_64-linux/ghc-9.2.8/$PKG/x/$PROG/build/$PROG/$PROG
+    BIN=./dist-newstyle/build/${system}/ghc-9.2.8/$PKG/x/$PROG/build/$PROG/$PROG
     exec -a $PROG $BIN "$@"
   '';
 


### PR DESCRIPTION
This PR allows an owner of an aarch64 based computer (Mac ) to build/run and deploy locally this repository in a linux VM.