### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
   outputs = inputs@{ self, nixpkgs, ... }: inputs.iogx.lib.mkFlake {
     inherit inputs;
     repoRoot = ./.;
-    systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
+    systems = [ "x86_64-linux" "aarch64-darwin" "aarch64-linux" ];
     flake = _:
       let
         inherit (nixpkgs) lib;


### PR DESCRIPTION
- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->

Pre-submit checklist:
- Branch
    - [x] ~~Tests are provided (if possible)~~
    - [x] ~~[Test report is updated](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/test/test-report.md) (if relevant)~~
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] ~~Relevant tickets are mentioned in commit messages~~
    - [x] ~~Formatting, PNG optimization, etc. are updated~~
    - [x] ~~Operables are updated with changes to executable command line options.~~
    - [x] ~~Deploy charts updated with changes to operables.~~
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
        - Review required
        - [ ] Substantial changes to code, test, or documentation
        - [ ] Change made to Marlowe validator (@bwbush and @palas must be included as reviewers)
        - Review not required
        - [x] Minor changes to non-critical code, documentation, nix derivations, configuration files, or scripts
        - [ ] Formatting, spelling, grammar, or reorganization
    - [ ] Reviewer requested
